### PR TITLE
add --ff-only and --no-ff to the merge command

### DIFF
--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Merge.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Merge.java
@@ -69,8 +69,16 @@ public class Merge extends AbstractCommand implements CLICommand {
     @Parameter(names = "--no-commit", description = "Do not perform a commit after merging")
     private boolean noCommit;
 
+    @Parameter(names = "--no-ff", description = "Create a merge commit even when the merge resolves as fast forward")
+    private boolean noFastForward;
+
+    @Parameter(names = "--ff-only", description = "Refuse to merge unless the current HEAD is already up-to-date or the merge can be resolved as a fast forward")
+    private boolean fastForwardOnly;
+
     @Parameter(names = "--abort", description = "Aborts the current merge")
     private boolean abort;
+
+
 
     @Parameter(description = "<commitish>...")
     private List<String> commits = Lists.newArrayList();
@@ -105,6 +113,7 @@ public class Merge extends AbstractCommand implements CLICommand {
             MergeOp merge = geogig.command(MergeOp.class);
             merge.setOurs(ours).setTheirs(theirs).setNoCommit(noCommit);
             merge.setMessage(message).setProgressListener(cli.getProgressListener());
+            merge.setFastForwardOnly(fastForwardOnly).setNoFastForward(noFastForward);
             for (String commitish : commits) {
                 Optional<ObjectId> commitId;
                 commitId = geogig.command(RevParse.class).setRefSpec(commitish).call();

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/MergeOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/MergeOp.java
@@ -60,6 +60,10 @@ public class MergeOp extends AbstractGeoGigOp<MergeOp.MergeReport> {
 
     private boolean noCommit;
 
+    private boolean noFastForward;
+
+    private boolean fastForwardOnly;
+
     private Optional<String> authorName = Optional.absent();
 
     private Optional<String> authorEmail = Optional.absent();
@@ -130,6 +134,26 @@ public class MergeOp extends AbstractGeoGigOp<MergeOp.MergeReport> {
     }
 
     /**
+     *
+     * @param noFastForward true if the merge command should never fast forward merge.
+     * @return {@code this}
+     */
+    public MergeOp setNoFastForward(boolean noFastForward) {
+        this.noFastForward = noFastForward;
+        return this;
+    }
+
+    /**
+     *
+     * @param fastForwardOnly true if the merge command should only fast forward merge. It will abort if it cant do so.
+     * @return
+     */
+    public MergeOp setFastForwardOnly(boolean fastForwardOnly) {
+        this.fastForwardOnly = fastForwardOnly;
+        return this;
+    }
+
+    /**
      * Executes the merge operation.
      * 
      * @return always {@code true}
@@ -139,6 +163,7 @@ public class MergeOp extends AbstractGeoGigOp<MergeOp.MergeReport> {
 
         Preconditions.checkArgument(commits.size() > 0, "No commits specified for merge.");
         Preconditions.checkArgument(!(ours && theirs), "Cannot use both --ours and --theirs.");
+        Preconditions.checkArgument(!(noFastForward && fastForwardOnly), "Cannot use both --no-ff and --ff-only");
 
         final Optional<Ref> currHead = command(RefParse.class).setName(Ref.HEAD).call();
         Preconditions.checkState(currHead.isPresent(), "Repository has no HEAD, can't rebase.");
@@ -168,7 +193,8 @@ public class MergeOp extends AbstractGeoGigOp<MergeOp.MergeReport> {
         }
         hasConflictsOrAutomerge = command(CheckMergeScenarioOp.class).setCommits(revCommits).call()
                 .booleanValue();
-
+        Preconditions.checkState(!(hasConflictsOrAutomerge && fastForwardOnly), "The flag --ff-only was specified but no "+
+                "fast forward merge could be executed");
         if (hasConflictsOrAutomerge && !theirs) {
             Preconditions.checkState(commits.size() < 2,
                     "Conflicted merge.\nCannot merge more than two commits when conflicts exist"
@@ -330,7 +356,9 @@ public class MergeOp extends AbstractGeoGigOp<MergeOp.MergeReport> {
         if (!changed) {
             throw new NothingToCommitException("The branch has already been merged.");
         }
-
+        if (noFastForward) {
+            fastForward = false;
+        }
         RevCommit mergeCommit = commit(fastForward);
 
         MergeReport result = new MergeReport(mergeCommit, mergeScenario, oursId, pairs);

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/MergeOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/MergeOpTest.java
@@ -25,11 +25,7 @@ import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.RevFeature;
 import org.locationtech.geogig.api.RevFeatureBuilder;
 import org.locationtech.geogig.api.RevTree;
-import org.locationtech.geogig.api.plumbing.FindTreeChild;
-import org.locationtech.geogig.api.plumbing.RefParse;
-import org.locationtech.geogig.api.plumbing.RevObjectParse;
-import org.locationtech.geogig.api.plumbing.UpdateRef;
-import org.locationtech.geogig.api.plumbing.UpdateSymRef;
+import org.locationtech.geogig.api.plumbing.*;
 import org.locationtech.geogig.api.plumbing.merge.Conflict;
 import org.locationtech.geogig.api.plumbing.merge.ConflictsReadOp;
 import org.locationtech.geogig.api.plumbing.merge.ReadMergeCommitMessageOp;
@@ -573,6 +569,69 @@ public class MergeOpTest extends RepositoryTestCase {
         assertEquals(c1.getMessage(), logC1.getMessage());
         assertEquals(c1.getTreeId(), logC1.getTreeId());
 
+    }
+
+    @Test
+    public void testFastForwardOnly() throws Exception {
+        // Create the following revision graph
+        // o
+        // |
+        // o - Point 1 added
+        // |\
+        // | o - TestBranch - Point 1 modified
+        // |
+        // o - master - HEAD - Point 1 modified
+        insertAndAdd(points1);
+        geogig.command(CommitOp.class).call();
+        geogig.command(BranchCreateOp.class).setName("TestBranch").call();
+        Feature points1Modified = feature(pointsType, idP1, "StringProp1_2", new Integer(1000),
+                "POINT(1 1)");
+        insertAndAdd(points1Modified);
+        geogig.command(CommitOp.class).call();
+        geogig.command(CheckoutOp.class).setSource("TestBranch").call();
+        Feature points1ModifiedB = feature(pointsType, idP1, "StringProp1_3", new Integer(2000),
+                "POINT(1 1)");
+        insertAndAdd(points1ModifiedB);
+        geogig.command(CommitOp.class).call();
+        geogig.command(CheckoutOp.class).setSource("master").call();
+        Ref branch = geogig.command(RefParse.class).setName("TestBranch").call().get();
+        MergeOp mergeOp = geogig.command(MergeOp.class).addCommit(Suppliers.ofInstance(branch.getObjectId()));
+        mergeOp.setFastForwardOnly(true);
+        try {
+            mergeOp.call();
+            fail();
+        }catch(IllegalStateException e) {
+            //This is what should happen, since the branch can not be fast forward merged
+        }
+    }
+
+    @Test
+    public void testNoFastForward() throws Exception {
+        // Create the following revision graph
+        // o
+        // |
+        // o - Point 1 added
+        // |\
+        // | o - TestBranch - Point 2 added
+        // |
+        // o - master - HEAD - Point 3 added
+        insertAndAdd(points1);
+        geogig.command(CommitOp.class).call();
+        geogig.command(BranchCreateOp.class).setName("TestBranch").call();
+        insertAndAdd(points3);
+        RevCommit masterCommit = geogig.command(CommitOp.class).call();
+        geogig.command(CheckoutOp.class).setSource("TestBranch").call();
+        insertAndAdd(points2);
+        RevCommit branchCommit = geogig.command(CommitOp.class).call();
+        geogig.command(CheckoutOp.class).setSource("master").call();
+        Ref branch = geogig.command(RefParse.class).setName("TestBranch").call().get();
+        MergeOp mergeOp = geogig.command(MergeOp.class).addCommit(Suppliers.ofInstance(branch.getObjectId()));
+        mergeOp.setNoFastForward(true).call();
+        Iterator<RevCommit> log = geogig.command(LogOp.class).call();
+        RevCommit mergeCommit = log.next();
+        assertEquals(2, mergeCommit.getParentIds().size());
+        assertEquals(masterCommit.getId(), mergeCommit.getParentIds().get(0));
+        assertEquals(branchCommit.getId(), mergeCommit.getParentIds().get(1));
     }
 
     @Test

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/MergeOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/MergeOpTest.java
@@ -597,12 +597,8 @@ public class MergeOpTest extends RepositoryTestCase {
         Ref branch = geogig.command(RefParse.class).setName("TestBranch").call().get();
         MergeOp mergeOp = geogig.command(MergeOp.class).addCommit(Suppliers.ofInstance(branch.getObjectId()));
         mergeOp.setFastForwardOnly(true);
-        try {
-            mergeOp.call();
-            fail();
-        }catch(IllegalStateException e) {
-            //This is what should happen, since the branch can not be fast forward merged
-        }
+        exception.expect(IllegalStateException.class);
+        mergeOp.call();
     }
 
     @Test


### PR DESCRIPTION
I have implemented the merge command flags --ff-only and --no-ff.
They enable the user to force fast forward merges, or disallow them

The descriptions are taken from the git documentation.

--no-ff: Create a merge commit even when the merge resolves as fast Forward
--ff-only: Refuse to merge unless the current HEAD is already up-to-date or the merge can be resolved as a fast forward