### PR TITLE
updated links to point to locationtech github repository

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,7 +39,7 @@
             <ul class="nav navbar-nav">
               <li><a href="#install">Get Started</a></li>
               <li><a href="/docs/index.html">Documentation</a></li>
-              <li><a href="http://github.com/boundlessgeo/GeoGig">On Github</a></li>
+              <li><a href="https://github.com/locationtech/GeoGig">On Github</a></li>
             </ul>
           </div><!--/.navbar-collapse -->
         </div>
@@ -64,7 +64,7 @@
               <h1 class="light copy">Track GeoSpatial Data Edits</h1>
               <p>Users are able to import raw geospatial data (currently from Shapefiles, PostGIS or SpatiaLite) in to a repository where every change to the data is tracked. These changes can be viewed in a history, reverted to older versions, branched in to sandboxed areas, merged back in, and pushed to remote repositories.</p>
 
-              <p>GeoGig is written in Java, and available under the <a href="http://github.com/boundlessgeo/GeoGig/blob/master/LICENSE.txt">BSD License</a>.</p>
+              <p>GeoGig is written in Java, and available under the <a href="https://github.com/locationtech/GeoGig/blob/master/LICENSE.txt">Eclipse License</a>.</p>
 
             </div>
             <div class="col-md-offset-1 col-md-4">
@@ -178,7 +178,7 @@
 
               <h2>Participate</h2>
 
-              <p>The project is hosted on github: <a href="http://github.com/boundlessgeo/GeoGig">http://github.com/boundlessgeo/GeoGig</a></p>
+              <p>The project is hosted on github: <a href="https://github.com/locationtech/GeoGig">https://github.com/locationtech/GeoGig</a></p>
               <p>Discussion takes place on our <a href="https://locationtech.org/mailman/listinfo/geogig-dev">GeoGig Mailing List</a>. 
               Please join and introduce yourself, we'd love to help, and to figure out ways for you to get involved.</p>
 
@@ -192,12 +192,12 @@
                 <li>Include proper license headers on your contributed files</li>
               </ul>
 
-              <p>Issues to help out on are at our <a href="http://github.com/boundlessgeo/GeoGig/issues">issue tracker</a>.</p>
+              <p>Issues to help out on are at our <a href="https://github.com/boundlessgeo/GeoGig/issues">issue tracker</a>.</p>
 
               <p>For those who can't code help on documentation is always appreciated, all docs can be found at 
-              <a href="http://github.com/boundlessgeo/GeoGig/tree/master/doc/">http://github.com/boundlessgeo/GeoGig/tree/master/doc/</a> and contributed to by editing in ReStructuredText and using standard GitHub workflows.</p>
+              <a href="https://github.com/locationtech/GeoGig/tree/master/doc/">https://github.com/locationtech/GeoGig/tree/master/doc/</a> and contributed to by editing in ReStructuredText and using standard GitHub workflows.</p>
 
-              <p>Our build is <a href="http://ares.boundlessgeo.com/jenkins/view/geogig/">actively monitored using Hudson</a>.</p>
+              <p>Our build is <a href="http://ares.boundlessgeo.com/jenkins/view/geogig/">actively monitored using Jenkins</a>.</p>
 
           </div>
           <div class="col-md-5 hidden-sm hidden-xs">
@@ -227,7 +227,7 @@
                 </ul>
               </p>
 
-              <p class="devmore">View <a href="https://github.com/boundlessgeo/GeoGig/graphs/contributors">more GeoGig contributors</a> on Github.</p>
+              <p class="devmore">View <a href="https://github.com/locationtech/GeoGig/graphs/contributors">more GeoGig contributors</a> on Github.</p>
 
               <p class="col-sm-offset-10 col-sm-1"><a href="#top"><img src="images/arrow_up.png" alt="back to top"/></a></p>
 
@@ -240,7 +240,7 @@
     <footer>
       <div class="container">
         <div class="row">
-          <div class=""><p class="repo-owner"><a href="http://github.com/boundlessgeo/GeoGig">GeoGig</a> is maintained by <a href="http://github.com/boundlessgeo"><img src="images/Boundless_Logo.png" alt="Boundless"></a></p></div>
+          <div class=""><p class="repo-owner"><a href="https://github.com/locationtech/GeoGig">GeoGig</a> is maintained by <a href="https://github.com/boundlessgeo"><img src="images/Boundless_Logo.png" alt="Boundless"></a></p></div>
         </div>
       </div>
     </footer>


### PR DESCRIPTION
Updated license to Eclipse license
Updated links to point to the new locationtech github repository

One link remains on the old repo: "issues" pointing to https://github.com/boundlessgeo/GeoGig/issues as https://github.com/locationtech/GeoGig/issues doesn't really exist (you get redirected to the pull requests page)
Should I update anyway? Or remove that part completely?