### PR TITLE
add --since and --until to "pg export"

### DIFF
--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
@@ -99,6 +99,7 @@ public class PGExport extends AbstractPGCommand implements CLICommand {
         String tableName = args.get(1);
 
         checkParameter(tableName != null && !tableName.isEmpty(), "No table name specified");
+        checkParameter(!overwrite || ((since == null && until == null)), "--overwrite can not be specified together with --since/--until");
 
         DataStore dataStore = getDataStore();
 
@@ -135,7 +136,7 @@ public class PGExport extends AbstractPGCommand implements CLICommand {
                 throw new CommandFailedException("Cannot create new table in database", e);
             }
         } else {
-            if (!overwrite) {
+            if (!overwrite && since == null) {
                 throw new InvalidParameterException(
                         "The selected table already exists. Use -o to overwrite");
             }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
@@ -11,13 +11,17 @@ package org.locationtech.geogig.geotools.cli.porcelain;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Iterator;
 import java.util.List;
 
 import javax.annotation.Nullable;
 
 import org.geotools.data.DataStore;
+import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
+import org.geotools.feature.DefaultFeatureCollection;
+import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeImpl;
 import org.locationtech.geogig.api.GeoGIG;
@@ -32,6 +36,8 @@ import org.locationtech.geogig.api.plumbing.ResolveObjectType;
 import org.locationtech.geogig.api.plumbing.ResolveTreeish;
 import org.locationtech.geogig.api.plumbing.RevObjectParse;
 import org.locationtech.geogig.api.plumbing.RevParse;
+import org.locationtech.geogig.api.plumbing.diff.DiffEntry;
+import org.locationtech.geogig.api.porcelain.DiffOp;
 import org.locationtech.geogig.cli.CLICommand;
 import org.locationtech.geogig.cli.CommandFailedException;
 import org.locationtech.geogig.cli.GeogigCLI;
@@ -39,6 +45,7 @@ import org.locationtech.geogig.cli.InvalidParameterException;
 import org.locationtech.geogig.cli.annotation.ReadOnly;
 import org.locationtech.geogig.geotools.plumbing.ExportOp;
 import org.locationtech.geogig.geotools.plumbing.GeoToolsOpException;
+import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.Filter;
 
@@ -70,6 +77,12 @@ public class PGExport extends AbstractPGCommand implements CLICommand {
     @Parameter(names = { "--featuretype" }, description = "Export only features with the specified feature type if several types are found")
     @Nullable
     public String sFeatureTypeId;
+
+    @Parameter(names = { "--since" }, description = "Only export changes that happend after the given commit")
+    public String since;
+
+    @Parameter(names = { "--until" }, description = "Only export changes until the given commit")
+    public String until;
 
     /**
      * Executes the export command using the provided options.
@@ -143,7 +156,7 @@ public class PGExport extends AbstractPGCommand implements CLICommand {
                     throw new CommandFailedException("Error trying to remove features", e);
                 }
             }
-            ExportOp op = cli.getGeogig().command(ExportOp.class).setFeatureStore(featureStore)
+            ExportOp op = cli.getGeogig().command(ExportOp.class).setOldRef(since).setNewRef(until).setFeatureStore(featureStore)
                     .setPath(path).setFilterFeatureTypeId(featureTypeId).setAlter(alter);
             if (defaultType) {
                 op.exportDefaultFeatureType();

--- a/src/geotools/src/test/java/org/locationtech/geogig/geotools/cli/porcelain/PGExportTest.java
+++ b/src/geotools/src/test/java/org/locationtech/geogig/geotools/cli/porcelain/PGExportTest.java
@@ -17,6 +17,7 @@ import jline.console.ConsoleReader;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.porcelain.CommitOp;
 import org.locationtech.geogig.cli.CommandFailedException;
 import org.locationtech.geogig.cli.GeogigCLI;
@@ -29,6 +30,8 @@ public class PGExportTest extends RepositoryTestCase {
     public ExpectedException exception = ExpectedException.none();
 
     private GeogigCLI cli;
+
+    private RevCommit head;
 
     @Override
     public void setUpInternal() throws Exception {
@@ -50,7 +53,7 @@ public class PGExportTest extends RepositoryTestCase {
         insertAndAdd(lines2);
         insertAndAdd(lines3);
 
-        geogig.command(CommitOp.class).call();
+        head = geogig.command(CommitOp.class).call();
     }
 
     @Override
@@ -158,5 +161,17 @@ public class PGExportTest extends RepositoryTestCase {
         exportCommand.dataStoreFactory = TestHelper.createTestFactory();
         exception.expect(InvalidParameterException.class);
         exportCommand.run(cli);
+    }
+
+    @Test
+    public void testChangeExport() throws Exception {
+        PGExport exportCommand = new PGExport();
+        insertAndAdd(points1_modified);
+        RevCommit until = geogig.command(CommitOp.class).call();
+        exportCommand.until = until.getTreeId().toString();
+        exportCommand.since = head.getTreeId().toString();
+        exportCommand.args = Arrays.asList("Points", "Points");
+        exportCommand.dataStoreFactory = TestHelper.createTestFactory();
+        exportCommand.runInternal(cli);
     }
 }


### PR DESCRIPTION
It is useful to have a postgres mirror, which reflects the current state of a geogig repo. This currently requires to do a complete export of the entire dataset after every change, which takes about 3/4 of a hour for our production datasets. 

This pull request contains support for the two Parameters --since and --until. They take a commit references as argument. A diff between the commits is computed and respective inserts and deletes are done on the database(modify is done as delete followed by insert). The speed of the export only depends on the number of changed elements. For small changes the Export is nearly instant.

