### PR TITLE
Remove jsr305

### DIFF
--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -78,10 +78,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -78,12 +78,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!-- 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/AbstractCommand.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/AbstractCommand.java
@@ -14,10 +14,9 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import java.io.IOException;
 import java.util.IllegalFormatException;
 
-import javax.annotation.Nullable;
-
 import jline.Terminal;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.fusesource.jansi.Ansi;
 import org.locationtech.geogig.cli.annotation.RequiresRepository;
 import org.locationtech.geogig.cli.porcelain.ColorArg;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
@@ -23,11 +23,10 @@ import java.util.ServiceLoader;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
 import jline.console.ConsoleReader;
 import jline.console.CursorBuffer;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.DefaultPlatform;
 import org.locationtech.geogig.api.DefaultProgressListener;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/Logging.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/Logging.java
@@ -14,8 +14,7 @@ import java.net.MalformedURLException;
 import java.net.URISyntaxException;
 import java.net.URL;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.DefaultPlatform;
 import org.locationtech.geogig.api.Platform;
 import org.locationtech.geogig.api.plumbing.ResolveGeogigDir;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/RevListArgs.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/RevListArgs.java
@@ -12,7 +12,7 @@ package org.locationtech.geogig.cli.plumbing;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.collect.Lists;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Diff.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Diff.java
@@ -13,10 +13,9 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
 import jline.console.ConsoleReader;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.fusesource.jansi.Ansi;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/LogArgs.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/LogArgs.java
@@ -11,7 +11,7 @@ package org.locationtech.geogig.cli.porcelain;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.beust.jcommander.Parameter;
 import com.google.common.collect.Lists;

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Version.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Version.java
@@ -11,10 +11,9 @@ package org.locationtech.geogig.cli.porcelain;
 
 import java.io.IOException;
 
-import javax.annotation.Nullable;
-
 import jline.console.ConsoleReader;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.GeoGIG;
 import org.locationtech.geogig.api.porcelain.VersionInfo;
 import org.locationtech.geogig.api.porcelain.VersionOp;

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -55,11 +55,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
-
+    -->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -55,12 +55,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!--
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-    -->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/src/core/src/main/java/org/locationtech/geogig/api/AbstractGeoGigOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/AbstractGeoGigOp.java
@@ -15,8 +15,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.StagingArea;
 import org.locationtech.geogig.repository.WorkingTree;

--- a/src/core/src/main/java/org/locationtech/geogig/api/Bucket.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/Bucket.java
@@ -9,7 +9,7 @@
  */
 package org.locationtech.geogig.api;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.vividsolutions.jts.geom.Envelope;
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/GeoGIG.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/GeoGIG.java
@@ -14,8 +14,7 @@ import static com.google.common.base.Preconditions.checkState;
 import java.io.File;
 import java.net.URL;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.plumbing.ResolveGeogigDir;
 import org.locationtech.geogig.api.plumbing.diff.DiffObjectCount;
 import org.locationtech.geogig.api.porcelain.InitOp;

--- a/src/core/src/main/java/org/locationtech/geogig/api/GeogigSimpleFeature.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/GeogigSimpleFeature.java
@@ -18,8 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.GeometryAttributeImpl;
 import org.geotools.feature.type.AttributeDescriptorImpl;
 import org.geotools.feature.type.Types;

--- a/src/core/src/main/java/org/locationtech/geogig/api/GeogigTransaction.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/GeogigTransaction.java
@@ -13,8 +13,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.plumbing.RefParse;
 import org.locationtech.geogig.api.plumbing.TransactionEnd;
 import org.locationtech.geogig.api.porcelain.ConflictsException;

--- a/src/core/src/main/java/org/locationtech/geogig/api/Node.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/Node.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.RevObject.TYPE;
 
 import com.google.common.base.Optional;

--- a/src/core/src/main/java/org/locationtech/geogig/api/NodeRef.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/NodeRef.java
@@ -14,7 +14,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;

--- a/src/core/src/main/java/org/locationtech/geogig/api/Remote.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/Remote.java
@@ -13,13 +13,13 @@ import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
 
-import javax.annotation.Nullable;
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.SecretKeyFactory;
 import javax.crypto.spec.PBEKeySpec;
 import javax.crypto.spec.PBEParameterSpec;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.Base64;
 
 import com.google.common.base.Optional;

--- a/src/core/src/main/java/org/locationtech/geogig/api/RevPersonImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/RevPersonImpl.java
@@ -11,7 +11,7 @@ package org.locationtech.geogig.api;
 
 import static com.google.common.base.Objects.equal;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;

--- a/src/core/src/main/java/org/locationtech/geogig/api/RevTreeBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/RevTreeBuilder.java
@@ -23,8 +23,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.RevObject.TYPE;
 import org.locationtech.geogig.api.plumbing.HashObject;
 import org.locationtech.geogig.repository.DepthSearch;

--- a/src/core/src/main/java/org/locationtech/geogig/api/hooks/CommandHook.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/hooks/CommandHook.java
@@ -11,9 +11,7 @@ package org.locationtech.geogig.api.hooks;
 
 import java.util.ServiceLoader;
 
-import javax.annotation.Nullable;
-import javax.annotation.concurrent.ThreadSafe;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 
 /**
@@ -27,7 +25,6 @@ import org.locationtech.geogig.api.AbstractGeoGigOp;
  * Implementations must have a default constructor (or no explicit constructor at all), and must be
  * thread safe.
  */
-@ThreadSafe
 public interface CommandHook {
 
     public <C extends AbstractGeoGigOp<?>> C pre(C command)

--- a/src/core/src/main/java/org/locationtech/geogig/api/hooks/CommandHookChain.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/hooks/CommandHookChain.java
@@ -16,8 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.PriorityQueue;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/core/src/main/java/org/locationtech/geogig/api/hooks/Hookables.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/hooks/Hookables.java
@@ -15,8 +15,7 @@ import java.net.URL;
 import java.util.List;
 import java.util.ServiceLoader;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Context;
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/hooks/JVMScriptHook.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/hooks/JVMScriptHook.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.hooks;
 
 import java.io.File;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 
 class JVMScriptHook implements CommandHook {

--- a/src/core/src/main/java/org/locationtech/geogig/api/hooks/ShellScriptHook.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/hooks/ShellScriptHook.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.hooks;
 
 import java.io.File;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 
 class ShellScriptHook implements CommandHook {

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffBounds.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffBounds.java
@@ -15,8 +15,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffCount.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffCount.java
@@ -13,8 +13,7 @@ import static com.google.common.base.Preconditions.checkState;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevTree;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffIndex.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffIndex.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.api.plumbing;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffTree.java
@@ -19,8 +19,7 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Bounded;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffWorkTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/DiffWorkTree.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.plumbing;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/ResolveBranchId.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/ResolveBranchId.java
@@ -9,8 +9,7 @@
  */
 package org.locationtech.geogig.api.plumbing;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/ResolveGeogigDir.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/ResolveGeogigDir.java
@@ -13,8 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Platform;
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/SendPack.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/SendPack.java
@@ -11,8 +11,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.GlobalContextBuilder;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/TransactionEnd.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/TransactionEnd.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.plumbing;
 
 import java.util.concurrent.TimeoutException;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.GeogigTransaction;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteBack.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteBack.java
@@ -13,8 +13,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteTree.java
@@ -13,8 +13,7 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteTree2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/WriteTree2.java
@@ -16,8 +16,7 @@ import java.util.Set;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/BoundsFilteringDiffConsumer.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/BoundsFilteringDiffConsumer.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.api.plumbing.diff;
 import java.util.HashMap;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.crs.DefaultEngineeringCRS;
 import org.locationtech.geogig.api.Bounded;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DepthTreeIterator.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DepthTreeIterator.java
@@ -13,8 +13,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Bounded;
 import org.locationtech.geogig.api.Bucket;
 import org.locationtech.geogig.api.Node;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffEntry.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffEntry.java
@@ -11,10 +11,7 @@ package org.locationtech.geogig.api.plumbing.diff;
 
 import static com.google.common.base.Preconditions.checkArgument;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import javax.annotation.meta.When;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;
@@ -81,8 +78,8 @@ public class DiffEntry {
      * @param oldObject the old node ref
      * @param newObject the new node ref
      */
-    public DiffEntry(@Nonnull(when = When.MAYBE) NodeRef oldObject,
-            @Nonnull(when = When.MAYBE) NodeRef newObject) {
+    public DiffEntry(@Nullable NodeRef oldObject,
+            @Nullable NodeRef newObject) {
 
         Preconditions.checkArgument(oldObject != null || newObject != null,
                 "Either oldObject or newObject shall not be null");

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffPathTracker.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffPathTracker.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.plumbing.diff;
 
 import java.util.Stack;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffSummary.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/DiffSummary.java
@@ -9,7 +9,7 @@
  */
 package org.locationtech.geogig.api.plumbing.diff;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.base.Optional;
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/GenericAttributeDiffImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/GenericAttributeDiffImpl.java
@@ -9,8 +9,7 @@
  */
 package org.locationtech.geogig.api.plumbing.diff;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.storage.text.TextValueSerializer;
 
 import com.google.common.base.Objects;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/LCSGeometryDiffImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/LCSGeometryDiffImpl.java
@@ -16,8 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.plumbing.diff.DiffMatchPatch.Diff;
 import org.locationtech.geogig.api.plumbing.diff.DiffMatchPatch.LinesToCharsResult;
 import org.locationtech.geogig.api.plumbing.diff.DiffMatchPatch.Operation;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/MutableTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/MutableTree.java
@@ -20,8 +20,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PostOrderDiffWalk.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PostOrderDiffWalk.java
@@ -2,7 +2,7 @@ package org.locationtech.geogig.api.plumbing.diff;
 
 import java.util.Stack;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import org.locationtech.geogig.api.Bounded;
 import org.locationtech.geogig.api.Bucket;

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalk.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalk.java
@@ -24,9 +24,8 @@ import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
-import javax.annotation.Nullable;
-import javax.annotation.ParametersAreNonnullByDefault;
-
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Bounded;
 import org.locationtech.geogig.api.Bucket;
 import org.locationtech.geogig.api.Node;
@@ -56,7 +55,7 @@ import com.vividsolutions.jts.geom.Envelope;
  * had collected enough information for its purpose and don't need to go further down a given pair
  * of trees (either named or bucket).
  */
-@ParametersAreNonnullByDefault
+@NonNullByDefault
 public class PreOrderDiffWalk {
 
     private static final NodeStorageOrder ORDER = new NodeStorageOrder();

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/TreeDifference.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/TreeDifference.java
@@ -17,8 +17,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.SortedSet;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/AddOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/AddOp.java
@@ -14,8 +14,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.ProgressListener;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/BranchCreateOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/BranchCreateOp.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.api.porcelain;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CheckoutOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CheckoutOp.java
@@ -17,8 +17,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CleanOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CleanOp.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.porcelain;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.RevObject.TYPE;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CloneOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CloneOp.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.api.porcelain;
 
 import java.io.IOException;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.GlobalContextBuilder;
 import org.locationtech.geogig.api.ProgressListener;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CommitOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/CommitOp.java
@@ -17,8 +17,7 @@ import java.util.Date;
 import java.util.LinkedList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.CommitBuilder;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/DiffOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/DiffOp.java
@@ -13,8 +13,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.plumbing.DiffIndex;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/InitOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/InitOp.java
@@ -23,8 +23,7 @@ import java.net.URL;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Platform;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/MergeOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/MergeOp.java
@@ -13,8 +13,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.FeatureInfo;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/PullOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/PullOp.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.api.porcelain;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/RebaseOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/RebaseOp.java
@@ -43,7 +43,6 @@ import org.locationtech.geogig.api.plumbing.merge.ReportCommitConflictsOp;
 import org.locationtech.geogig.api.porcelain.ResetOp.ResetMode;
 import org.locationtech.geogig.di.CanRunDuringConflict;
 import org.locationtech.geogig.repository.Repository;
-import org.locationtech.geogig.storage.ObjectReader;
 import org.locationtech.geogig.storage.text.TextSerializationFactory;
 
 import com.google.common.base.Charsets;

--- a/src/core/src/main/java/org/locationtech/geogig/api/porcelain/SquashOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/porcelain/SquashOp.java
@@ -17,8 +17,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.CommitBuilder;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/di/caching/ObjectDatabaseCacheInterceptor.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/caching/ObjectDatabaseCacheInterceptor.java
@@ -17,8 +17,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.RevFeature;

--- a/src/core/src/main/java/org/locationtech/geogig/remote/BinaryPackedChanges.java
+++ b/src/core/src/main/java/org/locationtech/geogig/remote/BinaryPackedChanges.java
@@ -22,8 +22,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.NodeRef;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevObject;

--- a/src/core/src/main/java/org/locationtech/geogig/remote/BinaryPackedObjects.java
+++ b/src/core/src/main/java/org/locationtech/geogig/remote/BinaryPackedObjects.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.RevObject;
@@ -31,7 +30,6 @@ import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.BulkOpListener.CountingListener;
 import org.locationtech.geogig.storage.Deduplicator;
 import org.locationtech.geogig.storage.ObjectDatabase;
-import org.locationtech.geogig.storage.ObjectReader;
 import org.locationtech.geogig.storage.ObjectSerializingFactory;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
 import org.slf4j.Logger;

--- a/src/core/src/main/java/org/locationtech/geogig/remote/HttpUtils.java
+++ b/src/core/src/main/java/org/locationtech/geogig/remote/HttpUtils.java
@@ -22,11 +22,11 @@ import java.net.URL;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;
 import org.locationtech.geogig.api.RevObject;

--- a/src/core/src/main/java/org/locationtech/geogig/remote/IRemoteRepo.java
+++ b/src/core/src/main/java/org/locationtech/geogig/remote/IRemoteRepo.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.remote;
 
 import java.io.IOException;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ProgressListener;
 import org.locationtech.geogig.api.Ref;
 import org.locationtech.geogig.api.plumbing.ReceivePack;

--- a/src/core/src/main/java/org/locationtech/geogig/remote/LocalRemoteRepo.java
+++ b/src/core/src/main/java/org/locationtech/geogig/remote/LocalRemoteRepo.java
@@ -20,8 +20,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Bounded;
 import org.locationtech.geogig.api.Bucket;
 import org.locationtech.geogig.api.Context;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/Index.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/Index.java
@@ -14,8 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/RevTreeBuilder2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/RevTreeBuilder2.java
@@ -15,8 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Platform;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/SpatialOps.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/SpatialOps.java
@@ -9,8 +9,8 @@
  */
 package org.locationtech.geogig.repository;
 
-import javax.annotation.Nullable;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.geometry.jts.JTS;
 import org.locationtech.geogig.api.Bucket;
 import org.locationtech.geogig.api.Node;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/StagingArea.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/StagingArea.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.repository;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.ProgressListener;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/WorkingTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/WorkingTree.java
@@ -22,8 +22,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
 import org.geotools.data.store.FeatureIteratorIterator;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/AbstractObjectDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/AbstractObjectDatabase.java
@@ -18,8 +18,7 @@ import java.io.OutputStream;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.RevFeature;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/BulkOpListener.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/BulkOpListener.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.storage;
 
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 
 public abstract class BulkOpListener {

--- a/src/core/src/main/java/org/locationtech/geogig/storage/ConflictsDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/ConflictsDatabase.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.storage;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.plumbing.merge.Conflict;
 
 import com.google.common.base.Optional;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/ObjectDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/ObjectDatabase.java
@@ -13,8 +13,7 @@ import java.io.Closeable;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.RevFeature;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/TransactionConflictsDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/TransactionConflictsDatabase.java
@@ -15,8 +15,7 @@ import static org.locationtech.geogig.api.Ref.append;
 import java.util.List;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.GeogigTransaction;
 import org.locationtech.geogig.api.plumbing.TransactionBegin;
 import org.locationtech.geogig.api.plumbing.TransactionEnd;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/TransactionStagingArea.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/TransactionStagingArea.java
@@ -13,8 +13,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.GeogigTransaction;
 import org.locationtech.geogig.api.Node;
 import org.locationtech.geogig.api.ObjectId;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
@@ -19,8 +19,7 @@ import java.util.List;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.feature.type.BasicFeatureTypes;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
@@ -30,8 +30,7 @@ import java.util.Map;
 import java.util.SortedMap;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.NameImpl;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.feature.type.BasicFeatureTypes;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/fs/FileConflictsDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/fs/FileConflictsDatabase.java
@@ -18,8 +18,7 @@ import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Platform;
 import org.locationtech.geogig.api.plumbing.ResolveGeogigDir;
 import org.locationtech.geogig.api.plumbing.merge.Conflict;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapConflictsDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapConflictsDatabase.java
@@ -13,8 +13,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.plumbing.merge.Conflict;
 import org.locationtech.geogig.storage.ConflictsDatabase;
 

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/DiffBoundsTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/DiffBoundsTest.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.api.plumbing;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.SchemaException;
 import org.geotools.geometry.jts.ReferencedEnvelope;

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/WriteTree2Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/WriteTree2Test.java
@@ -13,8 +13,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Test;
 import org.locationtech.geogig.api.Bucket;
 import org.locationtech.geogig.api.CommitBuilder;

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/MutableTreeTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/MutableTreeTest.java
@@ -14,8 +14,7 @@ import static org.locationtech.geogig.api.ObjectId.NULL;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/TreeDifferenceTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/TreeDifferenceTest.java
@@ -13,8 +13,7 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/CommitOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/CommitOpTest.java
@@ -17,8 +17,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;

--- a/src/geotools/pom.xml
+++ b/src/geotools/pom.xml
@@ -35,12 +35,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!-- 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-	-->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/src/geotools/pom.xml
+++ b/src/geotools/pom.xml
@@ -35,11 +35,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
-
+	-->
     <dependency>
       <groupId>com.google.inject</groupId>
       <artifactId>guice</artifactId>

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/GeoJsonExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/GeoJsonExport.java
@@ -14,8 +14,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/OracleExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/OracleExport.java
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/PGExport.java
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/SLExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/SLExport.java
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/SQLServerExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/SQLServerExport.java
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/ShpExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/ShpExport.java
@@ -17,8 +17,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.data.shapefile.ShapefileDataStoreFactory;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/ShpExportDiff.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/porcelain/ShpExportDiff.java
@@ -16,8 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.shapefile.ShapefileDataStore;
 import org.geotools.data.shapefile.ShapefileDataStoreFactory;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/ExtractBounds.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/ExtractBounds.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.geotools.data;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.filter.visitor.DefaultFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.opengis.filter.expression.Literal;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeoGigDataStore.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeoGigDataStore.java
@@ -15,8 +15,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.NoSuchElementException;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeoGigDataStoreFactory.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeoGigDataStoreFactory.java
@@ -16,8 +16,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStoreFactorySpi;
 import org.geotools.util.KVP;
 import org.locationtech.geogig.api.ContextBuilder;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureReader.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureReader.java
@@ -20,8 +20,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.FeatureReader;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.filter.spatial.ReprojectingFilterVisitor;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.geotools.data;
 import java.io.IOException;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.FeatureReader;
 import org.geotools.data.FeatureSource;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigTransactionState.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/data/GeogigTransactionState.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.geotools.data;
 import java.io.IOException;
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.Transaction;
 import org.geotools.data.Transaction.State;
 import org.geotools.data.store.ContentEntry;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ExportDiffOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ExportDiffOp.java
@@ -14,8 +14,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.IOException;
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ExportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ExportOp.java
@@ -19,8 +19,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DefaultTransaction;
 import org.geotools.data.Transaction;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ImportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ImportOp.java
@@ -16,8 +16,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;

--- a/src/geotools/src/test/java/org/locationtech/geogig/geotools/plumbing/ExportOpTest.java
+++ b/src/geotools/src/test/java/org/locationtech/geogig/geotools/plumbing/ExportOpTest.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.geotools.plumbing;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataUtilities;
 import org.geotools.data.memory.MemoryDataStore;
 import org.geotools.data.simple.SimpleFeatureCollection;

--- a/src/metrics/src/main/java/org/locationtech/geogig/metrics/MeteredCommandHook.java
+++ b/src/metrics/src/main/java/org/locationtech/geogig/metrics/MeteredCommandHook.java
@@ -15,8 +15,7 @@ import static org.locationtech.geogig.metrics.MetricsModule.METRICS_LOGGER;
 
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Platform;
 import org.locationtech.geogig.api.hooks.CannotRunGeogigOperationException;

--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -35,12 +35,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!-- 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-    -->
     
     <!-- used to implement a point cache as a temporary database -->
     <dependency>

--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -35,10 +35,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    -->
     
     <!-- used to implement a point cache as a temporary database -->
     <dependency>

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExport.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExport.java
@@ -15,8 +15,7 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.locationtech.geogig.api.Bounded;
 import org.locationtech.geogig.api.GeoGIG;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportPG.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportPG.java
@@ -13,8 +13,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportShp.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportShp.java
@@ -18,8 +18,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.shapefile.ShapefileDataStoreFactory;
 import org.geotools.data.simple.SimpleFeatureSource;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMHistoryImport.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMHistoryImport.java
@@ -31,11 +31,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
 import javax.management.relation.Relation;
 
 import jline.console.ConsoleReader;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.locationtech.geogig.api.DefaultProgressListener;
 import org.locationtech.geogig.api.FeatureBuilder;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/CreateOSMChangesetOp.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/CreateOSMChangesetOp.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.osm.internal;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/MappingRule.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/MappingRule.java
@@ -16,11 +16,12 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.geotools.referencing.CRS;
+import org.locationtech.geogig.osm.internal.MappingRule.DefaultField;
+import org.locationtech.geogig.osm.internal.MappingRule.GeomRestriction;
 import org.locationtech.geogig.storage.FieldType;
 import org.locationtech.geogig.storage.text.TextValueSerializer;
 import org.opengis.feature.Feature;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMApplyDiffOp.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMApplyDiffOp.java
@@ -17,8 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMDownloader.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMDownloader.java
@@ -24,8 +24,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLEncoder;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ProgressListener;
 
 import com.google.common.io.Closeables;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMImportOp.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMImportOp.java
@@ -21,8 +21,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Platform;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMMapOp.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMMapOp.java
@@ -15,8 +15,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.FeatureBuilder;
 import org.locationtech.geogig.api.NodeRef;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMUtils.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/OSMUtils.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.osm.internal;
 import java.util.Collection;
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataUtilities;
 import org.geotools.referencing.CRS;
 import org.opengis.feature.simple.SimpleFeatureType;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/QueueIterator.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/QueueIterator.java
@@ -13,15 +13,13 @@ import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.TimeUnit;
 
-import javax.annotation.concurrent.ThreadSafe;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 
-@ThreadSafe
+
 class QueueIterator<T> extends AbstractIterator<T> {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(QueueIterator.class);

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/coordcache/MappedIndex.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/coordcache/MappedIndex.java
@@ -26,8 +26,7 @@ import java.util.List;
 import java.util.RandomAccess;
 import java.util.TreeMap;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.osm.internal.OSMCoordinateSequence;
 import org.locationtech.geogig.osm.internal.OSMCoordinateSequenceFactory;
 

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/ChangesetDownloader.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/ChangesetDownloader.java
@@ -36,9 +36,9 @@ import java.util.concurrent.TimeoutException;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.InflaterInputStream;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ProgressListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/ChangesetScanner.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/ChangesetScanner.java
@@ -15,11 +15,12 @@ import static javax.xml.stream.XMLStreamConstants.START_ELEMENT;
 
 import java.io.InputStream;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.FactoryConfigurationError;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
+
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.vividsolutions.jts.geom.Envelope;
 

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/Relation.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/history/Relation.java
@@ -11,7 +11,7 @@ package org.locationtech.geogig.osm.internal.history;
 
 import java.util.List;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;

--- a/src/osm/src/test/java/org/locationtech/geogig/osm/internal/history/ChangesetContentsScannerTest.java
+++ b/src/osm/src/test/java/org/locationtech/geogig/osm/internal/history/ChangesetContentsScannerTest.java
@@ -19,11 +19,11 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.Map;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLInputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.junit.Assert;
 import org.junit.Test;
 import org.locationtech.geogig.osm.internal.history.Relation.Member;

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -139,7 +139,7 @@
     <jcommander.version>1.35</jcommander.version>
     <jettison.version>1.0.1</jettison.version> <!-- matches version used in geoserver -->
     <jline.version>2.11</jline.version>
-    <!--  <jsr305.version>2.0.3</jsr305.version> -->
+    <jdt-annotation.version>1.1.0</jdt-annotation.version>
     <jts.version>1.13</jts.version>
     <junit.version>4.10</junit.version>
     <logback.version>1.1.2</logback.version>
@@ -243,11 +243,11 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
       </dependency>
-      <!-- <dependency>
-        <groupId>com.google.code.findbugs</groupId>
-        <artifactId>jsr305</artifactId>
-        <version>${jsr305.version}</version>
-      </dependency> -->
+      <dependency>
+        <groupId>org.eclipse.jdt</groupId>
+        <artifactId>org.eclipse.jdt.annotation</artifactId>
+        <version>${jdt-annotation.version}</version>
+      </dependency>
 
       <dependency>
         <groupId>com.ning</groupId>

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -139,7 +139,7 @@
     <jcommander.version>1.35</jcommander.version>
     <jettison.version>1.0.1</jettison.version> <!-- matches version used in geoserver -->
     <jline.version>2.11</jline.version>
-    <jsr305.version>2.0.3</jsr305.version>
+    <!--  <jsr305.version>2.0.3</jsr305.version> -->
     <jts.version>1.13</jts.version>
     <junit.version>4.10</junit.version>
     <logback.version>1.1.2</logback.version>
@@ -243,11 +243,11 @@
         <artifactId>guava</artifactId>
         <version>${guava.version}</version>
       </dependency>
-      <dependency>
+      <!-- <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>${jsr305.version}</version>
-      </dependency>
+      </dependency> -->
 
       <dependency>
         <groupId>com.ning</groupId>

--- a/src/storage/bdbje/pom.xml
+++ b/src/storage/bdbje/pom.xml
@@ -25,10 +25,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!--
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/storage/bdbje/pom.xml
+++ b/src/storage/bdbje/pom.xml
@@ -25,12 +25,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!--
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase.java
@@ -19,8 +19,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.RepositoryConnectionException;

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase_v0_1.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase_v0_1.java
@@ -14,8 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.ConfigDatabase;

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase_v0_2.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEGraphDatabase_v0_2.java
@@ -14,8 +14,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.ConfigDatabase;

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase.java
@@ -34,15 +34,13 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevObject;
 import org.locationtech.geogig.storage.AbstractObjectDatabase;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
-import org.locationtech.geogig.storage.ObjectReader;
 import org.locationtech.geogig.storage.ObjectSerializingFactory;
 import org.locationtech.geogig.storage.fs.FileConflictsDatabase;
 import org.slf4j.Logger;

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/NodeData.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/NodeData.java
@@ -16,8 +16,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 
 import com.google.common.collect.ImmutableList;

--- a/src/storage/mongo/pom.xml
+++ b/src/storage/mongo/pom.xml
@@ -30,10 +30,12 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
+    <!-- 
     <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
     </dependency>
+    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/storage/mongo/pom.xml
+++ b/src/storage/mongo/pom.xml
@@ -30,12 +30,10 @@
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
     </dependency>
-    <!-- 
     <dependency>
-      <groupId>com.google.code.findbugs</groupId>
-      <artifactId>jsr305</artifactId>
+      <groupId>org.eclipse.jdt</groupId>
+      <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
-    -->
 
     <dependency>
       <groupId>com.google.inject</groupId>

--- a/src/storage/mongo/src/main/java/org/locationtech/geogig/storage/mongo/MongoConflictsDatabase.java
+++ b/src/storage/mongo/src/main/java/org/locationtech/geogig/storage/mongo/MongoConflictsDatabase.java
@@ -12,8 +12,7 @@ package org.locationtech.geogig.storage.mongo;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.plumbing.merge.Conflict;
 import org.locationtech.geogig.storage.ConflictsDatabase;

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/JettisonRepresentation.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/JettisonRepresentation.java
@@ -12,13 +12,13 @@ package org.locationtech.geogig.rest;
 import java.io.IOException;
 import java.io.Writer;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLOutputFactory;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.codehaus.jettison.mapped.MappedNamespaceConvention;
 import org.codehaus.jettison.mapped.MappedXMLStreamWriter;
+import org.eclipse.jdt.annotation.Nullable;
 import org.restlet.data.MediaType;
 
 import com.google.common.base.Preconditions;

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/RestletException.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/RestletException.java
@@ -9,8 +9,7 @@
  */
 package org.locationtech.geogig.rest;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.restlet.data.MediaType;
 import org.restlet.data.Status;
 import org.restlet.resource.Representation;

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/osm/OsmDownloadWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/osm/OsmDownloadWebOp.java
@@ -13,8 +13,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.List;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.osm.internal.OSMDownloadOp;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/ParameterSet.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/ParameterSet.java
@@ -9,7 +9,9 @@
  */
 package org.locationtech.geogig.web.api;
 
-import javax.annotation.Nullable;
+import org.eclipse.jdt.annotation.Nullable;
+
+
 
 /**
  * Provides an interface for a set of parameters keyed by a string value. Supports implementations

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/ResponseWriter.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/ResponseWriter.java
@@ -17,11 +17,11 @@ import java.util.Map.Entry;
 import java.util.Set;
 import java.util.UUID;
 
-import javax.annotation.Nullable;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamWriter;
 
 import org.codehaus.jettison.AbstractXMLStreamWriter;
+import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.referencing.CRS;
 import org.locationtech.geogig.api.Bucket;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.web.api.commands;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevCommit;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
@@ -9,8 +9,7 @@
  */
 package org.locationtech.geogig.web.api.commands;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.GeogigTransaction;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.web.api.commands;
 
 import java.util.Iterator;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.Ref;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
@@ -11,8 +11,7 @@ package org.locationtech.geogig.web.api.commands;
 
 import static com.google.common.base.Preconditions.checkState;
 
-import javax.annotation.Nullable;
-
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.api.CommitBuilder;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.NodeRef;


### PR DESCRIPTION
As described on the developers mailing list, this PR replaces jsr305 with Eclipse JDT Null analysis Annotations. The jars containing the annotations are available in the maven central repository. 

So this is mainly replacing import statements and changing maven dependencies. It should not affect runtime behaviour as these annotations aren't evaluated during runtime.

Beside that, there are two or three places where I needed to remove parameters from the annotations (when.MAYBE) or delete an annotation (there is no equivalent to @ThreadSafe in the JDT Annotations).

On my system, this compiles with JDK7 from Oracle and tests are green. 