### PR TITLE
fixes issue with performing end transaction through web api

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/api/GeogigTransaction.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/GeogigTransaction.java
@@ -76,11 +76,11 @@ public class GeogigTransaction implements Context {
         transactionIndex = new TransactionStagingArea(new Index(this), transactionId);
         transactionWorkTree = new WorkingTree(this);
         transactionRefDatabase = new TransactionRefDatabase(context.refDatabase(), transactionId);
+        transactionBlobStore = new TransactionBlobStoreImpl(
+                (TransactionBlobStore) context.blobStore(), transactionId);
     }
 
     public void create() {
-        transactionBlobStore = new TransactionBlobStoreImpl(
-                (TransactionBlobStore) context.blobStore(), transactionId);
         transactionRefDatabase.create();
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/GeogigTransactionTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/GeogigTransactionTest.java
@@ -516,4 +516,19 @@ public class GeogigTransactionTest extends RepositoryTestCase {
         txRemoteHead = geogig.command(RefParse.class).setName(unchangedRemoteRef).call().get();
         assertEquals(headCommit.getId(), txRemoteHead.getObjectId());
     }
+
+    @Test
+    public void testEndTransactionFromTransactionId() throws Exception {
+        GeogigTransaction tx = geogig.command(TransactionBegin.class).call();
+
+        // Use transaction id from the TransactionBegin to create another transaction that
+        // can be used to perform other actions such as pull, push, and end. The web api
+        // for example needs a way to retrieve/recreate a transaction object using a transactionId
+        // without calling GeogigTransaction.create() since the transaction was previously created.
+        GeogigTransaction txNew = new GeogigTransaction(geogig.getContext(), tx.getTransactionId());
+
+        TransactionEnd endTransaction = geogig.command(TransactionEnd.class);
+        boolean closed = endTransaction.setCancel(false).setTransaction((GeogigTransaction) txNew).call();
+        assertTrue(closed);
+    }
 }


### PR DESCRIPTION
commit https://github.com/locationtech/geogig/commit/e93b67d85e0f4e2f83efa6af92345ce9f8d8a35b added the blobstore to GeogigTransaction which causes a null pointer exception when endTransaction is called through the web api:

Added a test case, or to reproduce:
```
1) beginTransaction?output_format=JSON
   {"response":{"success":true,"Transaction":{"ID":"dc1c3d7d-74bb-40d7-b770-964b04dd5284"}}}
2) endTransaction?output_format=JSON&transactionId=dc1c3d7d-74bb-40d7-b770-964b04dd5284
   {"response":{"success":false,"error":"org.locationtech.geogig.api.GeogigTransaction.close(GeogigTransaction.java:90)\torg.locationtech.geogig.api.plumbing.TransactionEnd._call(TransactionEnd.java:117)\torg.locationtech.geogig.api.plumbing.TransactionEnd._call(TransactionEnd.java:45)\torg.locationtech.geogig.api.AbstractGeoGigOp.call(AbstractGeoGigOp.java:132)\torg.locationtech.geogig.web.api.commands.EndTransaction.run(EndTransaction.java:66)\t"}}
```
Exception:
```
Sep 02, 2015 3:30:47 AM org.locationtech.geogig.rest.repository.CommandResource formatUnexpectedException
SEVERE: Unexpected exception : 32502cc7-9804-46bb-89e3-07d4326e6fce
java.lang.NullPointerException
        at org.locationtech.geogig.api.GeogigTransaction.close(GeogigTransaction.java:90)
        at org.locationtech.geogig.api.plumbing.TransactionEnd._call(TransactionEnd.java:117)
        at org.locationtech.geogig.api.plumbing.TransactionEnd._call(TransactionEnd.java:45)
        at org.locationtech.geogig.api.AbstractGeoGigOp.call(AbstractGeoGigOp.java:132)
        at org.locationtech.geogig.web.api.commands.EndTransaction.run(EndTransaction.java:66)
        at org.locationtech.geogig.rest.repository.CommandResource.runCommand(CommandResource.java:101)
        at org.locationtech.geogig.rest.repository.CommandResource.getRepresentation(CommandResource.java:77)
        at org.restlet.resource.Resource.handleGet(Resource.java:415)
```