### PR TITLE
fixed project licence (now Eclipse) in documentation theme

### DIFF
--- a/doc/themes/geogig_docs/layout.html
+++ b/doc/themes/geogig_docs/layout.html
@@ -87,7 +87,7 @@
         </div>
         <div class="section">
           <h3>License</h3>
-          <p>This project is licensed under the <a href="https://github.com/locationtech/geogig/blob/master/LICENSE.txt">BSD New License</a>.</p>
+          <p>This project is licensed under the <a href="https://github.com/locationtech/geogig/blob/master/LICENSE.txt">Eclipse License</a>.</p>
         </div>
       {%- endif %}
       {%- if customsidebar %}


### PR DESCRIPTION
In the docs there's still a reference to the old BSD License name. Fixed it.