### PR TITLE
Import osm way.nodes as a long[] and way.tags as a Map<String, String>.

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/api/data/MapToStringConverterFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/data/MapToStringConverterFactory.java
@@ -1,0 +1,210 @@
+/* Copyright (c) 2015 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.api.data;
+
+import static org.locationtech.geogig.storage.FieldType.UNKNOWN;
+
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Map.Entry;
+
+import org.geotools.factory.Hints;
+import org.geotools.util.Converter;
+import org.geotools.util.ConverterFactory;
+import org.geotools.util.Converters;
+import org.locationtech.geogig.storage.FieldType;
+import org.opengis.feature.simple.SimpleFeature;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Provides GeoTools converters for attributes of type {@link Map java.util.Map<String, Object>} to
+ * and from String, since GeoGig supports these kind of attributes in {@link SimpleFeature}s (See
+ * {@link FieldType}).
+ * <p>
+ * Engages into the {@link Converters#getConverterFactories} SPI lookup by means of the
+ * {@code src/main/resources/META-INF/services/org.geotools.util.ConverterFactory} file.
+ */
+public class MapToStringConverterFactory implements ConverterFactory {
+
+    private static final char VALUE_START = '<';
+
+    private static final char VALUE_END = '>';
+
+    private static final char KEY_VALUE_SEPARATOR = '=';
+
+    private static final char ENTRY_SEPARATOR = '|';
+
+    @Override
+    public Converter createConverter(Class<?> source, Class<?> target, Hints hints) {
+
+        final FieldType sourceBinding = FieldType.forBinding(source);
+        final FieldType targetBinding = FieldType.forBinding(target);
+        if (UNKNOWN == sourceBinding || UNKNOWN == targetBinding) {
+            return null;
+        }
+        final boolean sourceIsMap = Map.class.isAssignableFrom(sourceBinding.getBinding());
+        final boolean targetIsMap = Map.class.isAssignableFrom(targetBinding.getBinding());
+        if (!(sourceIsMap || targetIsMap)) {
+            return null;
+        }
+        if (String.class.equals(sourceBinding.getBinding())) {
+            return FROM_STRING;
+        }
+        if (String.class.equals(targetBinding.getBinding())) {
+            return TO_STRING;
+        }
+        return null;
+    }
+
+    private static Converter TO_STRING = new Converter() {
+
+        @Override
+        public <T> T convert(Object source, Class<T> target) throws Exception {
+            if (source == null) {
+                return null;
+            }
+            Preconditions.checkArgument(Map.class.isAssignableFrom(source.getClass()));
+            @SuppressWarnings("unchecked")
+            Map<String, Object> map = (Map<String, Object>) source;
+            StringBuilder sb = new StringBuilder();
+
+            for (Iterator<Map.Entry<String, Object>> entries = map.entrySet().iterator(); entries
+                    .hasNext();) {
+                Entry<String, Object> e = entries.next();
+                String key = e.getKey();
+                Object value = e.getValue();
+                FieldType valueType = FieldType.forValue(value);
+                String convertedValue = Converters.convert(value, String.class);
+                sb.append(key);
+                sb.append(KEY_VALUE_SEPARATOR);
+                sb.append(valueType).append(VALUE_START).append(convertedValue).append(VALUE_END);
+                if (entries.hasNext()) {
+                    sb.append(ENTRY_SEPARATOR);
+                }
+            }
+
+            return (T) sb.toString();
+        }
+    };
+
+    private static Converter FROM_STRING = new Converter() {
+
+        @Override
+        public <T> T convert(Object source, Class<T> target) throws Exception {
+            if (source == null) {
+                return null;
+            }
+            Preconditions.checkArgument(source.getClass().equals(String.class));
+            Preconditions.checkArgument(Map.class.isAssignableFrom(target));
+
+            Map<String, String> entries = EntrySplitter.split((String) source);
+
+            Map<String, Object> map = new HashMap<>();
+
+            for (Entry<String, String> entry : entries.entrySet()) {
+                String key = entry.getKey();
+                String value = entry.getValue();
+
+                int openIdex = value.indexOf('<');
+                Preconditions
+                        .checkArgument(
+                                openIdex > 0 && value.endsWith(">"),
+                                "Invalid value format for key %s: '%s'. Expected: {FieldType}<{converted value}>",
+                                key, value);
+                String valueType = value.substring(0, openIdex);
+                String stringValue = value.substring(openIdex + 1, value.length() - 1);
+
+                FieldType valueFieldType;
+                try {
+                    valueFieldType = FieldType.valueOf(valueType);
+                } catch (IllegalArgumentException e) {
+                    throw new IllegalArgumentException(String.format(
+                            "Invalid field type '%s' for key '%s', value '%s;", valueType, key,
+                            value), e);
+                }
+                Class<?> valueBinding = valueFieldType.getBinding();
+
+                Object finalValue = Converters.convert(stringValue, valueBinding);
+
+                map.put(key, finalValue);
+            }
+            return (T) map;
+        }
+
+    };
+
+    private static class EntrySplitter {
+
+        public enum States {
+            STARTING, IN_VALUE, END_VALUE
+        }
+
+        public static Map<String, String> split(final String string) {
+
+            Map<String, String> map = new LinkedHashMap<>();
+
+            States state = States.STARTING;
+            StringBuilder temp = new StringBuilder();
+
+            int depth = 0;
+
+            String key = null, value = null;
+
+            for (int i = 0; i < string.length(); i++) {
+                char cTemp = string.charAt(i);
+                switch (cTemp) {
+                case KEY_VALUE_SEPARATOR: {
+                    if (state == States.STARTING) {
+                        state = States.IN_VALUE;
+                        key = temp.toString();
+                        temp.setLength(0);
+                    } else {
+                        temp.append(cTemp);
+                    }
+                    break;
+                }
+                case VALUE_START: {
+                    depth++;
+                    temp.append(cTemp);
+                    Preconditions.checkState(state == States.IN_VALUE);
+                    break;
+                }
+                case VALUE_END: {
+                    depth--;
+                    temp.append(cTemp);
+                    if (depth == 0) {
+                        state = States.STARTING;
+                        value = temp.toString();
+                        temp.setLength(0);
+                        map.put(key, value);
+                    }
+                    break;
+                }
+                case ENTRY_SEPARATOR: {
+                    if (depth == 0) {
+                        state = States.STARTING;
+                    } else {
+                        temp.append(cTemp);
+                    }
+                    break;
+                }
+                default: {
+                    temp.append(cTemp);
+                }
+                }
+            }
+
+            return map;
+        }
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/api/data/PrimitiveArrayToStringConverterFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/data/PrimitiveArrayToStringConverterFactory.java
@@ -1,0 +1,131 @@
+/* Copyright (c) 2015 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.api.data;
+
+import static org.locationtech.geogig.storage.FieldType.UNKNOWN;
+
+import java.lang.reflect.Array;
+import java.util.List;
+
+import org.geotools.factory.Hints;
+import org.geotools.util.Converter;
+import org.geotools.util.ConverterFactory;
+import org.geotools.util.Converters;
+import org.locationtech.geogig.storage.FieldType;
+import org.opengis.feature.simple.SimpleFeature;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+
+/**
+ * Provides GeoTools converters for attributes of primitive arrays types (
+ * {@code long[], byte[], boolean[], etc}) to and from String, since GeoGig supports these kind of
+ * attributes in {@link SimpleFeature}s (See {@link FieldType}).
+ * <p>
+ * Engages into the {@link Converters#getConverterFactories} SPI lookup by means of the
+ * {@code src/main/resources/META-INF/services/org.geotools.util.ConverterFactory} file.
+ */
+public class PrimitiveArrayToStringConverterFactory implements ConverterFactory {
+
+    @Override
+    public Converter createConverter(Class<?> source, Class<?> target, Hints hints) {
+
+        final FieldType sourceBinding = FieldType.forBinding(source);
+        final FieldType targetBinding = FieldType.forBinding(target);
+        if (UNKNOWN == sourceBinding || UNKNOWN == targetBinding) {
+            return null;
+        }
+        final boolean sourceIsArray = sourceBinding.getBinding().isArray();
+        final boolean targetIsArray = targetBinding.getBinding().isArray();
+        if (!sourceIsArray && !targetIsArray) {
+            return null;
+        }
+        if (String.class.equals(sourceBinding.getBinding())) {
+            return FROM_STRING;
+        }
+        if (String.class.equals(targetBinding.getBinding())) {
+            return TO_STRING;
+        }
+        return null;
+    }
+
+    private static Converter TO_STRING = new Converter() {
+
+        @Override
+        public <T> T convert(Object source, Class<T> target) throws Exception {
+            if (source == null) {
+                return null;
+            }
+            Preconditions.checkArgument(source.getClass().isArray());
+            final int length = Array.getLength(source);
+            StringBuilder sb = new StringBuilder();
+            if (length > 0) {
+                for (int i = 0; i < length - 1; i++) {
+                    sb.append(Array.get(source, i));
+                    sb.append(';');
+                }
+                sb.append(Array.get(source, length - 1));
+            }
+
+            return (T) sb.toString();
+        }
+    };
+
+    private static Converter FROM_STRING = new Converter() {
+
+        @Override
+        public <T> T convert(Object source, Class<T> target) throws Exception {
+            if (source == null) {
+                return null;
+            }
+            Preconditions.checkArgument(source.getClass().equals(String.class));
+            Preconditions.checkArgument(target.isArray());
+            Preconditions.checkArgument(target.getComponentType().isPrimitive());
+
+            final FieldType arrayType = FieldType.forBinding(target);
+            Preconditions.checkState(arrayType.getBinding().isArray());
+
+            final List<String> list = Splitter.on(';').omitEmptyStrings().trimResults()
+                    .splitToList((CharSequence) source);
+            final int length = list.size();
+            Object array = Array.newInstance(target.getComponentType(), length);
+            for (int i = 0; i < length; i++) {
+                String val = list.get(i);
+                switch (arrayType) {
+                case BOOLEAN_ARRAY:
+                    Array.setBoolean(array, i, Boolean.parseBoolean(val));
+                    break;
+                case BYTE_ARRAY:
+                    Array.setByte(array, i, Byte.parseByte(val));
+                    break;
+                case SHORT_ARRAY:
+                    Array.setShort(array, i, Short.parseShort(val));
+                    break;
+                case INTEGER_ARRAY:
+                    Array.setInt(array, i, Integer.parseInt(val));
+                    break;
+                case LONG_ARRAY:
+                    Array.setLong(array, i, Long.parseLong(val));
+                    break;
+                case FLOAT_ARRAY:
+                    Array.setFloat(array, i, Float.parseFloat(val));
+                    break;
+                case DOUBLE_ARRAY:
+                    Array.setDouble(array, i, Double.parseDouble(val));
+                    break;
+                default:
+                    throw new IllegalArgumentException();
+                }
+            }
+            return (T) array;
+        }
+    };
+
+}

--- a/src/core/src/main/java/org/locationtech/geogig/storage/text/TextValueSerializer.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/text/TextValueSerializer.java
@@ -16,6 +16,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.geotools.util.Converters;
 import org.locationtech.geogig.storage.FieldType;
 
 import com.google.common.base.Joiner;
@@ -49,6 +50,9 @@ public class TextValueSerializer {
     static abstract class ArraySerializer implements ValueSerializer {
         @Override
         public String toString(Object value) {
+            if(value.getClass().getComponentType().isPrimitive()){
+                return Converters.convert(value, String.class);
+            }
             return "[" + Joiner.on(" ").join((Object[]) value) + "]";
         }
     }
@@ -281,6 +285,18 @@ public class TextValueSerializer {
                 java.sql.Timestamp ts = (java.sql.Timestamp) value;
                 return new StringBuilder().append(ts.getTime()).append(' ').append(ts.getNanos())
                         .toString();
+            }
+        });
+        serializers.put(FieldType.MAP, new ValueSerializer() {
+            
+            @Override
+            public String toString(Object value) {
+                return Converters.convert(value, String.class);
+            }
+            
+            @Override
+            public Object fromString(String in) throws ParseException {
+                return Converters.convert(in, Map.class);
             }
         });
     }

--- a/src/core/src/main/resources/META-INF/services/org.geotools.util.ConverterFactory
+++ b/src/core/src/main/resources/META-INF/services/org.geotools.util.ConverterFactory
@@ -1,0 +1,2 @@
+org.locationtech.geogig.api.data.PrimitiveArrayToStringConverterFactory
+org.locationtech.geogig.api.data.MapToStringConverterFactory

--- a/src/core/src/test/java/org/locationtech/geogig/api/data/MapToStringConverterFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/data/MapToStringConverterFactoryTest.java
@@ -1,0 +1,46 @@
+/* Copyright (c) 2015 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.api.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import java.util.Map;
+
+import org.geotools.util.Converters;
+import org.junit.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+public class MapToStringConverterFactoryTest {
+
+    @Test
+    public void roundtripTest() {
+
+        Map<String, ? extends Object> map = ImmutableMap.of(//
+                "key1", "value1",//
+                "key:2", "value|2",//
+                "key3", Integer.valueOf(12345),//
+                "submap", ImmutableMap.of("submap1", "subvalue1", "submap2", new Long(789)));
+
+        assertNull(Converters.convert(map, Integer.class));
+
+        String converted = Converters.convert(map, String.class);
+        assertNotNull(converted);
+
+        @SuppressWarnings("unchecked")
+        Map<String, Object> roundTripped = Converters.convert(converted, Map.class);
+        assertNotNull(roundTripped);
+
+        assertEquals(map, roundTripped);
+    }
+
+}

--- a/src/core/src/test/java/org/locationtech/geogig/api/data/PrimitiveArrayToStringConverterFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/data/PrimitiveArrayToStringConverterFactoryTest.java
@@ -1,0 +1,93 @@
+/* Copyright (c) 2015 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.api.data;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Array;
+
+import org.geotools.util.Converters;
+import org.junit.Test;
+
+public class PrimitiveArrayToStringConverterFactoryTest {
+
+    @Test
+    public void testBoolean() {
+        roundtripTest(new boolean[0]);
+        roundtripTest(new boolean[] { true, false, false, false, true });
+    }
+
+    @Test
+    public void testByte() {
+        roundtripTest(new byte[0]);
+        roundtripTest(new byte[] { Byte.MIN_VALUE, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, Byte.MAX_VALUE });
+    }
+
+    @Test
+    public void testShort() {
+        roundtripTest(new short[0]);
+        roundtripTest(new short[] { Short.MIN_VALUE, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, Short.MAX_VALUE });
+    }
+
+    @Test
+    public void testInt() {
+        roundtripTest(new int[0]);
+        roundtripTest(new int[] { Integer.MIN_VALUE, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8,
+                Integer.MAX_VALUE });
+    }
+
+    @Test
+    public void testLong() {
+        roundtripTest(new long[0]);
+        roundtripTest(new long[] { Long.MIN_VALUE, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, Long.MAX_VALUE });
+    }
+
+    @Test
+    public void testFloat() {
+        roundtripTest(new float[0]);
+        roundtripTest(new float[] { Float.NaN, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY,
+                Float.MIN_VALUE, -1.1f, 0, 1.1f, 2.2f, 3.3f, Float.MAX_VALUE });
+    }
+
+    @Test
+    public void testDouble() {
+        roundtripTest(new double[0]);
+        roundtripTest(new double[] { Double.NaN, Double.NEGATIVE_INFINITY,
+                Double.POSITIVE_INFINITY, Double.MIN_VALUE, -1.1, 0, 1.1, 2.2, 3.3,
+                Double.MAX_VALUE });
+    }
+
+    private void roundtripTest(Object value) {
+
+        String converted = Converters.convert(value, String.class);
+        assertNotNull(converted);
+
+        Object roundTripped = Converters.convert(converted, value.getClass());
+
+        assertNotNull(roundTripped);
+        assertTrue(roundTripped.getClass().isArray());
+        assertTrue(roundTripped.getClass().getComponentType().isPrimitive());
+
+        assertArrayEquals(value, roundTripped);
+    }
+
+    private void assertArrayEquals(Object array1, Object array2) {
+        assertEquals(Array.getLength(array1), Array.getLength(array2));
+        int length = Array.getLength(array1);
+        for (int i = 0; i < length; i++) {
+            Object v1 = Array.get(array1, i);
+            Object v2 = Array.get(array2, i);
+            assertEquals(v1, v2);
+        }
+    }
+
+}

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureTypeV2Serialization.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureTypeV2Serialization.java
@@ -9,130 +9,14 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
-import static org.locationtech.geogig.api.RevFeatureBuilder.build;
-
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.TreeMap;
-
-import org.geotools.data.DataUtilities;
-import org.geotools.feature.simple.SimpleFeatureBuilder;
-import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
-import org.geotools.geometry.jts.WKTReader2;
-import org.junit.Before;
-import org.junit.Test;
-import org.locationtech.geogig.api.ObjectId;
-import org.locationtech.geogig.api.RevFeature;
 import org.locationtech.geogig.storage.ObjectSerializingFactory;
 import org.locationtech.geogig.storage.RevFeatureTypeSerializationTest;
-import org.opengis.feature.Feature;
-import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.GeometryDescriptor;
-
-import com.google.common.collect.ImmutableMap;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
 
 public class DataStreamFeatureTypeV2Serialization extends RevFeatureTypeSerializationTest {
-
-    private SimpleFeatureType ftWithMapAttribute;
-
-    @Before
-    public void before() {
-        SimpleFeatureTypeBuilder ftb = new SimpleFeatureTypeBuilder();
-        ftb.setName("TestType");
-        ftb.add("name", String.class);
-        ftb.add("tags", Map.class);
-        
-        ftWithMapAttribute = ftb.buildFeatureType();
-    }
 
     @Override
     protected ObjectSerializingFactory getObjectSerializingFactory() {
         return new DataStreamSerializationFactoryV2();
-    }
-
-    private Geometry geom(String wkt) throws ParseException {
-        Geometry value = new WKTReader2().read(wkt);
-        return value;
-    }
-
-    protected Feature feature(SimpleFeatureType type, String id, Object... values)
-            throws ParseException {
-        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
-        for (int i = 0; i < values.length; i++) {
-            Object value = values[i];
-            if (type.getDescriptor(i) instanceof GeometryDescriptor) {
-                if (value instanceof String) {
-                    value = geom((String) value);
-                }
-            }
-            builder.set(i, value);
-        }
-        return builder.buildFeature(id);
-    }
-
-    @Test
-    public void testMapAttribute() throws Exception {
-
-        SimpleFeatureType featureType = DataUtilities.createType("http://geogig.org/test",
-                "TestType", "str:String, map:java.util.Map");
-
-        Map<String, Object> map1, map2, map3;
-        map1 = new HashMap<>();
-        map2 = new TreeMap<>();
-
-        map1.put("long", Long.valueOf(123));
-        map2.put("long", Long.valueOf(123));
-
-        map1.put("int", Integer.valueOf(456));
-        map2.put("int", Integer.valueOf(456));
-
-        map1.put("string", "hello");
-        map2.put("string", "hello");
-
-        map1.put("geom", geom("LINESTRING(1 1, 1.1 2.1, 100 1000)"));
-        map2.put("geom", geom("LINESTRING(1 1, 1.1 2.1, 100 1000)"));
-
-        map3 = ImmutableMap.of("I", (Object) "am", "a", (Object) "different", "map than",
-                (Object) map1, "and", (Object) map2);
-
-        RevFeature revFeature1 = build(feature(featureType, "f1", "the name", map1));
-        RevFeature revFeature2 = build(feature(featureType, "f2", "the name", map2));
-        RevFeature revFeature3 = build(feature(featureType, "f3", "the name", map3));
-
-        assertEquals(revFeature1, revFeature2);
-        assertEquals(revFeature1.getValues(), revFeature2.getValues());
-
-        byte[] data1 = serialize(revFeature1);
-        byte[] data2 = serialize(revFeature2);
-        byte[] data3 = serialize(revFeature3);
-
-        RevFeature read1 = read(data1, revFeature1.getId());
-        RevFeature read2 = read(data2, revFeature2.getId());
-        RevFeature read3 = read(data3, revFeature3.getId());
-
-        assertEquals(read1, read2);
-        assertEquals(read1.getValues(), read2.getValues());
-        assertEquals(revFeature3, read3);
-        assertEquals(revFeature3.getValues(), read3.getValues());
-    }
-
-    private RevFeature read(byte[] data, ObjectId id) throws IOException {
-        ByteArrayInputStream input = new ByteArrayInputStream(data);
-        RevFeature rft = (RevFeature) serializer.read(id, input);
-        return rft;
-    }
-
-    private byte[] serialize(RevFeature revFeature1) throws IOException {
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        serializer.write(revFeature1, output);
-
-        byte[] data = output.toByteArray();
-        return data;
     }
 
 }

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
@@ -13,8 +13,10 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 
 import org.geotools.data.DataUtilities;
 import org.geotools.feature.NameImpl;
@@ -52,6 +54,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.google.common.base.Function;
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
@@ -450,4 +453,14 @@ public abstract class RepositoryTestCase extends Assert {
         }
         return bounds;
     }
+
+    public static Map<String, String> asMap(String... kvp) {
+        Preconditions.checkArgument(kvp.length % 2 == 0, "An even number of arguments is expected");
+        Map<String, String> map = new HashMap<>();
+        for (int i = 0; i < kvp.length; i += 2) {
+            map.put(kvp[i], kvp[i + 1]);
+        }
+        return map;
+    }
+
 }

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportPG.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMExportPG.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.simple.SimpleFeatureSource;
 import org.geotools.data.simple.SimpleFeatureStore;
+import org.locationtech.geogig.api.ProgressListener;
 import org.locationtech.geogig.cli.AbstractCommand;
 import org.locationtech.geogig.cli.CLICommand;
 import org.locationtech.geogig.cli.CommandFailedException;
@@ -28,6 +29,7 @@ import org.locationtech.geogig.geotools.plumbing.ExportOp;
 import org.locationtech.geogig.geotools.plumbing.GeoToolsOpException;
 import org.locationtech.geogig.osm.internal.Mapping;
 import org.locationtech.geogig.osm.internal.MappingRule;
+import org.locationtech.geogig.osm.internal.OSMUtils;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
@@ -89,7 +91,9 @@ public class OSMExportPG extends AbstractCommand implements CLICommand {
                 }
 
             };
+            final ProgressListener progressListener = cli.getProgressListener();
             SimpleFeatureType outputFeatureType = rule.getFeatureType();
+            outputFeatureType = OSMUtils.adaptIncompatibleAttributesForExport(outputFeatureType, progressListener);
             String path = getOriginTreesFromOutputFeatureType(outputFeatureType);
             DataStore dataStore = null;
             try {

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMHistoryImport.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/cli/commands/OSMHistoryImport.java
@@ -21,7 +21,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -240,8 +239,8 @@ public class OSMHistoryImport extends AbstractCommand implements CLICommand {
         return osmAPIUrl;
     }
 
-    private void importOsmHistory(GeogigCLI cli, Console console,
-            HistoryDownloader downloader, @Nullable Envelope featureFilter) throws IOException {
+    private void importOsmHistory(GeogigCLI cli, Console console, HistoryDownloader downloader,
+            @Nullable Envelope featureFilter) throws IOException {
 
         Iterator<Changeset> changesets = downloader.fetchChangesets();
 
@@ -547,7 +546,7 @@ public class OSMHistoryImport extends AbstractCommand implements CLICommand {
         builder.set("timestamp", Long.valueOf(feature.getTimestamp()));
         builder.set("changeset", Long.valueOf(feature.getChangesetId()));
 
-        String tags = buildTagsString(feature.getTags());
+        Map<String, String> tags = feature.getTags();
         builder.set("tags", tags);
 
         String user = feature.getUserName() + ":" + feature.getUserId();
@@ -557,7 +556,7 @@ public class OSMHistoryImport extends AbstractCommand implements CLICommand {
             builder.set("location", geom);
         } else if (feature instanceof Way) {
             builder.set("way", geom);
-            String nodes = buildNodesString(((Way) feature).getNodes());
+            long[] nodes = buildNodesArray(((Way) feature).getNodes());
             builder.set("nodes", nodes);
         } else {
             throw new IllegalArgumentException();
@@ -568,41 +567,11 @@ public class OSMHistoryImport extends AbstractCommand implements CLICommand {
         return simpleFeature;
     }
 
-    /**
-     * @param tags
-     * @return
-     */
-    @Nullable
-    private static String buildTagsString(Map<String, String> tags) {
-        if (tags.isEmpty()) {
-            return null;
+    private static long[] buildNodesArray(List<Long> nodeIds) {
+        long[] nodes = new long[nodeIds.size()];
+        for (int i = 0; i < nodeIds.size(); i++) {
+            nodes[i] = nodeIds.get(i).longValue();
         }
-        StringBuilder sb = new StringBuilder();
-        for (Iterator<Map.Entry<String, String>> it = tags.entrySet().iterator(); it.hasNext();) {
-            Entry<String, String> e = it.next();
-            String key = e.getKey();
-            if (key == null || key.isEmpty()) {
-                continue;
-            }
-            String value = e.getValue();
-            sb.append(key).append(':').append(value);
-            if (it.hasNext()) {
-                sb.append(';');
-            }
-        }
-        return sb.toString();
-    }
-
-    private static String buildNodesString(List<Long> nodeIds) {
-        StringBuilder sb = new StringBuilder();
-        for (Iterator<Long> it = nodeIds.iterator(); it.hasNext();) {
-            Long node = it.next();
-            sb.append(node);
-            if (it.hasNext()) {
-                sb.append(";");
-            }
-        }
-        return sb.toString();
-
+        return nodes;
     }
 }

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/Mapping.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/Mapping.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
@@ -56,8 +57,10 @@ public class Mapping {
         if (feature == null) {
             return ImmutableList.of();
         }
-        String tagsString = (String) ((SimpleFeature) feature).getAttribute("tags");
-        Collection<Tag> tags = OSMUtils.buildTagsCollectionFromString(tagsString);
+        @SuppressWarnings("unchecked")
+        Map<String, String> tagsMap = (Map<String, String>) ((SimpleFeature) feature)
+                .getAttribute("tags");
+        Collection<Tag> tags = OSMUtils.buildTagsCollection(tagsMap);
         ImmutableList.Builder<MappedFeature> builder = ImmutableList.<MappedFeature> builder();
         for (MappingRule rule : rules) {
             Optional<Feature> newFeature = rule.apply(feature, tags);
@@ -76,8 +79,10 @@ public class Mapping {
      * @return
      */
     public boolean canBeApplied(Feature feature) {
-        String tagsString = (String) ((SimpleFeature) feature).getAttribute("tags");
-        Collection<Tag> tags = OSMUtils.buildTagsCollectionFromString(tagsString);
+        @SuppressWarnings("unchecked")
+        Map<String, String> tagsMap = (Map<String, String>) ((SimpleFeature) feature)
+                .getAttribute("tags");
+        Collection<Tag> tags = OSMUtils.buildTagsCollection(tagsMap);
         if (tags.isEmpty()) {
             return false;
         }

--- a/src/osm/src/main/java/org/locationtech/geogig/osm/internal/MappingRule.java
+++ b/src/osm/src/main/java/org/locationtech/geogig/osm/internal/MappingRule.java
@@ -74,7 +74,7 @@ public class MappingRule {
     }
 
     public enum DefaultField {
-        visible(Boolean.class), timestamp(Long.class), tags(String.class), changeset(Long.class), version(
+        visible(Boolean.class), timestamp(Long.class), tags(Map.class), changeset(Long.class), version(
                 Integer.class), user(String.class);
 
         private Class<?> clazz;
@@ -206,7 +206,7 @@ public class MappingRule {
             Preconditions.checkNotNull(geometryType,
                     "The mapping rule does not define a geometry field");
             if (!geometryType.equals(Point.class)) {
-                fb.add("nodes", String.class);
+                fb.add("nodes", long[].class);
             }
             featureType = fb.buildFeatureType();
 
@@ -235,8 +235,10 @@ public class MappingRule {
      * @return
      */
     public Optional<Feature> apply(Feature feature) {
-        String tagsString = (String) ((SimpleFeature) feature).getAttribute("tags");
-        Collection<Tag> tags = OSMUtils.buildTagsCollectionFromString(tagsString);
+        @SuppressWarnings("unchecked")
+        Map<String, String> tagsMap = (Map<String, String>) ((SimpleFeature) feature)
+                .getAttribute("tags");
+        Collection<Tag> tags = OSMUtils.buildTagsCollection(tagsMap);
         return apply(feature, tags);
     }
 
@@ -287,7 +289,8 @@ public class MappingRule {
             }
         }
         if (!featureType.getGeometryDescriptor().getType().getBinding().equals(Point.class)) {
-            featureBuilder.set("nodes", feature.getProperty("nodes").getValue());
+            long[] nodeIds = (long[]) feature.getProperty("nodes").getValue();
+            featureBuilder.set("nodes", nodeIds);
         }
         return Optional.of((Feature) featureBuilder.buildFeature(id));
 

--- a/src/osm/src/test/java/org/locationtech/geogig/osm/cli/commands/OSMMapTest.java
+++ b/src/osm/src/test/java/org/locationtech/geogig/osm/cli/commands/OSMMapTest.java
@@ -11,6 +11,7 @@ package org.locationtech.geogig.osm.cli.commands;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 
 import org.junit.Assert;
@@ -88,7 +89,10 @@ public class OSMMapTest extends Assert {
         ImmutableList<Optional<Object>> values = revFeature.get().getValues();
         String wkt = "LINESTRING (7.1923367 50.7395887, 7.1923127 50.7396946, 7.1923444 50.7397419, 7.1924199 50.7397781)";
         assertEquals(wkt, values.get(2).get().toString());
-        assertEquals("345117525;345117526;1300224327;345117527", values.get(3).get());
+
+        long[] nodes = new long[] { 345117525, 345117526, 1300224327, 345117527 };
+        long[] actual = (long[]) values.get(3).get();
+        assertTrue(Arrays.equals(nodes, actual));
         assertEquals("yes", values.get(1).get());
         // check that a feature was correctly ignored
         revFeature = geogig.command(RevObjectParse.class).setRefSpec("HEAD:onewaystreets/31347480")

--- a/src/osm/src/test/java/org/locationtech/geogig/osm/cli/commands/OSMUnmapTest.java
+++ b/src/osm/src/test/java/org/locationtech/geogig/osm/cli/commands/OSMUnmapTest.java
@@ -10,6 +10,7 @@
 package org.locationtech.geogig.osm.cli.commands;
 
 import java.io.File;
+import java.util.Map;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -26,6 +27,7 @@ import org.locationtech.geogig.cli.Console;
 import org.locationtech.geogig.cli.GeogigCLI;
 import org.locationtech.geogig.cli.test.functional.general.CLITestContextBuilder;
 import org.locationtech.geogig.osm.internal.OSMImportOp;
+import org.locationtech.geogig.test.integration.RepositoryTestCase;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -81,9 +83,12 @@ public class OSMUnmapTest extends Assert {
         assertTrue(unmapped.isPresent());
         ImmutableList<Optional<Object>> values = unmapped.get().getValues();
         assertEquals("POINT (7.1959361 50.739397)", values.get(6).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:Gielgen|public_transport:platform",
-                values.get(3).get().toString());
+        Map<String, String> expected = RepositoryTestCase.asMap("VRS:gemeinde", "BONN",
+                "VRS:ortsteil", "Hoholz", "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop",
+                "name", "Gielgen", "public_transport", "platform");
+        @SuppressWarnings("unchecked")
+        Map<String, String> actual = (Map<String, String>) values.get(3).get();
+        assertEquals(expected, actual);
         geogig.close();
     }
 

--- a/src/osm/src/test/java/org/locationtech/geogig/osm/internal/OSMHookTest.java
+++ b/src/osm/src/test/java/org/locationtech/geogig/osm/internal/OSMHookTest.java
@@ -115,9 +115,11 @@ public class OSMHookTest extends RepositoryTestCase {
         assertTrue(unmapped.isPresent());
         values = unmapped.get().getValues();
         assertEquals("POINT (0 1)", values.get(6).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:newname|public_transport:platform",
-                values.get(3).get().toString());
+
+        Map<String, String> expected = asMap("VRS:gemeinde", "BONN", "VRS:ortsteil", "Hoholz",
+                "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop", "name", "newname",
+                "public_transport", "platform");
+        assertEquals(expected, values.get(3).get());
         // check that unchanged nodes keep their attributes
         Optional<RevFeature> unchanged = geogig.command(RevObjectParse.class)
                 .setRefSpec("WORK_HEAD:node/1633594723").call(RevFeature.class);

--- a/src/osm/src/test/java/org/locationtech/geogig/osm/internal/OSMUnmapOpTest.java
+++ b/src/osm/src/test/java/org/locationtech/geogig/osm/internal/OSMUnmapOpTest.java
@@ -33,6 +33,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.vividsolutions.jts.geom.Coordinate;
@@ -121,15 +122,16 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
                 "LINESTRING (7.1960069 50.7399033, 7.195868 50.7399081, 7.1950788 50.739912, 7.1949262 50.7399053, "
                         + "7.1942463 50.7398686, 7.1935778 50.7398262, 7.1931011 50.7398018, 7.1929987 50.7398009, 7.1925978 50.7397889, "
                         + "7.1924199 50.7397781, 0 1)", values.get(7).get().toString());
-        assertEquals("highway:residential|lit:no|name:newname|oneway:yes", values.get(3).get()
-                .toString());
+
+        Map<String, String> expected = ImmutableMap.of("highway", "residential", "lit", "no",
+                "name", "newname", "oneway", "yes");
+        assertEquals(expected, values.get(3).get());
 
         // now we get the 'nodes' field in the unmapped feature and check take the id of its last
         // node, which refers to the node that we have added to the geometry
         int WAY_NODES_FIELD = 6;
-        String nodes = values.get(WAY_NODES_FIELD).get().toString();
-        String[] nodeIds = nodes.split(";");
-        String newNodeId = nodeIds[nodeIds.length - 1];
+        long[] nodes = (long[]) values.get(WAY_NODES_FIELD).get();
+        long newNodeId = nodes[nodes.length - 1];
         // and we check that the node has been added to the 'node' tree and has the right
         // coordinates.
         Optional<RevFeature> newNode = geogig.command(RevObjectParse.class)
@@ -263,9 +265,12 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
         assertTrue(unmapped.isPresent());
         values = unmapped.get().getValues();
         assertEquals("POINT (0 1)", values.get(6).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:newname|public_transport:platform",
-                values.get(3).get().toString());
+
+        Map<String, String> expected = asMap("VRS:gemeinde", "BONN", "VRS:ortsteil", "Hoholz",
+                "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop", "name", "newname",
+                "public_transport", "platform");
+
+        assertEquals(expected, values.get(3).get());
         // check that unchanged nodes keep their attributes
         Optional<RevFeature> unchanged = geogig.command(RevObjectParse.class)
                 .setRefSpec("WORK_HEAD:node/1633594723").call(RevFeature.class);
@@ -400,9 +405,11 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
         assertTrue(unmapped.isPresent());
         values = unmapped.get().getValues();
         assertEquals("POINT (0 1)", values.get(6).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:newname|public_transport:platform",
-                values.get(3).get().toString());
+
+        Map<String, String> expected = asMap("VRS:gemeinde", "BONN", "VRS:ortsteil", "Hoholz",
+                "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop", "name", "newname",
+                "public_transport", "platform");
+        assertEquals(expected, values.get(3).get());
         // check that unchanged nodes keep their attributes
         Optional<RevFeature> unchanged = geogig.command(RevObjectParse.class)
                 .setRefSpec("WORK_HEAD:node/1633594723").call(RevFeature.class);
@@ -456,8 +463,12 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
         fb.set("geom", gf.createPoint(new Coordinate(0, 1)));
         fb.set("name_alias", "newname");
         fb.set("id", 507464799l);
-        fb.set("tags",
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:Gielgen|public_transport:platform");
+
+        Map<String, String> tagsMap = asMap("VRS:gemeinde", "BONN", "VRS:ortsteil", "Hoholz",
+                "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop", "name", "newname",
+                "public_transport", "platform");
+        fb.set("tags", tagsMap);
+
         fb.set("timestamp", 1355097351000l);
         SimpleFeature newFeature = fb.buildFeature("507464799");
         geogig.getRepository().workingTree().insert("busstops", newFeature);
@@ -471,9 +482,7 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
         assertEquals(507464799l, ((Long) values.get(0).get()).longValue());
         assertEquals("newname", values.get(3).get().toString());
         assertEquals("1355097351000", values.get(2).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:Gielgen|public_transport:platform",
-                values.get(1).get().toString());
+        assertEquals(tagsMap, values.get(1).get());
 
         // unmap
         geogig.command(OSMUnmapOp.class).setPath("busstops").call();
@@ -488,9 +497,11 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
         assertTrue(unmapped.isPresent());
         values = unmapped.get().getValues();
         assertEquals("POINT (0 1)", values.get(6).get().toString());
-        assertEquals(
-                "VRS:gemeinde:BONN|VRS:ortsteil:Hoholz|VRS:ref:68566|bus:yes|highway:bus_stop|name:newname|public_transport:platform",
-                values.get(3).get().toString());
+
+        Map<String, String> expected = asMap("VRS:gemeinde", "BONN", "VRS:ortsteil", "Hoholz",
+                "VRS:ref", "68566", "bus", "yes", "highway", "bus_stop", "name", "newname",
+                "public_transport", "platform");
+        assertEquals(expected, values.get(3).get());
         // check that unchanged nodes keep their attributes
         Optional<RevFeature> unchanged = geogig.command(RevObjectParse.class)
                 .setRefSpec("WORK_HEAD:node/1633594723").call(RevFeature.class);
@@ -580,15 +591,14 @@ public class OSMUnmapOpTest extends RepositoryTestCase {
                 "LINESTRING (7.1960069 50.7399033, 7.195868 50.7399081, 7.1950788 50.739912, 7.1949262 50.7399053, "
                         + "7.1942463 50.7398686, 7.1935778 50.7398262, 7.1931011 50.7398018, 7.1929987 50.7398009, 7.1925978 50.7397889, "
                         + "7.1924199 50.7397781, 0 1)", values.get(7).get().toString());
-        assertEquals("highway:residential|lit:no|name:newname|oneway:yes", values.get(3).get()
-                .toString());
+        assertEquals(ImmutableMap.of("highway", "residential", "lit", "no", "name", "newname",
+                "oneway", "yes"), values.get(3).get());
 
         // now we get the 'nodes' field in the unmapped feature and check the id of its last
         // node, which refers to the node that we have added to the geometry
         int WAY_NODES_FIELD = 6;
-        String nodes = values.get(WAY_NODES_FIELD).get().toString();
-        String[] nodeIds = nodes.split(";");
-        String newNodeId = nodeIds[nodeIds.length - 1];
+        long[] nodes = (long[]) values.get(WAY_NODES_FIELD).get();
+        long newNodeId = nodes[nodes.length - 1];
         // and we check that the node has been added to the 'node' tree and has the right
         // coordinates.
         Optional<RevFeature> newNode = geogig.command(RevObjectParse.class)


### PR DESCRIPTION
Instead of storing way.nodes and way.tags as strings, store them
as long[] and Map<String, String> instead.

The osm export commands functionality of exporting nodes and tags as Strings
is preserved, given the target GeoTools FeatureStores do not support long[]
and Map properties natively.

Conversion to and from String is delegated to the GeoTools Converters
framework (hence working transparently) by means of the
PrimitiveArrayToStringConverterFactory and MapToStringConverterFactory
converter factories.

All tests pass, including the ones that use mappings, though were adapted
to expect long[] or Map<String, String> accordingly.

The patch already provides a measurable improvement both in time and space.
An osm import takes a bit less time, and a rather small one like importing
the latest antarctica pbf provides for a 100MB reduction in the JE db size
(i.e. results in a 1.6 instead of 1.7 GB db). Yet the space savings are
expected to be bigger once the V3 serialization format is ready, as it uses
delta compression and variable lenght integer encoding for ints and longs.