### PR TITLE
Reverting "Random" repository directory name.

### DIFF
--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
@@ -163,17 +163,8 @@ public abstract class RepositoryTestCase extends Assert {
         doSetUp();
     }
 
-    /**
-     * In rare occasions a test fail for unknown reasons and it's definitely related to the
-     * temporary folder somehow resolving to the same directory in two different tests, which I
-     * thought was impossible and the whole point of {@link TemporaryFolder}. So although I didn't
-     * get to the root cause of the issue, appending a randon number to the repository directory
-     * name makes the trick for the time being.
-     */
-    private static final Random RANDOM = new Random();
-
     protected final void doSetUp() throws IOException, SchemaException, ParseException, Exception {
-        repositoryDirectory = repositoryTempFolder.newFolder("repo" + RANDOM.nextInt());
+        repositoryDirectory = repositoryTempFolder.newFolder("repo");
 
         injector = createInjector();
 

--- a/src/geotools/src/test/java/org/locationtech/geogig/geotools/data/GeoGigDataStoreFactoryTest.java
+++ b/src/geotools/src/test/java/org/locationtech/geogig/geotools/data/GeoGigDataStoreFactoryTest.java
@@ -30,12 +30,9 @@ public class GeoGigDataStoreFactoryTest extends RepositoryTestCase {
 
     private GeoGigDataStoreFactory factory;
 
-    private File repoDirectory;
-
     @Override
     protected void setUpInternal() throws Exception {
         factory = new GeoGigDataStoreFactory();
-        repoDirectory = super.repositoryDirectory;
     }
 
     @Test
@@ -55,7 +52,7 @@ public class GeoGigDataStoreFactoryTest extends RepositoryTestCase {
         dataStore = DataStoreFinder.getDataStore(params);
         assertNull(dataStore);
 
-        params = ImmutableMap.of(REPOSITORY.key, repoDirectory);
+        params = ImmutableMap.of(REPOSITORY.key, repositoryDirectory);
         dataStore = DataStoreFinder.getDataStore(params);
         assertNotNull(dataStore);
         assertTrue(dataStore instanceof GeoGigDataStore);
@@ -63,24 +60,19 @@ public class GeoGigDataStoreFactoryTest extends RepositoryTestCase {
 
     @Test
     public void testCanProcess() {
-        final File workingDir = repoDirectory;
-
         Map<String, Serializable> params = ImmutableMap.of();
         assertFalse(factory.canProcess(params));
         params = ImmutableMap.of(REPOSITORY.key,
-                (Serializable) (workingDir.getName() + "/testCanProcess"));
+                (Serializable) (repositoryDirectory.getName() + "/testCanProcess"));
         assertFalse(factory.canProcess(params));
 
-        params = ImmutableMap.of(REPOSITORY.key, (Serializable) workingDir.getAbsolutePath());
+        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repositoryDirectory.getPath());
         assertTrue(factory.canProcess(params));
 
-        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repoDirectory.getPath());
+        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repositoryDirectory.getAbsolutePath());
         assertTrue(factory.canProcess(params));
 
-        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repoDirectory.getAbsolutePath());
-        assertTrue(factory.canProcess(params));
-
-        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repoDirectory);
+        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repositoryDirectory);
         assertTrue(factory.canProcess(params));
     }
 
@@ -117,7 +109,7 @@ public class GeoGigDataStoreFactoryTest extends RepositoryTestCase {
     public void testCreateDataStore() throws IOException {
         Map<String, Serializable> params;
 
-        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repoDirectory.getAbsolutePath());
+        params = ImmutableMap.of(REPOSITORY.key, (Serializable) repositoryDirectory.getAbsolutePath());
 
         GeoGigDataStore store = factory.createDataStore(params);
         assertNotNull(store);

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -83,7 +83,7 @@
     <repository>
       <id>boundless</id>
       <name>Boundless Maven Repository</name>
-      <url>https://boundless.artifactoryonline.com/boundless/release/</url>
+      <url>https://boundless.artifactoryonline.com/boundless/main/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
Commit b7a0b615483c8e55669b9bac8a02143a33930ac5 did a few other things
to fix some tests due to repository directories being "shared" across
multiple tests. I'm still not sure what the issue was, but this random
string appended to the repository in the test makes the repo directory
name "unpredictable" for other tests using the RepositoryTestCase.

I discovered this in trying to build the GeoGig GeoServer Extension. One
of the tests in that project was failing because it was trying to verify
that the repository still existed after the GeoGig store is shutdown. But
it fails becuase it expects the repo directory to be named "repo", not
"repo-\<random number\>". Since the directory isn't exposed in the test
class here, external tests using it can't reliably predict what the
repo directory name will be and can't verify it exists by name.

I'm planning on submitting a fix on geoserver-exts for the GeoGig plugin,
but it will obviously depend on this fix getting merged in. The line in
particular is here:
https://github.com/boundlessgeo/geoserver-exts/blob/master/geogig/src/test/java/org/geogig/geoserver/wfs/WFSIntegrationTest.java#L380

I'll update this PR with more details once I have the PR for geoserver-exts created.