### PR TITLE
Updating Boundless dependency repository from "release" to "main".

### DIFF
--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -83,7 +83,7 @@
     <repository>
       <id>boundless</id>
       <name>Boundless Maven Repository</name>
-      <url>https://boundless.artifactoryonline.com/boundless/release/</url>
+      <url>https://boundless.artifactoryonline.com/boundless/main/</url>
       <snapshots>
         <enabled>true</enabled>
       </snapshots>


### PR DESCRIPTION
This should address the issue here:
https://locationtech.org/mhonarc/lists/geogig-dev/msg00191.html