### PR TITLE
Optimize RevTree structure to avoid an overwhelming exponential growth

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/api/RevTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/RevTree.java
@@ -12,7 +12,6 @@ package org.locationtech.geogig.api;
 import java.util.Iterator;
 
 import org.locationtech.geogig.storage.NodeStorageOrder;
-import org.locationtech.geogig.storage.ObjectDatabase;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -24,23 +23,6 @@ import com.google.common.collect.ImmutableSortedMap;
  * @see Node
  */
 public interface RevTree extends RevObject {
-
-    /**
-     * Maximum number of buckets a tree is split into when its size exceeds the
-     * {@link #NORMALIZED_SIZE_LIMIT}
-     */
-    public static final int MAX_BUCKETS = 32;
-
-    /**
-     * The canonical max size of a tree, hard limit, can't be changed or would affect the hash of
-     * trees
-     * 
-     * @todo evaluate what a good compromise would be re memory usage/speed. So far 512 seems like a
-     *       good compromise with an iteration throughput of 300K/s and random lookup of 50K/s on an
-     *       Asus Zenbook UX31A. A value of 256 shields significantly lower throughput and a higher
-     *       one (like 4096) no significant improvement
-     */
-    public static final int NORMALIZED_SIZE_LIMIT = 512;
 
     public static final RevTree EMPTY = RevTreeBuilder.empty();
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/RevTreeBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/RevTreeBuilder.java
@@ -12,7 +12,6 @@ package org.locationtech.geogig.api;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
-import static org.locationtech.geogig.api.RevTree.NORMALIZED_SIZE_LIMIT;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -112,8 +111,9 @@ public class RevTreeBuilder {
 
     /**
      * Copy constructor with tree depth
-     * @param obStore {@link org.locationtech.geogig.storage.ObjectStore ObjectStore} with which
-     * to initialize this RevTreeBuilder.
+     * 
+     * @param obStore {@link org.locationtech.geogig.storage.ObjectStore ObjectStore} with which to
+     *        initialize this RevTreeBuilder.
      * @param copy {@link org.locationtech.geogig.api.RevTree RevTree} to copy.
      */
     public RevTreeBuilder(ObjectStore obStore, @Nullable final RevTree copy) {
@@ -123,8 +123,9 @@ public class RevTreeBuilder {
     /**
      * Copy constructor
      */
-    private RevTreeBuilder(final ObjectStore obSotre, @Nullable final RevTree copy, final int depth,
-            final Map<ObjectId, RevTree> pendingWritesCache, final int normalizationThreshold) {
+    private RevTreeBuilder(final ObjectStore obSotre, @Nullable final RevTree copy,
+            final int depth, final Map<ObjectId, RevTree> pendingWritesCache,
+            final int normalizationThreshold) {
 
         checkNotNull(obSotre);
         checkNotNull(pendingWritesCache);
@@ -246,14 +247,15 @@ public class RevTreeBuilder {
         RevTree tree;
 
         final int numPendingChanges = numPendingChanges();
-        if (bucketTreesByBucket.isEmpty() && numPendingChanges <= NORMALIZED_SIZE_LIMIT) {
+        if (bucketTreesByBucket.isEmpty()
+                && numPendingChanges <= NodePathStorageOrder.normalizedSizeLimit(this.depth)) {
             tree = normalizeToChildren();
         } else {
             tree = normalizeToBuckets();
             checkState(featureChanges.isEmpty());
             checkState(treeChanges.isEmpty());
 
-            if (tree.size() <= NORMALIZED_SIZE_LIMIT) {
+            if (tree.size() <= NodePathStorageOrder.normalizedSizeLimit(this.depth)) {
                 this.bucketTreesByBucket.clear();
                 if (tree.buckets().isPresent()) {
                     tree = moveBucketsToChildren(tree);
@@ -456,7 +458,7 @@ public class RevTreeBuilder {
 
         // compute final size and number of trees out of the aggregate deltas
         long accSize = sizeDelta;
-        if (initialSize > RevTree.NORMALIZED_SIZE_LIMIT) {
+        if (initialSize > NodePathStorageOrder.normalizedSizeLimit(this.depth)) {
             accSize += initialSize;
         }
         int accChildTreeCount = this.initialNumTrees + treesDelta;

--- a/src/core/src/main/java/org/locationtech/geogig/api/RevTreeImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/RevTreeImpl.java
@@ -13,6 +13,7 @@ import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.NodeStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 
@@ -164,7 +165,7 @@ public abstract class RevTreeImpl extends AbstractRevObject implements RevTree {
 
         Preconditions.checkNotNull(id);
         Preconditions.checkNotNull(bucketTrees);
-        Preconditions.checkArgument(bucketTrees.size() <= RevTree.MAX_BUCKETS);
+        Preconditions.checkArgument(bucketTrees.size() <= NodePathStorageOrder.maxBucketsForLevel(0));
 
         ImmutableSortedMap<Integer, Bucket> innerTrees = ImmutableSortedMap.copyOf(bucketTrees);
 

--- a/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalk.java
+++ b/src/core/src/main/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalk.java
@@ -45,6 +45,7 @@ import org.locationtech.geogig.api.RevObject;
 import org.locationtech.geogig.api.RevObject.TYPE;
 import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.repository.SpatialOps;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.NodeStorageOrder;
 import org.locationtech.geogig.storage.ObjectStore;
 
@@ -594,7 +595,7 @@ public class PreOrderDiffWalk {
 
         /**
          * Compares a bucket tree (i.e. its size is greater than
-         * {@link RevTree#NORMALIZED_SIZE_LIMIT} and hence has been split into buckets) at the left
+         * {@link NodePathStorageOrder#NORMALIZED_SIZE_LIMIT} and hence has been split into buckets) at the left
          * side of the comparison, and a the {@link RevTree#children() children} nodes of a leaf
          * tree at the right side of the comparison.
          * <p>
@@ -683,7 +684,7 @@ public class PreOrderDiffWalk {
 
         /**
          * Compares a bucket tree (i.e. its size is greater than
-         * {@link RevTree#NORMALIZED_SIZE_LIMIT} and hence has been split into buckets) at the right
+         * {@link NodePathStorageOrder#NORMALIZED_SIZE_LIMIT} and hence has been split into buckets) at the right
          * side of the comparison, and a the {@link RevTree#children() children} nodes of a leaf
          * tree at the left side of the comparison.
          * <p>

--- a/src/core/src/main/java/org/locationtech/geogig/storage/NodePathStorageOrder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/NodePathStorageOrder.java
@@ -1,11 +1,11 @@
-/* Copyright (c) 2012-2014 Boundless and others.
+/* Copyright (c) 2012-2016 Boundless and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/org/documents/edl-v10.html
  *
  * Contributors:
- * Victor Olaya (Boundless) - initial implementation
+ * Gabriel Roldan (Boundless) - initial implementation
  */
 package org.locationtech.geogig.storage;
 
@@ -20,12 +20,13 @@ import com.google.common.collect.Ordering;
 import com.google.common.primitives.UnsignedLong;
 
 /**
- * Implements storage order of {@link Node} based on the non cryptographic 64-bit <a
+ * Defines storage order of {@link RevTree tree} {@link Node nodes} based on the non cryptographic
+ * 64-bit <a
  * href="http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function">FNV-1a</a>
  * variation of the "Fowler/Noll/Vo" hash algorithm.
  * <p>
  * This class mandates in which order {@link Node nodes} are stored inside {@link RevTree trees},
- * hence defining the prescribed order in which tree elements are traversed, regardless of in how
+ * hence defining the canonical order in which tree elements are traversed, regardless of in how
  * many subtrees a given tree is split into.
  * <p>
  * The resulting structure where a given node (identified by its name) always falls on the same
@@ -57,6 +58,43 @@ import com.google.common.primitives.UnsignedLong;
  * href="http://www.isthe.com/chongo/tech/comp/fnv/index.html#FNV-param">here</a> when speed is
  * needed in contrast to cryptographic security.
  * 
+ * <p>
+ * The table bellow shows the {@link RevTree} structure and capacity in its canonical form as
+ * defined by this class, for the first eight levels of depth, after which {@code buckets per node}
+ * is always {@code 2} and {@code #features per leaf tree} always {@code 256}.
+ * <p>
+ * This structure is fixes and intends to balance out the growth of the trees as feature nodes are
+ * added to provide for a good maximum capacity without too many levels of nesting, nor too few at
+ * the cost of an exponential growth on the number of internal tree nodes.
+ * 
+ * <pre>
+ * <code>
+ * Depth #buckets    Leaf trees     Total # of     #features    Max #features
+ *       per node                   tree objects   per leaf 
+ *                                                 tree
+ * --------------------------------------------------------------------------
+ * 0       32              32               33     512                 16,384
+ * 1       32           1,024            1,056     512                524,288
+ * 2       32          32,768           33,792     512             16,777,216
+ * 3        8         262,144          294,912     256             67,108,864
+ * 4        8       2,097,152        2,359,296     256            536,870,912
+ * 5        4       8,388,608       10,485,760     256          2,147,483,648
+ * 6        4      33,554,432       41,943,040     256          8,589,934,592
+ * 7        2      67,108,864      100,663,296     256         17,179,869,184
+ * </code>
+ * </pre>
+ * 
+ * The {@code "#buckets per node"} column (which matches the {@link #maxBucketsForLevel} method)
+ * represents in how many subtrees a leaf tree that reached it's maximum capacity is split into at
+ * every depth index (where the leaf tree maximum capacity is given by the
+ * {@code "#features per leaf tree"} column, matching the method {@link #normalizedSizeLimit}).
+ * <p>
+ * The {@code "Leaf trees"} column represents how many leaf trees result from splitting the tree at
+ * that level of nesting.
+ * <p>
+ * The {@code "Max #features"} column shows what's the maximum number of feature nodes a tree split
+ * at that level of nesting can contain.
+ * 
  * @since 0.6
  */
 public final class NodePathStorageOrder extends Ordering<String> implements Serializable {
@@ -71,29 +109,118 @@ public final class NodePathStorageOrder extends Ordering<String> implements Seri
     }
 
     /**
+     * Returns the canonical max size of a leaf tree for the given depth index; hard limit, can't be
+     * changed or would affect the hash of trees.
+     * <p>
+     * The combination of {@link #maxBucketsForLevel(int) maxBucketsForLevel(int depthIndex)} and
+     * {@code normalizedSizeLimit(int depthIndex)} defines the maximum capacity for a tree of a
+     * given depth.
+     * 
+     * @param depthIndex the depth index (starting at zero) of a leaf for which to return the
+     *        allowed maximum number of feature nodes before needing to split it into the number of
+     *        buckets given by {@link #maxBucketsForLevel} for the same depth.
+     * 
+     * @return {@code 512} for depth indexes {@code 0} to {@code 2}, and {@code 256} for depth
+     *         indexes bigger than {@code 2}
+     * @since 1.0
+     */
+    public static int normalizedSizeLimit(final int depthIndex) {
+        Preconditions.checkArgument(depthIndex > -1,
+                "depthIndex must be a positive integer or zero");
+        switch (depthIndex) {
+        case 0:
+        case 1:
+        case 2:
+            return 512;
+        default:
+            return 256;
+        }
+    }
+
+    /**
+     * Returns a positive integer defining in how many <i>bucket trees</i> a <i>leaf tree</i> that
+     * has reached its {@link #getNormalizedSizeLimit maximum capacity} is split into, at the given
+     * depth index.
+     * <p>
+     * E.g., if a feature tree is to be split into buckets, then this method must be called with
+     * {@code depthIndex == 0}; a bucket tree that's a direct child of a feature tree with
+     * {@code depthIndex == 1}, and so forth.
+     * <p>
+     * The combination of {@code maxBucketsForLevel(int depthIndex)} and
+     * {@link #normalizedSizeLimit(int) normalizedSizeLimit(int depthIndex)} defines the maximum
+     * capacity of a tree of a given depth.
+     * 
+     * @param depthIndex the depth index (starting at zero) of a leaf tree that needs to be split
+     *        into buckets.
+     * @return {@code 32} for depth indexes {@code 0} to {@code 2}; {@code 8} for depth indexes
+     *         {@code 3} and {@code 4}; {@code 4} for depth indexes {@code 5} and {@code 6}; and
+     *         {@code 2} for any depth index bigger than 6.
+     * @since 1.0
+     */
+    public static int maxBucketsForLevel(final int depthIndex) {
+        Preconditions.checkArgument(depthIndex > -1,
+                "depthIndex must be a positive integer or zero");
+        switch (depthIndex) {
+        case 0:
+        case 1:
+        case 2:
+            return 32;
+        case 3:
+        case 4:
+            return 8;
+        case 5:
+        case 6:
+            return 4;
+        default:
+            return 2;
+        }
+    }
+
+    /**
      * Computes the bucket index that corresponds to the given node name at the given depth.
      * 
-     * @return and Integer between zero and {@link RevTree#MAX_BUCKETS} minus one
+     * @return and Integer between zero and {@link #maxBucketsForLevel
+     *         maxBucketsForLevel(depthIndex)} minus one
      */
-    public Integer bucket(final String nodeName, final int depth) {
+    public Integer bucket(final String nodeName, final int depthIndex) {
 
-        final int byteN = hashOrder.byteN(nodeName, depth);
+        final int byteN = hashOrder.byteN(nodeName, depthIndex);
         Preconditions.checkState(byteN >= 0);
         Preconditions.checkState(byteN < 256);
 
-        final int maxBuckets = RevTree.MAX_BUCKETS;
+        final int maxBuckets = NodePathStorageOrder.maxBucketsForLevel(depthIndex);
 
         final int bucket = (byteN * maxBuckets) / 256;
         return Integer.valueOf(bucket);
     }
 
-    public UnsignedLong hashCodeLong(String name) {
-        UnsignedLong fnv = FNV1a64bitHash.fnv(name);
+    /**
+     * Computes the <a
+     * href="http://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function">FNV-1a</a>
+     * hash code for the given feature identifier, as an unsigned long.
+     * 
+     * @param featureIdentifier
+     * @return an unsigned long representing the FNV-1a hash code for the given feature identifier.
+     */
+    public UnsignedLong hashCodeLong(String featureIdentifier) {
+        UnsignedLong fnv = FNV1a64bitHash.fnv(featureIdentifier);
         return fnv;
     }
 
     /**
      * The FNV-1a hash function used as {@link Node} storage order.
+     * <p>
+     * Should match the following formula:
+     * 
+     * <pre>
+     * <code>
+     * hash = FNV_offset_basis
+     * for each octet_of_data to be hashed
+     *      hash = hash × FNV_prime
+     *      hash = hash XOR octet_of_data
+     * return hash
+     * </code>
+     * </pre>
      */
     private static class FNV1a64bitHash implements Serializable {
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/NodeStorageOrder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/NodeStorageOrder.java
@@ -1,11 +1,11 @@
-/* Copyright (c) 2012-2013 Boundless and others.
+/* Copyright (c) 2012-2014 Boundless and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
  * https://www.eclipse.org/org/documents/edl-v10.html
  *
  * Contributors:
- * Victor Olaya (Boundless) - initial implementation
+ * Gabriel Roldan (Boundless) - initial implementation
  */
 package org.locationtech.geogig.storage;
 

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/CatObjectTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/CatObjectTest.java
@@ -18,6 +18,7 @@ import org.locationtech.geogig.api.RevObject.TYPE;
 import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.RevTreeBuilder;
 import org.locationtech.geogig.storage.FieldType;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
 
@@ -38,7 +39,7 @@ public class CatObjectTest extends RepositoryTestCase {
 
     @Test
     public void TestCatTreeWithoutBucketsObject() throws Exception {
-        int numChildren = RevTree.NORMALIZED_SIZE_LIMIT / 2;
+        int numChildren = NodePathStorageOrder.normalizedSizeLimit(0) / 2;
         RevTree tree = createTree(numChildren);
         CharSequence desc = geogig.command(CatObject.class).setObject(Suppliers.ofInstance(tree))
                 .call();
@@ -53,7 +54,7 @@ public class CatObjectTest extends RepositoryTestCase {
 
     @Test
     public void TestCatTreeWithBucketsObject() throws Exception {
-        int numChildren = RevTree.NORMALIZED_SIZE_LIMIT * 2;
+        int numChildren = NodePathStorageOrder.normalizedSizeLimit(0) * 2;
         RevTree tree = createTree(numChildren);
         CharSequence desc = geogig.command(CatObject.class).setObject(Suppliers.ofInstance(tree))
                 .call();

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/DiffBoundsTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/DiffBoundsTest.java
@@ -20,11 +20,11 @@ import org.geotools.referencing.CRS;
 import org.junit.Test;
 import org.locationtech.geogig.api.DefaultProgressListener;
 import org.locationtech.geogig.api.RevCommit;
-import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.plumbing.diff.DiffSummary;
 import org.locationtech.geogig.api.porcelain.AddOp;
 import org.locationtech.geogig.api.porcelain.CommitOp;
 import org.locationtech.geogig.repository.WorkingTree;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
@@ -187,8 +187,8 @@ public class DiffBoundsTest extends RepositoryTestCase {
 
     @Test
     public void testReprojectToTargetBucketTree() throws Exception {
-        final int leftCount = RevTree.NORMALIZED_SIZE_LIMIT * 2;
-        final int rightCount = RevTree.NORMALIZED_SIZE_LIMIT * 3;
+        final int leftCount = NodePathStorageOrder.normalizedSizeLimit(0) * 2;
+        final int rightCount = NodePathStorageOrder.normalizedSizeLimit(0) * 3;
 
         WorkingTree workingTree = geogig.getRepository().workingTree();
         final String typeName = "newpoints";

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/DepthTreeIteratorTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/DepthTreeIteratorTest.java
@@ -9,7 +9,8 @@
  */
 package org.locationtech.geogig.api.plumbing.diff;
 
-import static org.locationtech.geogig.api.plumbing.diff.RevObjectTestSupport.*;
+import static org.locationtech.geogig.api.plumbing.diff.RevObjectTestSupport.createFeaturesTree;
+import static org.locationtech.geogig.api.plumbing.diff.RevObjectTestSupport.createTreesTree;
 import static org.locationtech.geogig.api.plumbing.diff.RevObjectTestSupport.createTreesTreeBuilder;
 import static org.locationtech.geogig.api.plumbing.diff.RevObjectTestSupport.featureNode;
 
@@ -23,6 +24,7 @@ import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.RevTreeBuilder;
 import org.locationtech.geogig.api.plumbing.diff.DepthTreeIterator.Strategy;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.memory.HeapObjectDatabse;
 
@@ -64,7 +66,7 @@ public class DepthTreeIteratorTest extends Assert {
         }
         mixedLeafTree = builder.build();
         source.put(mixedLeafTree);
-        
+
         featuresBucketsTree = createFeaturesTree(source, "feature.", 25000);
     }
 
@@ -78,7 +80,7 @@ public class DepthTreeIteratorTest extends Assert {
 
     @Test
     public void testFeaturesBucketsTree() {
-        int numEntries = 2 * RevTree.NORMALIZED_SIZE_LIMIT;
+        int numEntries = 2 * NodePathStorageOrder.normalizedSizeLimit(0);
         RevTree tree = createFeaturesTree(source, "feature.", numEntries);
         assertEquals(numEntries, list(tree, Strategy.FEATURES_ONLY).size());
 
@@ -103,9 +105,10 @@ public class DepthTreeIteratorTest extends Assert {
         assertEquals(10, list(mixedLeafTree, Strategy.TREES_ONLY).size());
         assertEquals(0, list(featuresBucketsTree, Strategy.TREES_ONLY).size());
 
-        int numSubTrees = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        int featuresPerTree = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree, metadataId);
+        int numSubTrees = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        int featuresPerTree = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree,
+                metadataId);
         for (int i = 0; i < 25000; i++) {
             builder.put(featureNode("f", i));
         }
@@ -124,9 +127,10 @@ public class DepthTreeIteratorTest extends Assert {
         assertEquals(featuresBucketsTree.size(), list(featuresBucketsTree, Strategy.RECURSIVE)
                 .size());
 
-        int numSubTrees = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        int featuresPerTree = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree, metadataId);
+        int numSubTrees = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        int featuresPerTree = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree,
+                metadataId);
         for (int i = 0; i < 25000; i++) {
             builder.put(featureNode("f", i));
         }
@@ -146,9 +150,10 @@ public class DepthTreeIteratorTest extends Assert {
         assertEquals(featuresBucketsTree.size(),
                 list(featuresBucketsTree, Strategy.RECURSIVE_FEATURES_ONLY).size());
 
-        int numSubTrees = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        int featuresPerTree = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree, metadataId);
+        int numSubTrees = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        int featuresPerTree = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree,
+                metadataId);
         for (int i = 0; i < 25000; i++) {
             builder.put(featureNode("f", i));
         }
@@ -167,9 +172,10 @@ public class DepthTreeIteratorTest extends Assert {
                 .size());
         assertEquals(0, list(featuresBucketsTree, Strategy.RECURSIVE_TREES_ONLY).size());
 
-        int numSubTrees = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        int featuresPerTree = RevTree.NORMALIZED_SIZE_LIMIT + 1;
-        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree, metadataId);
+        int numSubTrees = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        int featuresPerTree = NodePathStorageOrder.normalizedSizeLimit(0) + 1;
+        RevTreeBuilder builder = createTreesTreeBuilder(source, numSubTrees, featuresPerTree,
+                metadataId);
         for (int i = 0; i < 25000; i++) {
             builder.put(featureNode("f", i));
         }

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/DiffCountConsumerTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/DiffCountConsumerTest.java
@@ -19,6 +19,7 @@ import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.api.RevObject.TYPE;
 import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.RevTreeBuilder;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.memory.HeapObjectDatabse;
 
@@ -43,7 +44,10 @@ public class DiffCountConsumerTest extends Assert {
 
     private RevTree childrenFeatureTree;
 
-    /** single level tree with 2 * {@link RevTree#NORMALIZED_SIZE_LIMIT} feature references */
+    /**
+     * single level tree with 2 * {@link NodePathStorageOrder#NORMALIZED_SIZE_LIMIT} feature
+     * references
+     */
     private RevTree bucketsFeatureTree;
 
     private RevTree childrenFeatureTypesTree;
@@ -72,7 +76,8 @@ public class DiffCountConsumerTest extends Assert {
         }
 
         {
-            RevTreeBuilder builder = createFeaturesTree("", 2 * RevTree.NORMALIZED_SIZE_LIMIT);
+            RevTreeBuilder builder = createFeaturesTree("",
+                    2 * NodePathStorageOrder.normalizedSizeLimit(0));
             this.bucketsFeatureTree = builder.build();
             assertTrue(bucketsFeatureTree.buckets().isPresent());
             odb.put(bucketsFeatureTree);
@@ -121,7 +126,7 @@ public class DiffCountConsumerTest extends Assert {
         changed = builder.put(
                 Node.create("new", FAKE_FEATURE_ID, ObjectId.NULL, TYPE.FEATURE, null)).build();
         odb.put(changed);
-        
+
         assertEquals(2, count(childrenFeatureTree, changed).featureCount());
         assertEquals(2, count(changed, childrenFeatureTree).featureCount());
 
@@ -140,7 +145,7 @@ public class DiffCountConsumerTest extends Assert {
         createFeatureTypesTree(rootBuilder, "tree1", childTree1);
         RevTree newRoot = rootBuilder.build();
         odb.put(newRoot);
-        
+
         assertEquals(1, count(childrenFeatureTypesTree, newRoot).featureCount());
 
         childTree2.remove("tree2/2");
@@ -162,7 +167,7 @@ public class DiffCountConsumerTest extends Assert {
         RevTreeBuilder builder = new RevTreeBuilder(odb, bucketsFeatureTree);
 
         final int initialSize = (int) bucketsFeatureTree.size();
-        final int added = 1 + 2 * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int added = 1 + 2 * NodePathStorageOrder.normalizedSizeLimit(0);
         for (int i = initialSize; i < (initialSize + added); i++) {
             builder.put(featureRef("", i));
         }
@@ -194,24 +199,24 @@ public class DiffCountConsumerTest extends Assert {
         assertEquals(1, count(bucketsFeatureTree, changed).featureCount());
         assertEquals(1, count(changed, bucketsFeatureTree).featureCount());
 
-        for (int i = 0; i < RevTree.NORMALIZED_SIZE_LIMIT - 1; i++) {
+        for (int i = 0; i < NodePathStorageOrder.normalizedSizeLimit(0) - 1; i++) {
             builder.remove(String.valueOf(i));
         }
         changed = builder.build();
         odb.put(changed);
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT + 1, changed.size());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0) + 1, changed.size());
         assertTrue(changed.buckets().isPresent());
 
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT - 1, count(bucketsFeatureTree, changed)
-                .featureCount());
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT - 1, count(changed, bucketsFeatureTree)
-                .featureCount());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0) - 1,
+                count(bucketsFeatureTree, changed).featureCount());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0) - 1,
+                count(changed, bucketsFeatureTree).featureCount());
 
-        builder.remove(String.valueOf(RevTree.NORMALIZED_SIZE_LIMIT + 1));
+        builder.remove(String.valueOf(NodePathStorageOrder.normalizedSizeLimit(0) + 1));
 
         changed = builder.build();
         odb.put(changed);
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT, changed.size());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0), changed.size());
         assertFalse(changed.buckets().isPresent());
     }
 
@@ -226,7 +231,7 @@ public class DiffCountConsumerTest extends Assert {
                 Node.create("1023", FAKE_FEATURE_ID_CHANGED, ObjectId.NULL, TYPE.FEATURE, null))
                 .build();
         odb.put(changed);
-        
+
         DiffObjectCount count = count(bucketsFeatureTree, changed);
         assertEquals(1, count.featureCount());
         assertEquals(0, count.treeCount());
@@ -257,25 +262,25 @@ public class DiffCountConsumerTest extends Assert {
     public void testBucketChildren() {
         RevTreeBuilder builder = new RevTreeBuilder(odb, bucketsFeatureTree);
         RevTree changed;
-        for (int i = 0; i < RevTree.NORMALIZED_SIZE_LIMIT; i++) {
+        for (int i = 0; i < NodePathStorageOrder.normalizedSizeLimit(0); i++) {
             builder.remove(String.valueOf(i));
         }
         changed = builder.build();
         odb.put(changed);
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT, changed.size());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0), changed.size());
         assertFalse(changed.buckets().isPresent());
 
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT, count(bucketsFeatureTree, changed)
-                .featureCount());
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT, count(changed, bucketsFeatureTree)
-                .featureCount());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0),
+                count(bucketsFeatureTree, changed).featureCount());
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0),
+                count(changed, bucketsFeatureTree).featureCount());
     }
 
     @Test
     public void testBucketChildrenDeeperBuckets() {
 
-        final RevTree deepTree = createFeaturesTree("", 20000 + RevTree.NORMALIZED_SIZE_LIMIT)
-                .build();
+        final RevTree deepTree = createFeaturesTree("",
+                20000 + NodePathStorageOrder.normalizedSizeLimit(0)).build();
         odb.put(deepTree);
         // sanity check
         assertTrue(deepTree.buckets().isPresent());
@@ -288,7 +293,7 @@ public class DiffCountConsumerTest extends Assert {
 
         RevTreeBuilder builder = new RevTreeBuilder(odb, deepTree);
         {
-            final int count = (int) (deepTree.size() - RevTree.NORMALIZED_SIZE_LIMIT);
+            final int count = (int) (deepTree.size() - NodePathStorageOrder.normalizedSizeLimit(0));
             for (int i = 0; i < count; i++) {
                 String path = String.valueOf(i);
                 builder.remove(path);
@@ -296,8 +301,8 @@ public class DiffCountConsumerTest extends Assert {
         }
         RevTree changed = builder.build();
         odb.put(changed);
-        
-        assertEquals(RevTree.NORMALIZED_SIZE_LIMIT, changed.size());
+
+        assertEquals(NodePathStorageOrder.normalizedSizeLimit(0), changed.size());
         // sanity check
         assertTrue(changed.features().isPresent());
         assertFalse(changed.buckets().isPresent());

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/PostOrderDiffWalkTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/PostOrderDiffWalkTest.java
@@ -34,6 +34,7 @@ import org.locationtech.geogig.api.RevObject.TYPE;
 import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.plumbing.diff.PostOrderDiffWalk.Consumer;
 import org.locationtech.geogig.repository.SpatialOps;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.memory.HeapObjectDatabse;
 
@@ -217,10 +218,10 @@ public class PostOrderDiffWalkTest {
 
     @Test
     public void testBucketBucketFlat() {
-        RevTree left = createFeaturesTreeBuilder(leftSource, "f", RevTree.NORMALIZED_SIZE_LIMIT + 1)
-                .build();
+        RevTree left = createFeaturesTreeBuilder(leftSource, "f",
+                NodePathStorageOrder.normalizedSizeLimit(0) + 1).build();
         RevTree right = createFeaturesTreeBuilder(rightSource, "f",
-                RevTree.NORMALIZED_SIZE_LIMIT + 2).build();
+                NodePathStorageOrder.normalizedSizeLimit(0) + 2).build();
         leftSource.put(left);
         rightSource.put(right);
 

--- a/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalkTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/api/plumbing/diff/PreOrderDiffWalkTest.java
@@ -46,6 +46,7 @@ import org.locationtech.geogig.api.RevTreeBuilder;
 import org.locationtech.geogig.api.plumbing.diff.PreOrderDiffWalk.Consumer;
 import org.locationtech.geogig.api.plumbing.diff.PreOrderDiffWalk.MaxFeatureDiffsLimiter;
 import org.locationtech.geogig.repository.SpatialOps;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.memory.HeapObjectDatabse;
 import org.mockito.ArgumentCaptor;
@@ -276,7 +277,8 @@ public class PreOrderDiffWalkTest {
     @Test
     public void testSkipBucket() {
         // two bucket trees of depth 2
-        final int size = RevTree.MAX_BUCKETS * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int size = NodePathStorageOrder.maxBucketsForLevel(0)
+                * NodePathStorageOrder.normalizedSizeLimit(0);
         RevTree left = createFeaturesTree(leftSource, "f", size);
         RevTree right = createFeaturesTree(rightSource, "f", size, 0, true);// all features
                                                                             // changed
@@ -393,8 +395,10 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketBucketFlat() {
-        RevTree left = createFeaturesTree(leftSource, "f", RevTree.NORMALIZED_SIZE_LIMIT + 1);
-        RevTree right = createFeaturesTree(rightSource, "f", RevTree.NORMALIZED_SIZE_LIMIT + 2);
+        RevTree left = createFeaturesTree(leftSource, "f",
+                NodePathStorageOrder.normalizedSizeLimit(0) + 1);
+        RevTree right = createFeaturesTree(rightSource, "f",
+                NodePathStorageOrder.normalizedSizeLimit(0) + 2);
 
         PreOrderDiffWalk visitor = newVisitor(left, right);
 
@@ -417,10 +421,16 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketBucketFlatMoreDepth() {
-        RevTree left = createFeaturesTree(leftSource, "f", RevTree.MAX_BUCKETS
-                * RevTree.NORMALIZED_SIZE_LIMIT);
-        RevTree right = createFeaturesTree(rightSource, "f", RevTree.MAX_BUCKETS
-                * RevTree.NORMALIZED_SIZE_LIMIT + 1);
+        RevTree left = createFeaturesTree(
+                leftSource,
+                "f",
+                NodePathStorageOrder.maxBucketsForLevel(0)
+                        * NodePathStorageOrder.normalizedSizeLimit(0));
+        RevTree right = createFeaturesTree(
+                rightSource,
+                "f",
+                NodePathStorageOrder.maxBucketsForLevel(0)
+                        * NodePathStorageOrder.normalizedSizeLimit(0) + 1);
 
         PreOrderDiffWalk visitor = newVisitor(left, right);
 
@@ -450,7 +460,7 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketLeafSimple() {
-        final int leftsize = 1 + RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = 1 + NodePathStorageOrder.normalizedSizeLimit(0);
         RevTree left = createFeaturesTree(leftSource, "f", leftsize);
         RevTree right = createFeaturesTree(rightSource, "f", 1);
 
@@ -483,7 +493,7 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testLeafBucketSimple() {
-        final int rightsize = 1 + RevTree.NORMALIZED_SIZE_LIMIT;
+        final int rightsize = 1 + NodePathStorageOrder.normalizedSizeLimit(0);
         RevTree left = createFeaturesTree(leftSource, "f", 1);
         RevTree right = createFeaturesTree(rightSource, "f", rightsize);
 
@@ -516,8 +526,8 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketLeafOneLevelDepth() {
-        final int leftsize = 2 * RevTree.NORMALIZED_SIZE_LIMIT;
-        final int rightsize = RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = 2 * NodePathStorageOrder.normalizedSizeLimit(0);
+        final int rightsize = NodePathStorageOrder.normalizedSizeLimit(0);
         final int overlapCount = 100;
 
         RevTree left = createFeaturesTree(leftSource, "f", leftsize);
@@ -527,12 +537,13 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketLeafTwoLevelsDepth() {
-        final int leftsize = RevTree.MAX_BUCKETS * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = NodePathStorageOrder.maxBucketsForLevel(0)
+                * NodePathStorageOrder.normalizedSizeLimit(0);
 
         RevTree left = createFeaturesTree(leftSource, "f", leftsize);
         assertDepth(left, leftSource, 2);
 
-        final int rightsize = RevTree.NORMALIZED_SIZE_LIMIT;
+        final int rightsize = NodePathStorageOrder.normalizedSizeLimit(0);
         final int overlapCount = 100;
         testBucketLeafDeeper(left, rightsize, overlapCount);
     }
@@ -540,14 +551,16 @@ public class PreOrderDiffWalkTest {
     // goes OOM with the deafult test heap size, but can be manually run with a bigger one
     @Test
     public void testBucketLeafThreeLevelsDepth() {
-        final int leftsize = RevTree.MAX_BUCKETS * RevTree.MAX_BUCKETS
-                * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = NodePathStorageOrder.maxBucketsForLevel(0)
+                * NodePathStorageOrder.maxBucketsForLevel(0)
+                * NodePathStorageOrder.normalizedSizeLimit(0);
 
         RevTree left = createLargeFeaturesTree(leftSource, "f", leftsize, 0, false);
 
         assertDepth(left, leftSource, 3);
 
-        final int rightsize = RevTree.NORMALIZED_SIZE_LIMIT * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int rightsize = NodePathStorageOrder.normalizedSizeLimit(0)
+                * NodePathStorageOrder.normalizedSizeLimit(0);
         final int overlapCount = 100;
 
         long totalMillis = 0;
@@ -655,8 +668,8 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testLeafBucketOneLevelDepth() {
-        final int leftsize = RevTree.NORMALIZED_SIZE_LIMIT;
-        final int rightsize = 2 * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = NodePathStorageOrder.normalizedSizeLimit(0);
+        final int rightsize = 2 * NodePathStorageOrder.normalizedSizeLimit(0);
         final int overlapCount = 100;
 
         RevTree right = createFeaturesTree(rightSource, "f", rightsize);
@@ -666,8 +679,9 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testLeafBucketTwoLevelsDepth() {
-        final int leftsize = RevTree.NORMALIZED_SIZE_LIMIT;
-        final int rightsize = RevTree.MAX_BUCKETS * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = NodePathStorageOrder.normalizedSizeLimit(0);
+        final int rightsize = NodePathStorageOrder.maxBucketsForLevel(0)
+                * NodePathStorageOrder.normalizedSizeLimit(0);
         final int overlapCount = 100;
 
         RevTree right = createFeaturesTree(rightSource, "f", rightsize);
@@ -767,7 +781,7 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testBucketLeafSeveral() {
-        final int leftsize = 1 + RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = 1 + NodePathStorageOrder.normalizedSizeLimit(0);
         RevTree left = createFeaturesTree(leftSource, "f", leftsize);
         RevTree right = createFeaturesTree(rightSource, "f", 1);
 
@@ -800,8 +814,8 @@ public class PreOrderDiffWalkTest {
 
     @Test
     public void testMaxFeatureDiffsFilter() {
-        final int leftsize = 2 * RevTree.NORMALIZED_SIZE_LIMIT;
-        final int rightsize = RevTree.NORMALIZED_SIZE_LIMIT;
+        final int leftsize = 2 * NodePathStorageOrder.normalizedSizeLimit(0);
+        final int rightsize = NodePathStorageOrder.normalizedSizeLimit(0);
 
         final RevTree left = createFeaturesTree(leftSource, "f", leftsize);
 
@@ -824,7 +838,7 @@ public class PreOrderDiffWalkTest {
     public void testFalseReturnValueOnConsumerFeatureAbortsTraversal() {
 
         final int leftsize = 100;// RevTree.NORMALIZED_SIZE_LIMIT;
-        final int rightsize = 10 * RevTree.NORMALIZED_SIZE_LIMIT;
+        final int rightsize = 10 * NodePathStorageOrder.normalizedSizeLimit(0);
 
         final RevTree left = createFeaturesTree(leftSource, "f", leftsize);
 

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/RevTreeBuilderTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/RevTreeBuilderTest.java
@@ -33,6 +33,7 @@ import org.locationtech.geogig.api.plumbing.LsTreeOp;
 import org.locationtech.geogig.api.plumbing.diff.DepthTreeIterator;
 import org.locationtech.geogig.api.plumbing.diff.DepthTreeIterator.Strategy;
 import org.locationtech.geogig.repository.SpatialOps;
+import org.locationtech.geogig.storage.NodePathStorageOrder;
 import org.locationtech.geogig.storage.NodeStorageOrder;
 import org.locationtech.geogig.storage.ObjectDatabase;
 
@@ -138,7 +139,7 @@ public class RevTreeBuilderTest extends RepositoryTestCase {
 
     @Test
     public void testPutRandomGet() throws Exception {
-        final int numEntries = 2 * RevTree.NORMALIZED_SIZE_LIMIT + 1500;
+        final int numEntries = 2 * NodePathStorageOrder.normalizedSizeLimit(0) + 1500;
         final ObjectId treeId;
 
         Stopwatch sw;
@@ -242,7 +243,7 @@ public class RevTreeBuilderTest extends RepositoryTestCase {
 
     @Test
     public void testRemoveSplittedTree() throws Exception {
-        final int numEntries = (int) (1.5 * RevTree.NORMALIZED_SIZE_LIMIT);
+        final int numEntries = (int) (1.5 * NodePathStorageOrder.normalizedSizeLimit(0));
         final ObjectId treeId = createAndSaveTree(numEntries, true);
         final RevTree tree = odb.getTree(treeId);
 
@@ -288,7 +289,7 @@ public class RevTreeBuilderTest extends RepositoryTestCase {
     @Test
     public void testEquality() throws Exception {
         testEquality(100);
-        testEquality(100 + RevTree.NORMALIZED_SIZE_LIMIT);
+        testEquality(100 + NodePathStorageOrder.normalizedSizeLimit(0));
     }
 
     private void testEquality(final int numEntries) throws Exception {
@@ -345,7 +346,7 @@ public class RevTreeBuilderTest extends RepositoryTestCase {
 
     @Test
     public void testNodeOrderPassSplitThreshold() {
-        final int splitThreshold = RevTree.NORMALIZED_SIZE_LIMIT;
+        final int splitThreshold = NodePathStorageOrder.normalizedSizeLimit(0);
         List<Node> expectedOrder = nodes(splitThreshold + 1);
         Collections.sort(expectedOrder, new NodeStorageOrder());
 


### PR DESCRIPTION
Optimize RevTree structure to avoid an overwhelming exponential growth in the number of bucket trees.

See the comment at commit fcae386b63a42ee3af540595c0a31a5b86d22841 for more information.