### PR TITLE
Dependencies: Alternate Versions

### DIFF
--- a/src/geotools/pom.xml
+++ b/src/geotools/pom.xml
@@ -106,6 +106,10 @@
           <groupId>javax.media</groupId>
           <artifactId>jai_core</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>xml-apis</groupId>
+          <artifactId>xml-apis</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -79,7 +79,7 @@
     <dependency>
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>woodstox-core-asl</artifactId>
-      <version>4.1.4</version>
+      <version>4.2.0</version>
       <exclusions>
         <exclusion>
           <groupId>javax.xml.stream</groupId>

--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -91,6 +91,20 @@
       <groupId>org.openstreetmap.osmosis</groupId>
       <artifactId>osmosis-xml</artifactId>
       <version>${osmosis.version}</version>
+      <exclusions>
+        <!--
+         Bump commons-codec from 1.7 to 1.8 at request of IP team.
+        -->
+        <exclusion>
+          <groupId>commons-codec</groupId>
+          <artifactId>commons-codec</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>org.openstreetmap.osmosis</groupId>

--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -96,6 +96,20 @@
       <groupId>org.openstreetmap.osmosis</groupId>
       <artifactId>osmosis-pbf</artifactId>
       <version>${osmosis.version}</version>
+      <exclusions>
+        <!--
+         Bump protobuf from 2.4.1 to 2.5.0 at request of IP team.
+        -->
+        <exclusion>
+          <groupId>com.google.protobuf</groupId>
+          <artifactId>protobuf-java</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -112,7 +112,7 @@
     <cucumber-java.version>1.2.4</cucumber-java.version>
     <gson.version>2.4</gson.version>
     <gt.version>14.1</gt.version>
-    <guava.version>17.0</guava.version>
+    <guava.version>18.0</guava.version>
     <guice.version>3.0</guice.version>
     <jcommander.version>1.48</jcommander.version>
     <jettison.version>1.0.1</jettison.version> <!-- matches version used in geoserver -->


### PR DESCRIPTION
The IP team requested that we change to some alternate versions of libraries that have already been approved. This allows us to do a "piggyback" request which is generally much faster. There are a mix of direct and transitive dependencies.

xml-apis contains tainted IP and has been removed.
PR to remove it from GeoTools: https://github.com/geotools/geotools/pull/1091