### PR TITLE
Fixed maven unit test errors.

### DIFF
--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGStorage.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGStorage.java
@@ -209,15 +209,18 @@ public class PGStorage {
                             return null;
                         }
                     }
-                    cx.setAutoCommit(false);
                     try {
                         // tell postgres to send bytea fields in a more compact format than hex
                         // encoding
+                        cx.setAutoCommit(true);
+                        PGStorage.run(cx, "SELECT pg_advisory_lock(-1)");
                         String sql = String.format(
                                 "ALTER DATABASE \"%s\" SET bytea_output = 'escape'",
                                 config.getDatabaseName());
                         PGStorage.run(cx, sql);
+                        PGStorage.run(cx, "SELECT pg_advisory_unlock(-1)");
 
+                        cx.setAutoCommit(false);
                         PGStorage.run(cx, "SET constraint_exclusion=ON");
 
                         createConfigTable(cx, tables);


### PR DESCRIPTION
The ALTER DATABASE query was causing exceptions when run in parallel through maven.  Added an advisory lock to prevent different forks from executing the query simultaneously.