### PR TITLE
Get rid of boilerplate code in WEB API's CommandBuilder.

### DIFF
--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/AbstractWebAPICommand.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/AbstractWebAPICommand.java
@@ -22,6 +22,10 @@ public abstract class AbstractWebAPICommand implements WebAPICommand {
 
     private UUID transactionId = null;
 
+    protected AbstractWebAPICommand(ParameterSet options) {
+        setTransactionId(options.getFirstValue("transactionId", null));
+    }
+
     /**
      * Accessor for the transactionId
      * 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/AbstractWebAPICommand.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/AbstractWebAPICommand.java
@@ -58,4 +58,26 @@ public abstract class AbstractWebAPICommand implements WebAPICommand {
 
     public abstract void run(CommandContext context);
 
+    /**
+     * Parses a string to an Integer, using a default value if the was not found in the parameter
+     * set.
+     * 
+     * @param form the parameter set
+     * @param key the attribute key
+     * @param defaultValue the default value
+     * @return the parsed integer
+     */
+    protected static Integer parseInt(ParameterSet form, String key, Integer defaultValue) {
+        String val = form.getFirstValue(key);
+        Integer retval = defaultValue;
+        if (val != null) {
+            try {
+                retval = new Integer(val);
+            } catch (NumberFormatException nfe) {
+                throw new CommandSpecException("Invalid value '" + val + "' specified for option: "
+                        + key);
+            }
+        }
+        return retval;
+    }
 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/CommandBuilder.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/CommandBuilder.java
@@ -97,11 +97,6 @@ public class CommandBuilder {
 
         WebAPICommand command = MAPPINGS.get(commandName).apply(options);
 
-        if (command instanceof AbstractWebAPICommand) {
-            ((AbstractWebAPICommand) command).setTransactionId(options.getFirstValue(
-                    "transactionId", null));
-        }
-
         return command;
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/CommandBuilder.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/CommandBuilder.java
@@ -9,9 +9,10 @@
  */
 package org.locationtech.geogig.web.api;
 
-import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Function;
 
-import org.locationtech.geogig.api.ObjectId;
 import org.locationtech.geogig.web.api.commands.AddWebOp;
 import org.locationtech.geogig.web.api.commands.BeginTransaction;
 import org.locationtech.geogig.web.api.commands.BlameWebOp;
@@ -47,6 +48,38 @@ import org.locationtech.geogig.web.api.commands.VersionWebOp;
  */
 public class CommandBuilder {
 
+    private static Map<String, Function<ParameterSet, WebAPICommand>> MAPPINGS = new HashMap<>();
+    static {
+        MAPPINGS.put("status", Status::new);
+        MAPPINGS.put("log", Log::new);
+        MAPPINGS.put("commit", Commit::new);
+        MAPPINGS.put("ls-tree", LsTree::new);
+        MAPPINGS.put("updateref", UpdateRefWeb::new);
+        MAPPINGS.put("diff", Diff::new);
+        MAPPINGS.put("refparse", RefParseWeb::new);
+        MAPPINGS.put("branch", BranchWebOp::new);
+        MAPPINGS.put("remote", RemoteWebOp::new);
+        MAPPINGS.put("push", PushWebOp::new);
+        MAPPINGS.put("pull", PullWebOp::new);
+        MAPPINGS.put("fetch", FetchWebOp::new);
+        MAPPINGS.put("tag", TagWebOp::new);
+        MAPPINGS.put("featurediff", FeatureDiffWeb::new);
+        MAPPINGS.put("getCommitGraph", GetCommitGraph::new);
+        MAPPINGS.put("merge", MergeWebOp::new);
+        MAPPINGS.put("checkout", CheckoutWebOp::new);
+        MAPPINGS.put("beginTransaction", BeginTransaction::new);
+        MAPPINGS.put("endTransaction", EndTransaction::new);
+        MAPPINGS.put("add", AddWebOp::new);
+        MAPPINGS.put("remove", RemoveWebOp::new);
+        MAPPINGS.put("resolveconflict", ResolveConflict::new);
+        MAPPINGS.put("revertfeature", RevertFeatureWebOp::new);
+        MAPPINGS.put("rebuildgraph", RebuildGraphWebOp::new);
+        MAPPINGS.put("blame", BlameWebOp::new);
+        MAPPINGS.put("version", VersionWebOp::new);
+        MAPPINGS.put("cat", CatWebOp::new);
+        MAPPINGS.put("statistics", StatisticsWebOp::new);
+    }
+
     /**
      * Builds the {@link WebAPICommand}.
      * 
@@ -55,471 +88,21 @@ public class CommandBuilder {
      * @return the command that was built
      * @throws CommandSpecException
      */
-    public static WebAPICommand build(String commandName, ParameterSet options)
+    public static WebAPICommand build(final String commandName, final ParameterSet options)
             throws CommandSpecException {
-        AbstractWebAPICommand command = null;
-        if ("status".equalsIgnoreCase(commandName)) {
-            command = buildStatus(options);
-        } else if ("log".equalsIgnoreCase(commandName)) {
-            command = buildLog(options);
-        } else if ("commit".equalsIgnoreCase(commandName)) {
-            command = buildCommit(options);
-        } else if ("ls-tree".equalsIgnoreCase(commandName)) {
-            command = buildLsTree(options);
-        } else if ("updateref".equalsIgnoreCase(commandName)) {
-            command = buildUpdateRef(options);
-        } else if ("diff".equalsIgnoreCase(commandName)) {
-            command = buildDiff(options);
-        } else if ("refparse".equalsIgnoreCase(commandName)) {
-            command = buildRefParse(options);
-        } else if ("branch".equalsIgnoreCase(commandName)) {
-            command = buildBranch(options);
-        } else if ("remote".equalsIgnoreCase(commandName)) {
-            command = buildRemote(options);
-        } else if ("push".equalsIgnoreCase(commandName)) {
-            command = buildPush(options);
-        } else if ("pull".equalsIgnoreCase(commandName)) {
-            command = buildPull(options);
-        } else if ("fetch".equalsIgnoreCase(commandName)) {
-            command = buildFetch(options);
-        } else if ("tag".equalsIgnoreCase(commandName)) {
-            command = buildTag(options);
-        } else if ("featurediff".equalsIgnoreCase(commandName)) {
-            command = buildFeatureDiff(options);
-        } else if ("getCommitGraph".equalsIgnoreCase(commandName)) {
-            command = buildGetCommitGraph(options);
-        } else if ("merge".equalsIgnoreCase(commandName)) {
-            command = buildMerge(options);
-        } else if ("checkout".equalsIgnoreCase(commandName)) {
-            command = buildCheckout(options);
-        } else if ("beginTransaction".equalsIgnoreCase(commandName)) {
-            command = buildBeginTransaction(options);
-        } else if ("endTransaction".equalsIgnoreCase(commandName)) {
-            command = buildEndTransaction(options);
-        } else if ("add".equalsIgnoreCase(commandName)) {
-            command = buildAdd(options);
-        } else if ("remove".equalsIgnoreCase(commandName)) {
-            command = buildRemove(options);
-        } else if ("resolveconflict".equalsIgnoreCase(commandName)) {
-            command = buildResolveConflict(options);
-        } else if ("revertfeature".equalsIgnoreCase(commandName)) {
-            command = buildRevertFeature(options);
-        } else if ("rebuildgraph".equalsIgnoreCase(commandName)) {
-            command = buildRebuildGraph(options);
-        } else if ("blame".equalsIgnoreCase(commandName)) {
-            command = buildBlame(options);
-        } else if ("version".equalsIgnoreCase(commandName)) {
-            command = buildVersion(options);
-        } else if ("cat".equalsIgnoreCase(commandName)) {
-            command = buildCat(options);
-        } else if ("statistics".equalsIgnoreCase(commandName)) {
-            command = buildStatistics(options);
-        } else {
+
+        if (!MAPPINGS.containsKey(commandName)) {
             throw new CommandSpecException("'" + commandName + "' is not a geogig command");
         }
 
-        command.setTransactionId(options.getFirstValue("transactionId", null));
+        WebAPICommand command = MAPPINGS.get(commandName).apply(options);
 
-        return command;
-    }
-
-    /**
-     * Parses a string to an Integer, using a default value if the was not found in the parameter
-     * set.
-     * 
-     * @param form the parameter set
-     * @param key the attribute key
-     * @param defaultValue the default value
-     * @return the parsed integer
-     */
-    static Integer parseInt(ParameterSet form, String key, Integer defaultValue) {
-        String val = form.getFirstValue(key);
-        Integer retval = defaultValue;
-        if (val != null) {
-            try {
-                retval = new Integer(val);
-            } catch (NumberFormatException nfe) {
-                throw new CommandSpecException("Invalid value '" + val + "' specified for option: "
-                        + key);
-            }
+        if (command instanceof AbstractWebAPICommand) {
+            ((AbstractWebAPICommand) command).setTransactionId(options.getFirstValue(
+                    "transactionId", null));
         }
-        return retval;
-    }
 
-    /**
-     * Builds the {@link Status} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static Status buildStatus(ParameterSet options) {
-        Status command = new Status();
-        command.setLimit(parseInt(options, "limit", 50));
-        command.setOffset(parseInt(options, "offset", 0));
         return command;
     }
 
-    /**
-     * Builds the {@link Log} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static Log buildLog(ParameterSet options) {
-        Log command = new Log();
-        command.setLimit(parseInt(options, "limit", null));
-        command.setOffset(parseInt(options, "offset", null));
-        command.setPaths(Arrays.asList(options.getValuesArray("path")));
-        command.setSince(options.getFirstValue("since"));
-        command.setUntil(options.getFirstValue("until"));
-        command.setSinceTime(options.getFirstValue("sinceTime"));
-        command.setUntilTime(options.getFirstValue("untilTime"));
-        command.setPage(parseInt(options, "page", 0));
-        command.setElementsPerPage(parseInt(options, "show", 30));
-        command.setFirstParentOnly(Boolean.valueOf(options
-                .getFirstValue("firstParentOnly", "false")));
-        command.setCountChanges(Boolean.valueOf(options.getFirstValue("countChanges", "false")));
-        command.setReturnRange(Boolean.valueOf(options.getFirstValue("returnRange", "false")));
-        command.setSummary(Boolean.valueOf(options.getFirstValue("summary", "false")));
-        return command;
-    }
-
-    /**
-     * Builds the {@link Commit} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static Commit buildCommit(ParameterSet options) {
-        Commit commit = new Commit();
-        commit.setAll(Boolean.valueOf(options.getFirstValue("all", "false")));
-        commit.setMessage(options.getFirstValue("message", null));
-        commit.setAuthorName(options.getFirstValue("authorName", null));
-        commit.setAuthorEmail(options.getFirstValue("authorEmail", null));
-        return commit;
-    }
-
-    /**
-     * Builds the {@link LsTree} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static LsTree buildLsTree(ParameterSet options) {
-        LsTree lsTree = new LsTree();
-        lsTree.setIncludeTrees(Boolean.valueOf(options.getFirstValue("showTree", "false")));
-        lsTree.setOnlyTrees(Boolean.valueOf(options.getFirstValue("onlyTree", "false")));
-        lsTree.setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));
-        lsTree.setVerbose(Boolean.valueOf(options.getFirstValue("verbose", "false")));
-        lsTree.setRefList(Arrays.asList(options.getValuesArray("path")));
-        return lsTree;
-    }
-
-    /**
-     * Builds the {@link UpdateRefWeb} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static UpdateRefWeb buildUpdateRef(ParameterSet options) {
-        UpdateRefWeb command = new UpdateRefWeb();
-        command.setName(options.getFirstValue("name", null));
-        command.setDelete(Boolean.valueOf(options.getFirstValue("delete", "false")));
-        command.setNewValue(options.getFirstValue("newValue", ObjectId.NULL.toString()));
-        return command;
-    }
-
-    /**
-     * Builds the {@link Diff} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static Diff buildDiff(ParameterSet options) {
-        Diff command = new Diff();
-        command.setOldRefSpec(options.getFirstValue("oldRefSpec", null));
-        command.setNewRefSpec(options.getFirstValue("newRefSpec", null));
-        command.setPathFilter(options.getFirstValue("pathFilter", null));
-        command.setShowGeometryChanges(Boolean.parseBoolean(options.getFirstValue(
-                "showGeometryChanges", "false")));
-        command.setPage(parseInt(options, "page", 0));
-        command.setElementsPerPage(parseInt(options, "show", 30));
-        return command;
-    }
-
-    /**
-     * Builds the {@link RefParseWeb} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static RefParseWeb buildRefParse(ParameterSet options) {
-        RefParseWeb command = new RefParseWeb();
-        command.setName(options.getFirstValue("name", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link BranchWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static BranchWebOp buildBranch(ParameterSet options) {
-        BranchWebOp command = new BranchWebOp();
-        command.setList(Boolean.valueOf(options.getFirstValue("list", "false")));
-        command.setRemotes(Boolean.valueOf(options.getFirstValue("remotes", "false")));
-        command.setBranchName(options.getFirstValue("branchName", null));
-        command.setSource(options.getFirstValue("source", null));
-        // TODO: enable these options if necessary
-        //command.setAutoCheckout(Boolean.valueOf(options.getFirstValue("autoCheckout", "false")));
-        //command.setCreateForce(Boolean.valueOf(options.getFirstValue("force", "false")));
-        //command.setOrphan(Boolean.valueOf(options.getFirstValue("orphan", "false")));
-        return command;
-    }
-
-    /**
-     * Builds the {@link RemoteWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static RemoteWebOp buildRemote(ParameterSet options) {
-        RemoteWebOp command = new RemoteWebOp();
-        command.setList(Boolean.valueOf(options.getFirstValue("list", "false")));
-        command.setRemove(Boolean.valueOf(options.getFirstValue("remove", "false")));
-        command.setPing(Boolean.valueOf(options.getFirstValue("ping", "false")));
-        command.setUpdate(Boolean.valueOf(options.getFirstValue("update", "false")));
-        command.setVerbose(Boolean.valueOf(options.getFirstValue("verbose", "false")));
-        command.setRemoteName(options.getFirstValue("remoteName", null));
-        command.setNewName(options.getFirstValue("newName", null));
-        command.setRemoteURL(options.getFirstValue("remoteURL", null));
-        command.setUserName(options.getFirstValue("username", null));
-        command.setPassword(options.getFirstValue("password", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link PushWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static PushWebOp buildPush(ParameterSet options) {
-        PushWebOp command = new PushWebOp();
-        command.setPushAll(Boolean.valueOf(options.getFirstValue("all", "false")));
-        command.setRefSpec(options.getFirstValue("ref", null));
-        command.setRemoteName(options.getFirstValue("remoteName", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link PullWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static PullWebOp buildPull(ParameterSet options) {
-        PullWebOp command = new PullWebOp();
-        command.setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
-        command.setRefSpec(options.getFirstValue("ref", null));
-        command.setRemoteName(options.getFirstValue("remoteName", null));
-        command.setAuthorName(options.getFirstValue("authorName", null));
-        command.setAuthorEmail(options.getFirstValue("authorEmail", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link FetchWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static FetchWebOp buildFetch(ParameterSet options) {
-        FetchWebOp command = new FetchWebOp();
-        command.setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
-        command.setPrune(Boolean.valueOf(options.getFirstValue("prune", "false")));
-        command.setRemote(options.getFirstValue("remote"));
-        return command;
-    }
-
-    /**
-     * Builds the {@link TagWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static TagWebOp buildTag(ParameterSet options) {
-        TagWebOp command = new TagWebOp();
-        command.setList(Boolean.valueOf(options.getFirstValue("list", "false")));
-        return command;
-    }
-
-    /**
-     * Builds the {@link FeatureDiffWeb} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static FeatureDiffWeb buildFeatureDiff(ParameterSet options) {
-        FeatureDiffWeb command = new FeatureDiffWeb();
-        command.setPath(options.getFirstValue("path", null));
-        command.setOldTreeish(options.getFirstValue("oldTreeish", ObjectId.NULL.toString()));
-        command.setNewTreeish(options.getFirstValue("newTreeish", ObjectId.NULL.toString()));
-        command.setAll(Boolean.valueOf(options.getFirstValue("all", "false")));
-        return command;
-    }
-
-    /**
-     * Builds the {@link GetCommitGraph} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static GetCommitGraph buildGetCommitGraph(ParameterSet options) {
-        GetCommitGraph command = new GetCommitGraph();
-        command.setDepth(parseInt(options, "depth", 0));
-        command.setCommitId(options.getFirstValue("commitId", ObjectId.NULL.toString()));
-        command.setPage(parseInt(options, "page", 0));
-        command.setElementsPerPage(parseInt(options, "show", 30));
-        return command;
-    }
-
-    /**
-     * Builds the {@link BeginTransaction} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static BeginTransaction buildBeginTransaction(ParameterSet options) {
-        BeginTransaction command = new BeginTransaction();
-        return command;
-    }
-
-    /**
-     * Builds the {@link EndTransaction} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static EndTransaction buildEndTransaction(ParameterSet options) {
-        EndTransaction command = new EndTransaction();
-        command.setCancel(Boolean.valueOf(options.getFirstValue("cancel", "false")));
-        return command;
-    }
-
-    /**
-     * Builds the {@link MergeWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static MergeWebOp buildMerge(ParameterSet options) {
-        MergeWebOp command = new MergeWebOp();
-        command.setNoCommit(Boolean.valueOf(options.getFirstValue("noCommit", "false")));
-        command.setCommit(options.getFirstValue("commit", null));
-        command.setAuthorName(options.getFirstValue("authorName", null));
-        command.setAuthorEmail(options.getFirstValue("authorEmail", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link CheckoutWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static CheckoutWebOp buildCheckout(ParameterSet options) {
-        CheckoutWebOp command = new CheckoutWebOp();
-        command.setName(options.getFirstValue("branch", null));
-        command.setOurs(Boolean.valueOf(options.getFirstValue("ours", "false")));
-        command.setTheirs(Boolean.valueOf(options.getFirstValue("theirs", "false")));
-        command.setPath(options.getFirstValue("path", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link AddWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static AddWebOp buildAdd(ParameterSet options) {
-        AddWebOp command = new AddWebOp();
-        command.setPath(options.getFirstValue("path", null));
-        return command;
-    }
-
-    /**
-     * Builds the {@link VersionWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static VersionWebOp buildVersion(ParameterSet options) {
-        VersionWebOp command = new VersionWebOp();
-        return command;
-    }
-
-    /**
-     * Builds the {@link RemoveWebOp} command.
-     * 
-     * @param options the parameter set
-     * @return the built command
-     */
-    static RemoveWebOp buildRemove(ParameterSet options) {
-        RemoveWebOp command = new RemoveWebOp();
-        command.setPath(options.getFirstValue("path", null));
-        command.setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));
-        return command;
-    }
-
-    static ResolveConflict buildResolveConflict(ParameterSet options) {
-        ResolveConflict command = new ResolveConflict();
-        command.setPath(options.getFirstValue("path", null));
-        command.setFeatureObjectId(options.getFirstValue("objectid", null));
-        return command;
-    }
-
-    static RebuildGraphWebOp buildRebuildGraph(ParameterSet options) {
-        RebuildGraphWebOp command = new RebuildGraphWebOp();
-        command.setQuiet(Boolean.valueOf(options.getFirstValue("quiet", "false")));
-        return command;
-    }
-
-    static RevertFeatureWebOp buildRevertFeature(ParameterSet options) {
-        RevertFeatureWebOp command = new RevertFeatureWebOp();
-        command.setAuthorName(options.getFirstValue("authorName", null));
-        command.setAuthorEmail(options.getFirstValue("authorEmail", null));
-        command.setCommitMessage(options.getFirstValue("commitMessage", null));
-        command.setMergeMessage(options.getFirstValue("mergeMessage", null));
-        command.setNewCommitId(options.getFirstValue("newCommitId", null));
-        command.setOldCommitId(options.getFirstValue("oldCommitId", null));
-        command.setPath(options.getFirstValue("path", null));
-        return command;
-    }
-
-    static BlameWebOp buildBlame(ParameterSet options) {
-        BlameWebOp command = new BlameWebOp();
-        command.setCommit(options.getFirstValue("commit", null));
-        command.setPath(options.getFirstValue("path", null));
-        return command;
-    }
-
-    static CatWebOp buildCat(ParameterSet options) {
-        CatWebOp command = new CatWebOp();
-        String objectId = options.getFirstValue("objectid", null);
-        if (objectId != null) {
-            command.setObjectId(ObjectId.valueOf(objectId));
-        }
-        return command;
-    }
-
-    static StatisticsWebOp buildStatistics(ParameterSet options) {
-        StatisticsWebOp command = new StatisticsWebOp();
-        command.setPath(options.getFirstValue("path", null));
-        command.setSince(options.getFirstValue("since", null));
-        command.setUntil(options.getFirstValue("branch", null));
-        return command;
-    }
 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/AddWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/AddWebOp.java
@@ -29,6 +29,7 @@ public class AddWebOp extends AbstractWebAPICommand {
     String path;
 
     public AddWebOp(ParameterSet options) {
+        super(options);
         setPath(options.getFirstValue("path", null));
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/AddWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/AddWebOp.java
@@ -15,6 +15,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -26,6 +27,10 @@ import org.locationtech.geogig.web.api.ResponseWriter;
 public class AddWebOp extends AbstractWebAPICommand {
 
     String path;
+
+    public AddWebOp(ParameterSet options) {
+        setPath(options.getFirstValue("path", null));
+    }
 
     /**
      * Mutator for the path variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BeginTransaction.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BeginTransaction.java
@@ -16,6 +16,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -25,6 +26,10 @@ import org.locationtech.geogig.web.api.ResponseWriter;
  */
 
 public class BeginTransaction extends AbstractWebAPICommand {
+
+    public BeginTransaction(ParameterSet options) {
+        // no-op
+    }
 
     /**
      * Runs the command and builds the appropriate response.

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BeginTransaction.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BeginTransaction.java
@@ -28,7 +28,7 @@ import org.locationtech.geogig.web.api.ResponseWriter;
 public class BeginTransaction extends AbstractWebAPICommand {
 
     public BeginTransaction(ParameterSet options) {
-        // no-op
+        super(options);
     }
 
     /**

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BlameWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BlameWebOp.java
@@ -21,6 +21,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -36,6 +37,11 @@ public class BlameWebOp extends AbstractWebAPICommand {
     private String path;
 
     private String branchOrCommit;
+
+    public BlameWebOp(ParameterSet options) {
+        setCommit(options.getFirstValue("commit", null));
+        setPath(options.getFirstValue("path", null));
+    }
 
     /**
      * Mutator for the branchOrCommit variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BlameWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BlameWebOp.java
@@ -39,6 +39,7 @@ public class BlameWebOp extends AbstractWebAPICommand {
     private String branchOrCommit;
 
     public BlameWebOp(ParameterSet options) {
+        super(options);
         setCommit(options.getFirstValue("commit", null));
         setPath(options.getFirstValue("path", null));
     }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BranchWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BranchWebOp.java
@@ -18,6 +18,7 @@ import org.locationtech.geogig.api.porcelain.BranchListOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.collect.Lists;
@@ -57,10 +58,22 @@ public class BranchWebOp extends AbstractWebAPICommand {
     boolean orphan;
 
     /**
-    * A branch ref or commit id where the branch to create starts at. If not set
-    * defaults to the current {@link Ref#HEAD HEAD}
-    */
+     * A branch ref or commit id where the branch to create starts at. If not set defaults to the
+     * current {@link Ref#HEAD HEAD}
+     */
     String source;
+
+    public BranchWebOp(ParameterSet options) {
+        setList(Boolean.valueOf(options.getFirstValue("list", "false")));
+        setRemotes(Boolean.valueOf(options.getFirstValue("remotes", "false")));
+        setBranchName(options.getFirstValue("branchName", null));
+        setSource(options.getFirstValue("source", null));
+        // TODO: enable these options if necessary
+        // setAutoCheckout(Boolean.valueOf(options.getFirstValue("autoCheckout", "false")));
+        // setCreateForce(Boolean.valueOf(options.getFirstValue("force", "false")));
+        // setOrphan(Boolean.valueOf(options.getFirstValue("orphan", "false")));
+    }
+
     /**
      * Mutator for the list option
      * 
@@ -92,7 +105,7 @@ public class BranchWebOp extends AbstractWebAPICommand {
      * Mutator for the Force option.
      *
      * @param createForce - true if branch creation should overwrite an existing branch with the
-     * same Branch Name.
+     *        same Branch Name.
      */
     public void setCreateForce(boolean createForce) {
         this.force = createForce;
@@ -102,7 +115,7 @@ public class BranchWebOp extends AbstractWebAPICommand {
      * Mutator for AutoCheckout.
      *
      * @param autoCheckout - true if the working branch should switch/checkout the newly created
-     * branch.
+     *        branch.
      */
     public void setAutoCheckout(boolean autoCheckout) {
         this.autoCheckout = autoCheckout;
@@ -112,7 +125,7 @@ public class BranchWebOp extends AbstractWebAPICommand {
      * Mutator for Orphan.
      *
      * @param orphan - true is the newly created branch should NOT inherit the history of the branch
-     * it was created from.
+     *        it was created from.
      */
     public void setOrphan(boolean orphan) {
         this.orphan = orphan;
@@ -122,7 +135,7 @@ public class BranchWebOp extends AbstractWebAPICommand {
      * Mutator for source.
      *
      * @param source - A branch ref or commit id where the branch to create starts at. If not set
-     * defaults to the current {@link Ref#HEAD HEAD}.
+     *        defaults to the current {@link Ref#HEAD HEAD}.
      */
     public void setSource(String source) {
         this.source = source;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BranchWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/BranchWebOp.java
@@ -64,6 +64,7 @@ public class BranchWebOp extends AbstractWebAPICommand {
     String source;
 
     public BranchWebOp(ParameterSet options) {
+        super(options);
         setList(Boolean.valueOf(options.getFirstValue("list", "false")));
         setRemotes(Boolean.valueOf(options.getFirstValue("remotes", "false")));
         setBranchName(options.getFirstValue("branchName", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CatWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CatWebOp.java
@@ -21,6 +21,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Preconditions;
@@ -34,6 +35,13 @@ import com.google.common.base.Preconditions;
 public class CatWebOp extends AbstractWebAPICommand {
 
     private ObjectId object;
+
+    public CatWebOp(ParameterSet options) {
+        String objectId = options.getFirstValue("objectid", null);
+        if (objectId != null) {
+            setObjectId(ObjectId.valueOf(objectId));
+        }
+    }
 
     /**
      * Mutator for the object variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CatWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CatWebOp.java
@@ -37,6 +37,7 @@ public class CatWebOp extends AbstractWebAPICommand {
     private ObjectId object;
 
     public CatWebOp(ParameterSet options) {
+        super(options);
         String objectId = options.getFirstValue("objectid", null);
         if (objectId != null) {
             setObjectId(ObjectId.valueOf(objectId));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CheckoutWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CheckoutWebOp.java
@@ -40,6 +40,7 @@ public class CheckoutWebOp extends AbstractWebAPICommand {
     private String path;
 
     public CheckoutWebOp(ParameterSet options) {
+        super(options);
         setName(options.getFirstValue("branch", null));
         setOurs(Boolean.valueOf(options.getFirstValue("ours", "false")));
         setTheirs(Boolean.valueOf(options.getFirstValue("theirs", "false")));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CheckoutWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/CheckoutWebOp.java
@@ -18,6 +18,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -37,6 +38,13 @@ public class CheckoutWebOp extends AbstractWebAPICommand {
     private boolean theirs;
 
     private String path;
+
+    public CheckoutWebOp(ParameterSet options) {
+        setName(options.getFirstValue("branch", null));
+        setOurs(Boolean.valueOf(options.getFirstValue("ours", "false")));
+        setTheirs(Boolean.valueOf(options.getFirstValue("theirs", "false")));
+        setPath(options.getFirstValue("path", null));
+    }
 
     /**
      * Mutator for the branchOrCommit variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
@@ -44,6 +44,7 @@ public class Commit extends AbstractWebAPICommand {
     private Optional<String> authorEmail = Optional.absent();
 
     public Commit(ParameterSet options) {
+        super(options);
         setAll(Boolean.valueOf(options.getFirstValue("all", "false")));
         setMessage(options.getFirstValue("message", null));
         setAuthorName(options.getFirstValue("authorName", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Commit.java
@@ -23,6 +23,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -41,6 +42,13 @@ public class Commit extends AbstractWebAPICommand {
     private Optional<String> authorName = Optional.absent();
 
     private Optional<String> authorEmail = Optional.absent();
+
+    public Commit(ParameterSet options) {
+        setAll(Boolean.valueOf(options.getFirstValue("all", "false")));
+        setMessage(options.getFirstValue("message", null));
+        setAuthorName(options.getFirstValue("authorName", null));
+        setAuthorEmail(options.getFirstValue("authorEmail", null));
+    }
 
     /**
      * Mutator for the message variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Diff.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Diff.java
@@ -18,6 +18,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -38,6 +39,16 @@ public class Diff extends AbstractWebAPICommand {
     private int page;
 
     private int elementsPerPage;
+
+    public Diff(ParameterSet options) {
+        setOldRefSpec(options.getFirstValue("oldRefSpec", null));
+        setNewRefSpec(options.getFirstValue("newRefSpec", null));
+        setPathFilter(options.getFirstValue("pathFilter", null));
+        setShowGeometryChanges(Boolean.parseBoolean(options.getFirstValue("showGeometryChanges",
+                "false")));
+        setPage(parseInt(options, "page", 0));
+        setElementsPerPage(parseInt(options, "show", 30));
+    }
 
     /**
      * Mutator for the oldRefSpec variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Diff.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Diff.java
@@ -41,6 +41,7 @@ public class Diff extends AbstractWebAPICommand {
     private int elementsPerPage;
 
     public Diff(ParameterSet options) {
+        super(options);
         setOldRefSpec(options.getFirstValue("oldRefSpec", null));
         setNewRefSpec(options.getFirstValue("newRefSpec", null));
         setPathFilter(options.getFirstValue("pathFilter", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/EndTransaction.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/EndTransaction.java
@@ -23,6 +23,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -36,7 +37,10 @@ import com.google.common.base.Optional;
 public class EndTransaction extends AbstractWebAPICommand {
 
     private boolean cancel;
-
+    
+    public EndTransaction (ParameterSet options) {
+        setCancel(Boolean.valueOf(options.getFirstValue("cancel", "false")));
+    }
     /**
      * Mutator for the cancel variable
      * 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/EndTransaction.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/EndTransaction.java
@@ -39,6 +39,7 @@ public class EndTransaction extends AbstractWebAPICommand {
     private boolean cancel;
     
     public EndTransaction (ParameterSet options) {
+        super(options);
         setCancel(Boolean.valueOf(options.getFirstValue("cancel", "false")));
     }
     /**

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FeatureDiffWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FeatureDiffWeb.java
@@ -57,6 +57,7 @@ public class FeatureDiffWeb extends AbstractWebAPICommand {
     private boolean all;
 
     public FeatureDiffWeb(ParameterSet options) {
+        super(options);
         setPath(options.getFirstValue("path", null));
         setOldTreeish(options.getFirstValue("oldTreeish", ObjectId.NULL.toString()));
         setNewTreeish(options.getFirstValue("newTreeish", ObjectId.NULL.toString()));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FeatureDiffWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FeatureDiffWeb.java
@@ -30,6 +30,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 import org.opengis.feature.type.PropertyDescriptor;
 
@@ -54,6 +55,13 @@ public class FeatureDiffWeb extends AbstractWebAPICommand {
     private String oldTreeish;
 
     private boolean all;
+
+    public FeatureDiffWeb(ParameterSet options) {
+        setPath(options.getFirstValue("path", null));
+        setOldTreeish(options.getFirstValue("oldTreeish", ObjectId.NULL.toString()));
+        setNewTreeish(options.getFirstValue("newTreeish", ObjectId.NULL.toString()));
+        setAll(Boolean.valueOf(options.getFirstValue("all", "false")));
+    }
 
     /**
      * Mutator of the path variable
@@ -155,7 +163,8 @@ public class FeatureDiffWeb extends AbstractWebAPICommand {
             } else {
                 throw new CommandSpecException("Couldn't resolve newCommit's featureType");
             }
-            object = geogig.command(RevObjectParse.class).setObjectId(ref.get().getObjectId()).call();
+            object = geogig.command(RevObjectParse.class).setObjectId(ref.get().getObjectId())
+                    .call();
             if (object.isPresent() && object.get() instanceof RevFeature) {
                 newFeature = (RevFeature) object.get();
             } else {

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FetchWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FetchWebOp.java
@@ -11,12 +11,13 @@ package org.locationtech.geogig.web.api.commands;
 
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.porcelain.FetchOp;
-import org.locationtech.geogig.api.porcelain.TransferSummary;
 import org.locationtech.geogig.api.porcelain.SynchronizationException;
+import org.locationtech.geogig.api.porcelain.TransferSummary;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -31,6 +32,12 @@ public class FetchWebOp extends AbstractWebAPICommand {
     private boolean fetchAll;
 
     private String remote;
+
+    public FetchWebOp(ParameterSet options) {
+        setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
+        setPrune(Boolean.valueOf(options.getFirstValue("prune", "false")));
+        setRemote(options.getFirstValue("remote"));
+    }
 
     /**
      * Mutator for the prune variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FetchWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/FetchWebOp.java
@@ -34,6 +34,7 @@ public class FetchWebOp extends AbstractWebAPICommand {
     private String remote;
 
     public FetchWebOp(ParameterSet options) {
+        super(options);
         setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
         setPrune(Boolean.valueOf(options.getFirstValue("prune", "false")));
         setRemote(options.getFirstValue("remote"));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/GetCommitGraph.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/GetCommitGraph.java
@@ -19,6 +19,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.collect.Iterators;
@@ -38,6 +39,13 @@ public class GetCommitGraph extends AbstractWebAPICommand {
     private int page;
 
     private int elementsPerPage;
+
+    public GetCommitGraph(ParameterSet options) {
+        setDepth(parseInt(options, "depth", 0));
+        setCommitId(options.getFirstValue("commitId", ObjectId.NULL.toString()));
+        setPage(parseInt(options, "page", 0));
+        setElementsPerPage(parseInt(options, "show", 30));
+    }
 
     /**
      * Mutator for the commitId variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/GetCommitGraph.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/GetCommitGraph.java
@@ -41,6 +41,7 @@ public class GetCommitGraph extends AbstractWebAPICommand {
     private int elementsPerPage;
 
     public GetCommitGraph(ParameterSet options) {
+        super(options);
         setDepth(parseInt(options, "depth", 0));
         setCommitId(options.getFirstValue("commitId", ObjectId.NULL.toString()));
         setPage(parseInt(options, "page", 0));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Log.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Log.java
@@ -84,6 +84,7 @@ public class Log extends AbstractWebAPICommand {
     boolean summary = false;
 
     public Log(ParameterSet options) {
+        super(options);
         setLimit(parseInt(options, "limit", null));
         setOffset(parseInt(options, "offset", null));
         setPaths(Arrays.asList(options.getValuesArray("path")));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Log.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Log.java
@@ -13,6 +13,7 @@ import java.io.Writer;
 import java.sql.Time;
 import java.sql.Timestamp;
 import java.text.SimpleDateFormat;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Date;
 import java.util.Iterator;
@@ -39,6 +40,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 import org.locationtech.geogig.web.api.StreamResponse;
 import org.opengis.feature.type.PropertyDescriptor;
@@ -80,6 +82,22 @@ public class Log extends AbstractWebAPICommand {
     boolean returnRange = false;
 
     boolean summary = false;
+
+    public Log(ParameterSet options) {
+        setLimit(parseInt(options, "limit", null));
+        setOffset(parseInt(options, "offset", null));
+        setPaths(Arrays.asList(options.getValuesArray("path")));
+        setSince(options.getFirstValue("since"));
+        setUntil(options.getFirstValue("until"));
+        setSinceTime(options.getFirstValue("sinceTime"));
+        setUntilTime(options.getFirstValue("untilTime"));
+        setPage(parseInt(options, "page", 0));
+        setElementsPerPage(parseInt(options, "show", 30));
+        setFirstParentOnly(Boolean.valueOf(options.getFirstValue("firstParentOnly", "false")));
+        setCountChanges(Boolean.valueOf(options.getFirstValue("countChanges", "false")));
+        setReturnRange(Boolean.valueOf(options.getFirstValue("returnRange", "false")));
+        setSummary(Boolean.valueOf(options.getFirstValue("summary", "false")));
+    }
 
     /**
      * Mutator for the limit variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/LsTree.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/LsTree.java
@@ -40,6 +40,7 @@ public class LsTree extends AbstractWebAPICommand {
     List<String> refList;
 
     public LsTree(ParameterSet options) {
+        super(options);
         setIncludeTrees(Boolean.valueOf(options.getFirstValue("showTree", "false")));
         setOnlyTrees(Boolean.valueOf(options.getFirstValue("onlyTree", "false")));
         setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/LsTree.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/LsTree.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.web.api.commands;
 
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 
@@ -18,6 +19,7 @@ import org.locationtech.geogig.api.plumbing.LsTreeOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -36,6 +38,14 @@ public class LsTree extends AbstractWebAPICommand {
     boolean verbose;
 
     List<String> refList;
+
+    public LsTree(ParameterSet options) {
+        setIncludeTrees(Boolean.valueOf(options.getFirstValue("showTree", "false")));
+        setOnlyTrees(Boolean.valueOf(options.getFirstValue("onlyTree", "false")));
+        setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));
+        setVerbose(Boolean.valueOf(options.getFirstValue("verbose", "false")));
+        setRefList(Arrays.asList(options.getValuesArray("path")));
+    }
 
     /**
      * Mutator for the includeTrees variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
@@ -48,6 +48,7 @@ public class MergeWebOp extends AbstractWebAPICommand {
     private Optional<String> authorEmail = Optional.absent();
 
     public MergeWebOp(ParameterSet options) {
+        super(options);
         setNoCommit(Boolean.valueOf(options.getFirstValue("noCommit", "false")));
         setCommit(options.getFirstValue("commit", null));
         setAuthorName(options.getFirstValue("authorName", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/MergeWebOp.java
@@ -25,6 +25,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -45,6 +46,13 @@ public class MergeWebOp extends AbstractWebAPICommand {
     private Optional<String> authorName = Optional.absent();
 
     private Optional<String> authorEmail = Optional.absent();
+
+    public MergeWebOp(ParameterSet options) {
+        setNoCommit(Boolean.valueOf(options.getFirstValue("noCommit", "false")));
+        setCommit(options.getFirstValue("commit", null));
+        setAuthorName(options.getFirstValue("authorName", null));
+        setAuthorEmail(options.getFirstValue("authorEmail", null));
+    }
 
     /**
      * Mutator for the noCommit variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
@@ -30,6 +30,7 @@ import org.locationtech.geogig.api.porcelain.SynchronizationException;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -51,6 +52,14 @@ public class PullWebOp extends AbstractWebAPICommand {
     private Optional<String> authorName = Optional.absent();
 
     private Optional<String> authorEmail = Optional.absent();
+
+    public PullWebOp(ParameterSet options) {
+        setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
+        setRefSpec(options.getFirstValue("ref", null));
+        setRemoteName(options.getFirstValue("remoteName", null));
+        setAuthorName(options.getFirstValue("authorName", null));
+        setAuthorEmail(options.getFirstValue("authorEmail", null));
+    }
 
     /**
      * Mutator for the remoteName variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PullWebOp.java
@@ -54,6 +54,7 @@ public class PullWebOp extends AbstractWebAPICommand {
     private Optional<String> authorEmail = Optional.absent();
 
     public PullWebOp(ParameterSet options) {
+        super(options);
         setFetchAll(Boolean.valueOf(options.getFirstValue("all", "false")));
         setRefSpec(options.getFirstValue("ref", null));
         setRemoteName(options.getFirstValue("remoteName", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PushWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PushWebOp.java
@@ -32,6 +32,7 @@ public class PushWebOp extends AbstractWebAPICommand {
     private String refSpec;
 
     public PushWebOp(ParameterSet options) {
+        super(options);
         setPushAll(Boolean.valueOf(options.getFirstValue("all", "false")));
         setRefSpec(options.getFirstValue("ref", null));
         setRemoteName(options.getFirstValue("remoteName", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PushWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/PushWebOp.java
@@ -16,6 +16,7 @@ import org.locationtech.geogig.api.porcelain.TransferSummary;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -29,6 +30,12 @@ public class PushWebOp extends AbstractWebAPICommand {
     private boolean pushAll;
 
     private String refSpec;
+
+    public PushWebOp(ParameterSet options) {
+        setPushAll(Boolean.valueOf(options.getFirstValue("all", "false")));
+        setRefSpec(options.getFirstValue("ref", null));
+        setRemoteName(options.getFirstValue("remoteName", null));
+    }
 
     /**
      * Mutator for the remoteName variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RebuildGraphWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RebuildGraphWebOp.java
@@ -15,6 +15,7 @@ import org.locationtech.geogig.api.plumbing.RebuildGraphOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.collect.ImmutableList;
@@ -28,6 +29,10 @@ import com.google.common.collect.ImmutableList;
 public class RebuildGraphWebOp extends AbstractWebAPICommand {
 
     private boolean quiet = false;
+
+    public RebuildGraphWebOp(ParameterSet options) {
+        setQuiet(Boolean.valueOf(options.getFirstValue("quiet", "false")));
+    }
 
     /**
      * Mutator for the quiet variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RebuildGraphWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RebuildGraphWebOp.java
@@ -31,6 +31,7 @@ public class RebuildGraphWebOp extends AbstractWebAPICommand {
     private boolean quiet = false;
 
     public RebuildGraphWebOp(ParameterSet options) {
+        super(options);
         setQuiet(Boolean.valueOf(options.getFirstValue("quiet", "false")));
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RefParseWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RefParseWeb.java
@@ -32,6 +32,7 @@ public class RefParseWeb extends AbstractWebAPICommand {
     private String refSpec;
 
     public RefParseWeb(ParameterSet options) {
+        super(options);
         setName(options.getFirstValue("name", null));
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RefParseWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RefParseWeb.java
@@ -16,6 +16,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -29,6 +30,10 @@ import com.google.common.base.Optional;
 public class RefParseWeb extends AbstractWebAPICommand {
 
     private String refSpec;
+
+    public RefParseWeb(ParameterSet options) {
+        setName(options.getFirstValue("name", null));
+    }
 
     /**
      * Mutator for the refSpec variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoteWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoteWebOp.java
@@ -61,6 +61,7 @@ public class RemoteWebOp extends AbstractWebAPICommand {
     private String password = null;
 
     public RemoteWebOp(ParameterSet options) {
+        super(options);
         setList(Boolean.valueOf(options.getFirstValue("list", "false")));
         setRemove(Boolean.valueOf(options.getFirstValue("remove", "false")));
         setPing(Boolean.valueOf(options.getFirstValue("ping", "false")));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoteWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoteWebOp.java
@@ -27,6 +27,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -58,6 +59,19 @@ public class RemoteWebOp extends AbstractWebAPICommand {
     private String username = null;
 
     private String password = null;
+
+    public RemoteWebOp(ParameterSet options) {
+        setList(Boolean.valueOf(options.getFirstValue("list", "false")));
+        setRemove(Boolean.valueOf(options.getFirstValue("remove", "false")));
+        setPing(Boolean.valueOf(options.getFirstValue("ping", "false")));
+        setUpdate(Boolean.valueOf(options.getFirstValue("update", "false")));
+        setVerbose(Boolean.valueOf(options.getFirstValue("verbose", "false")));
+        setRemoteName(options.getFirstValue("remoteName", null));
+        setNewName(options.getFirstValue("newName", null));
+        setRemoteURL(options.getFirstValue("remoteURL", null));
+        setUserName(options.getFirstValue("username", null));
+        setPassword(options.getFirstValue("password", null));
+    }
 
     /**
      * Mutator for the list variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoveWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoveWebOp.java
@@ -32,6 +32,7 @@ public class RemoveWebOp extends AbstractWebAPICommand {
     private boolean recursive;
 
     public RemoveWebOp(ParameterSet options) {
+        super(options);
         setPath(options.getFirstValue("path", null));
         setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));
     }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoveWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RemoveWebOp.java
@@ -16,6 +16,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -29,6 +30,11 @@ public class RemoveWebOp extends AbstractWebAPICommand {
     private String path;
 
     private boolean recursive;
+
+    public RemoveWebOp(ParameterSet options) {
+        setPath(options.getFirstValue("path", null));
+        setRecursive(Boolean.valueOf(options.getFirstValue("recursive", "false")));
+    }
 
     /**
      * Mutator for the path variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/ResolveConflict.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/ResolveConflict.java
@@ -30,6 +30,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
@@ -49,6 +50,11 @@ public class ResolveConflict extends AbstractWebAPICommand {
     private String path;
 
     private ObjectId objectId;
+
+    public ResolveConflict(ParameterSet options) {
+        setPath(options.getFirstValue("path", null));
+        setFeatureObjectId(options.getFirstValue("objectid", null));
+    }
 
     /**
      * Mutator for the path variable
@@ -126,9 +132,10 @@ public class ResolveConflict extends AbstractWebAPICommand {
             treeBuilder = new RevTreeBuilder(geogig.objectDatabase());
         }
         treeBuilder.put(node.getNode());
-        ObjectId newTreeId = geogig.command(WriteBack.class)
-                .setAncestor(new RevTreeBuilder(geogig.objectDatabase(),
-                        geogig.workingTree().getTree()))
+        ObjectId newTreeId = geogig
+                .command(WriteBack.class)
+                .setAncestor(
+                        new RevTreeBuilder(geogig.objectDatabase(), geogig.workingTree().getTree()))
                 .setChildPath(node.getParentPath()).setTree(treeBuilder.build())
                 .setMetadataId(metadataId).call();
         geogig.workingTree().updateWorkHead(newTreeId);

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/ResolveConflict.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/ResolveConflict.java
@@ -52,6 +52,7 @@ public class ResolveConflict extends AbstractWebAPICommand {
     private ObjectId objectId;
 
     public ResolveConflict(ParameterSet options) {
+        super(options);
         setPath(options.getFirstValue("path", null));
         setFeatureObjectId(options.getFirstValue("objectid", null));
     }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
@@ -35,6 +35,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -63,6 +64,16 @@ public class RevertFeatureWebOp extends AbstractWebAPICommand {
     private Optional<String> commitMessage = Optional.absent();
 
     private Optional<String> mergeMessage = Optional.absent();
+
+    public RevertFeatureWebOp(ParameterSet options) {
+        setAuthorName(options.getFirstValue("authorName", null));
+        setAuthorEmail(options.getFirstValue("authorEmail", null));
+        setCommitMessage(options.getFirstValue("commitMessage", null));
+        setMergeMessage(options.getFirstValue("mergeMessage", null));
+        setNewCommitId(options.getFirstValue("newCommitId", null));
+        setOldCommitId(options.getFirstValue("oldCommitId", null));
+        setPath(options.getFirstValue("path", null));
+    }
 
     /**
      * Mutator for the featurePath variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RevertFeatureWebOp.java
@@ -66,6 +66,7 @@ public class RevertFeatureWebOp extends AbstractWebAPICommand {
     private Optional<String> mergeMessage = Optional.absent();
 
     public RevertFeatureWebOp(ParameterSet options) {
+        super(options);
         setAuthorName(options.getFirstValue("authorName", null));
         setAuthorEmail(options.getFirstValue("authorEmail", null));
         setCommitMessage(options.getFirstValue("commitMessage", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/StatisticsWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/StatisticsWebOp.java
@@ -28,6 +28,7 @@ import org.locationtech.geogig.api.porcelain.LogOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -45,6 +46,12 @@ public class StatisticsWebOp extends AbstractWebAPICommand {
     String since;
 
     String until;
+
+    public StatisticsWebOp(ParameterSet options) {
+        setPath(options.getFirstValue("path", null));
+        setSince(options.getFirstValue("since", null));
+        setUntil(options.getFirstValue("branch", null));
+    }
 
     public void setPath(String path) {
         this.path = path;

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/StatisticsWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/StatisticsWebOp.java
@@ -48,6 +48,7 @@ public class StatisticsWebOp extends AbstractWebAPICommand {
     String until;
 
     public StatisticsWebOp(ParameterSet options) {
+        super(options);
         setPath(options.getFirstValue("path", null));
         setSince(options.getFirstValue("since", null));
         setUntil(options.getFirstValue("branch", null));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Status.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Status.java
@@ -19,6 +19,7 @@ import org.locationtech.geogig.api.plumbing.merge.ConflictsReadOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -35,6 +36,10 @@ public class Status extends AbstractWebAPICommand {
 
     int limit = -1;
 
+    public Status(ParameterSet options){
+        setLimit(parseInt(options, "limit", 50));
+        setOffset(parseInt(options, "offset", 0));
+    }
     /**
      * Mutator for the offset variable
      * 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Status.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/Status.java
@@ -37,6 +37,7 @@ public class Status extends AbstractWebAPICommand {
     int limit = -1;
 
     public Status(ParameterSet options){
+        super(options);
         setLimit(parseInt(options, "limit", 50));
         setOffset(parseInt(options, "offset", 0));
     }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/TagWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/TagWebOp.java
@@ -31,6 +31,7 @@ public class TagWebOp extends AbstractWebAPICommand {
     private boolean list;
 
     public TagWebOp(ParameterSet options) {
+        super(options);
         setList(Boolean.valueOf(options.getFirstValue("list", "false")));
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/TagWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/TagWebOp.java
@@ -17,6 +17,7 @@ import org.locationtech.geogig.api.porcelain.TagListOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -28,6 +29,10 @@ import org.locationtech.geogig.web.api.ResponseWriter;
 public class TagWebOp extends AbstractWebAPICommand {
 
     private boolean list;
+
+    public TagWebOp(ParameterSet options) {
+        setList(Boolean.valueOf(options.getFirstValue("list", "false")));
+    }
 
     /**
      * Mutator for the list variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/UpdateRefWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/UpdateRefWeb.java
@@ -41,6 +41,7 @@ public class UpdateRefWeb extends AbstractWebAPICommand {
     private boolean delete;
 
     public UpdateRefWeb(ParameterSet options) {
+        super(options);
         setName(options.getFirstValue("name", null));
         setDelete(Boolean.valueOf(options.getFirstValue("delete", "false")));
         setNewValue(options.getFirstValue("newValue", ObjectId.NULL.toString()));

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/UpdateRefWeb.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/UpdateRefWeb.java
@@ -21,6 +21,7 @@ import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
 import org.locationtech.geogig.web.api.CommandSpecException;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 import com.google.common.base.Optional;
@@ -38,6 +39,12 @@ public class UpdateRefWeb extends AbstractWebAPICommand {
     private String newValue;
 
     private boolean delete;
+
+    public UpdateRefWeb(ParameterSet options) {
+        setName(options.getFirstValue("name", null));
+        setDelete(Boolean.valueOf(options.getFirstValue("delete", "false")));
+        setNewValue(options.getFirstValue("newValue", ObjectId.NULL.toString()));
+    }
 
     /**
      * Mutator for the name variable

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/VersionWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/VersionWebOp.java
@@ -27,7 +27,7 @@ import org.locationtech.geogig.web.api.ResponseWriter;
 public class VersionWebOp extends AbstractWebAPICommand {
 
     public VersionWebOp(ParameterSet options) {
-        // no-op
+        super(options);
     }
 
     /**

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/VersionWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/VersionWebOp.java
@@ -15,6 +15,7 @@ import org.locationtech.geogig.api.porcelain.VersionOp;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.ResponseWriter;
 
 /**
@@ -24,6 +25,10 @@ import org.locationtech.geogig.web.api.ResponseWriter;
  */
 
 public class VersionWebOp extends AbstractWebAPICommand {
+
+    public VersionWebOp(ParameterSet options) {
+        // no-op
+    }
 
     /**
      * Runs the command and builds the appropriate response.


### PR DESCRIPTION
WEB API's `CommandBuilder` was cumbersome to maintain with so many conditionals.

This PR makes use of Java 8's method arguments to remove all the boilerplate