### PR TITLE
Adding in JaCoCo maven plugin for code coverage

### DIFF
--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -133,6 +133,7 @@
     <online.skip.pattern>**/*OnlineTest.java</online.skip.pattern>
     <sqlServerOnline.skip.pattern>**/*SQLServerFunctionalTest.java</sqlServerOnline.skip.pattern>
     <allow.test.skip>true</allow.test.skip>
+    <argLine>-Xms256m -Xmx512m</argLine>
   </properties>
 
   <dependencyManagement>
@@ -427,7 +428,6 @@
           </excludes>
           <forkCount>1C</forkCount> <!-- i.e. 1 x # of processor cores -->
           <reuseForks>true</reuseForks>
-          <argLine>-Xms256m -Xmx512m</argLine>
           <workingDirectory>${project.build.directory}</workingDirectory>
           <systemPropertyVariables>
             <java.io.tmpdir>${test.tmpDir}</java.io.tmpdir>
@@ -514,6 +514,40 @@
           <generateGitPropertiesFilename>src/main/resources/git.properties</generateGitPropertiesFilename>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.6.201602180812</version>
+        <configuration>
+          <excludes>
+            <exclude>**/*Exception.class</exclude>
+          </excludes>
+        </configuration>
+        <executions>
+          <execution>
+            <id>pre-unit-test</id>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <!-- 
+              uncomment this to enable automatic coverage reports during test phase 
+              To generate reports manually, specify the jacoco:report goal at the end
+              of the mavne command. Example:
+              
+              mvn clean insatll jacoco:report
+          -->
+          <!--
+          <execution>
+            <id>post-unit-test</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
+          -->
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -547,21 +581,6 @@
         <version>2.16</version>
         <configuration>
           <aggregate>true</aggregate>
-        </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>cobertura-maven-plugin</artifactId>
-        <version>2.6</version>
-        <configuration>
-          <aggregate>true</aggregate>
-          <instrumentation>
-            <!-- ignores> <ignore>**/*Exception.class</ignore> </ignores -->
-            <excludes>
-              <exclude>**/*Exception.class</exclude>
-            </excludes>
-            <!-- includes> <include>**/*Test.class</include> </includes -->
-          </instrumentation>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
- Add the JaCoCo maven plugin to the parent
- JaCoCo can parse/handle Java 8 syntax in places where Cobertura 2.6/2.7 can't

There are 2 JaCoCo goals that have to be executed at the correct time during the maven build to generate reports: `jacoco:prepare-agent` and `jacoco:report`.

`jacoco:prepare-agent` creates an agent for collecting the coverage metrics during test execution (a file in each module's `target` build directory) and injects a property pointing to this file during the build. Having this goal enabled automatically is convenient and has little impact to the build.

`jacoco:report` generates XML, CSV and HTML reports for each module under the module's `target/site/jacoco` directory. Having this goal enabled automatically means every time the `test` goal is executed, reports will be generated.

**Option 1: Don't automatically execute JaCoCo goals**
The pom can be changed to not enable either goal by default, requiring both goals to be specified on the command line, and in the right order, to generate reports. Specifically, `jacoco:prepare-agent` must be executed prior to any goal that executes the `test` goal, and the `jacoco:report` goal must be executed after any goal that executes the `test` goal. Example:

`mvn clean jacoco:prepare-agent test jacoco:report`

**Option 2: Automatically execute `prepare-agent`, but don't automatically execute `report`**
The pom can be changed to automatically execute `jacoco:prepare-agent`, requiring only the `jacoco:report` goal to be specified when reports are desired. Example:

`mvn clean test jacoco:report`

**Option 3: Automatically execute both goals (reports are always generated when tests are run)**
This is the way the pom exists currently. Coverage reports will be generated for each module whenever tests are executed (i.e. `test` goal, `package` goal, `install` goal, etc...)

`mvn clean test`
`mvn clean package`
`mvn clean install`

would all generate coverage reports.