### PR TITLE
Organize top-level routes to prevent conflicts.

### DIFF
--- a/doc/manual/source/interaction/web-api.rst
+++ b/doc/manual/source/interaction/web-api.rst
@@ -3,7 +3,7 @@ Web-Api Documentation
 
 This will walk you through GeoGig's web-api and all of its currently supported functionality. This doc also assumes that you already know what any given command does, this is strictly how to use these commands. First I will explain an easy way to get the web-api up and running.
 
-If you don't already have the GeoGig source from GitHub and a GeoGig repository set up do that first. Next, to get the web-api up and running after you have built the latest GeoGig go into your repository and run ``geogig serve``. This will set up a jetty server with your repository and give you access to the web-api. Now you just need to open up a web browser and go to localhost:8182/log to make sure it comes up. After you have gotten it up and running now you can test any of the commands listed here.
+If you don't already have the GeoGig source from GitHub and a GeoGig repository set up do that first. Next, to get the web-api up and running after you have built the latest GeoGig go into your repository and run ``geogig serve``. This will set up a jetty server with your repository and give you access to the web-api. Now you just need to open up a web browser and go to localhost:8182/repos/<repo name>/log to make sure it comes up. After you have gotten it up and running now you can test any of the commands listed here.
 
 All web-api commands have transaction support, which means you can run the web-api commands beginTransaction to start a transaction and then use the id that is returned to do other commands on that transaction instead of the actual repository. After you are done with everything on the transaction you just have call endTransaction through the web-api and pass it the transaction id. Some commands require a transaction to preserve the stability of the repository, those that require it will have ``(-T)`` next to the name of the command in this doc. To pass the transaction id you just need to use the transactionId option and set it equal to the id that beginTransaction returns. Some commands also have other options that are required for that command to work they will have a ``(-R)`` next to them. Any options that have notes associated with them have and asterisk next to them.
 
@@ -28,7 +28,7 @@ Porcelain Commands Supported
  	 
  	 ::
 
-	   localhost:8182/add?path=tree/fid&transactionId=id
+	   localhost:8182/repos/<repo name>/add?path=tree/fid&transactionId=id
 	   
 	 **Output:**
 	
@@ -56,7 +56,7 @@ Porcelain Commands Supported
 		
  	::
  
- 	  localhost:8182/blame?path=pathToFeature&commit=commitId
+ 	  localhost:8182/repos/<repo name>/blame?path=pathToFeature&commit=commitId
 	
 	**Output:**
 	
@@ -84,7 +84,7 @@ Porcelain Commands Supported
 		
  	 ::
 
-	   localhost:8182/branch?list=true&remote=true
+	   localhost:8182/repos/<repo name>/branch?list=true&remote=true
 	
 	 **Output:**
 	
@@ -124,7 +124,7 @@ Porcelain Commands Supported
 		
  	 ::
 
-	   localhost:8182/checkout?branch=master&transactionId=id
+	   localhost:8182/repos/<repo name>/checkout?branch=master&transactionId=id
 	       	  localhost:8182/checkout?path=tree/fid&ours=true&transactionId=id
 	
 	 **Output:**
@@ -167,7 +167,7 @@ Porcelain Commands Supported
 		
  	::
 
-	 localhost:8182/commit?authorName=John&authorEmail=john@example.com&message=something&all=true&transactionId=id
+	 localhost:8182/repos/<repo name>/commit?authorName=John&authorEmail=john@example.com&message=something&all=true&transactionId=id
 	
 	**Output:**
 	
@@ -219,7 +219,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/diff?oldRefSpec=commitId1&newRefSpec=commitId2&showGeometryChanges=true&show=100
+	  localhost:8182/repos/<repo name>/diff?oldRefSpec=commitId1&newRefSpec=commitId2&showGeometryChanges=true&show=100
 	
 	**Output:**
 	
@@ -253,7 +253,7 @@ Porcelain Commands Supported
 		
  	::
  	
-	  localhost:8182/fetch?prune=true&remote=origin
+	  localhost:8182/repos/<repo name>/fetch?prune=true&remote=origin
 	
 	**Output:**
 	
@@ -349,8 +349,8 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/log?path=treeName&firstParentOnly=true
-	  localhost:8182/log?summary=true&path=treeName&output_format=csv
+	  localhost:8182/repos/<repo name>/log?path=treeName&firstParentOnly=true
+	  localhost:8182/repos/<repo name>/log?summary=true&path=treeName&output_format=csv
 	
 	**Output:**
 	
@@ -392,7 +392,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/merge?commit=branch1&noCommit=true&transactionId=id
+	  localhost:8182/repos/<repo name>/merge?commit=branch1&noCommit=true&transactionId=id
 	
 	**Output:**
 	
@@ -440,7 +440,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/pull?remoteName=origin&all=true&ref=master:master
+	  localhost:8182/repos/<repo name>/pull?remoteName=origin&all=true&ref=master:master
 	
 	**Output:**
 	
@@ -476,7 +476,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/push?ref=master:master&remoteName=origin
+	  localhost:8182/repos/<repo name>/push?ref=master:master&remoteName=origin
 	  
 	
 	**Output:**
@@ -555,11 +555,11 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/remote?list=true&verbose=true
-	  localhost:8182/remote?remove=true&remoteName=origin
-	  localhost:8182/remote?remoteName=origin&remoteURL=urlToRepo.com
-	  localhost:8182/remote?ping=true&remoteName=origin
-	  localhost:8182/remote?update=true&newName=origin&remoteName=remote1&remoteURL=urlToRepo.com
+	  localhost:8182/repos/<repo name>/remote?list=true&verbose=true
+	  localhost:8182/repos/<repo name>/remote?remove=true&remoteName=origin
+	  localhost:8182/repos/<repo name>/remote?remoteName=origin&remoteURL=urlToRepo.com
+	  localhost:8182/repos/<repo name>/remote?ping=true&remoteName=origin
+	  localhost:8182/repos/<repo name>/remote?update=true&newName=origin&remoteName=remote1&remoteURL=urlToRepo.com
 	
 	**Output:**
 	
@@ -587,8 +587,8 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/remove?path=treeName/fid&transactionId=id
-	  localhost:8182/remove?path=treeName&recursive=true&transactionId=id
+	  localhost:8182/repos/<repo name>/remove?path=treeName/fid&transactionId=id
+	  localhost:8182/repos/<repo name>/remove?path=treeName&recursive=true&transactionId=id
 	
 	**Output:**
 	
@@ -617,7 +617,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/status?limit=100
+	  localhost:8182/repos/<repo name>/status?limit=100
 	
 	**Output:**
 	
@@ -639,7 +639,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/tag?list=true
+	  localhost:8182/repos/<repo name>/tag?list=true
 	
 	**Output:**
 	
@@ -657,7 +657,7 @@ Porcelain Commands Supported
 		
  	::
 
-	  localhost:8182/version
+	  localhost:8182/repos/<repo name>/version
 	
 	**Output:**
 	
@@ -678,7 +678,7 @@ Plumbing Commands Supported
 		
  	::
 
-	  localhost:8182/beginTransaction
+	  localhost:8182/repos/<repo name>/beginTransaction
 	
 	**Output:**
 	
@@ -700,7 +700,7 @@ Plumbing Commands Supported
 		
  	::
 
-	  localhost:8182/endTransaction?cancel=true&transactionId=id
+	  localhost:8182/repos/<repo name>/endTransaction?cancel=true&transactionId=id
 	
 	**Output:**
 	
@@ -740,7 +740,7 @@ Plumbing Commands Supported
 		
  	::
 	 
-	  localhost:8182/featurediff?path=treeName/fid&newTreeish=commitId1&oldTreeish=commitId2
+	  localhost:8182/repos/<repo name>/featurediff?path=treeName/fid&newTreeish=commitId1&oldTreeish=commitId2
 	
 	**Output:**
 	
@@ -788,7 +788,7 @@ Plumbing Commands Supported
 		
  	::
 
-	  localhost:8182/ls-tree?showTree=true&recursive=true&verbose=true
+	  localhost:8182/repos/<repo name>/ls-tree?showTree=true&recursive=true&verbose=true
 	
 	**Output:**
 	
@@ -812,7 +812,7 @@ Plumbing Commands Supported
 		
  	::
  
- 	  localhost:8182/rebuildgraph?quiet=true
+ 	  localhost:8182/repos/<repo name>/rebuildgraph?quiet=true
 	
 	**Output:**
 	
@@ -834,7 +834,7 @@ Plumbing Commands Supported
 		
  	::
 
-	  localhost:8182/refparse?name=master
+	  localhost:8182/repos/<repo name>/refparse?name=master
 	
 	**Output:**
 	
@@ -868,7 +868,7 @@ Plumbing Commands Supported
 		
  	::
 
-	  localhost:8182/updateref?name=master&newValue=branch1
+	  localhost:8182/repos/<repo name>/updateref?name=master&newValue=branch1
 	
 	**Output:**
 	
@@ -915,7 +915,7 @@ Web-Api Specific
 		
  	::
 
-	  localhost:8182/getCommitGraph?show=100
+	  localhost:8182/repos/<repo name>/getCommitGraph?show=100
 	
 	**Output:**
 	
@@ -945,7 +945,7 @@ Web-Api Specific
 		
  	::
  			
-	  localhost:8182/resolveconflict?path=pathToFeature&objectid=featureObjectId
+	  localhost:8182/repos/<repo name>/resolveconflict?path=pathToFeature&objectid=featureObjectId
 	
 	**Output:**
 	
@@ -1005,7 +1005,7 @@ Web-Api Specific
 		
  	::
  
- 	    localhost:8182/revertfeature?authorName=John&authorEmail=John@example.com&commitMessage="Reverted Feature"&mergeMessage="Merge of reverted feature"&newCommitId=commitId1&oldCommitId=commitId2&path=pathToFeature
+ 	    localhost:8182/repos/<repo name>/revertfeature?authorName=John&authorEmail=John@example.com&commitMessage="Reverted Feature"&mergeMessage="Merge of reverted feature"&newCommitId=commitId1&oldCommitId=commitId2&path=pathToFeature
 	
 	**Output:**
 	
@@ -1016,7 +1016,7 @@ Web-Api Specific
 Repo Commands
 -----------------------------
 
-These commands can be used by using the ``repo/`` endpoint, instead of the standard ``/`` endpoint.
+These commands can be used by using the ``repos/<repo name>/repo/`` endpoint, instead of the standard ``repos/<repo name>/`` endpoint.
 
  .. note:: The output format for all repo commands is plain text.
 
@@ -1048,7 +1048,7 @@ These commands can be used by using the ``repo/`` endpoint, instead of the stand
 		
     ::
 
-      localhost:8182/repo/mergefeature
+      localhost:8182/repos/<repo name>/repo/mergefeature
 	
     **Output:**
 	
@@ -1064,7 +1064,7 @@ These commands can be used by using the ``repo/`` endpoint, instead of the stand
 		
     ::
 
-      localhost:8182/repo/manifest
+      localhost:8182/repos/<repo name>/repo/manifest
 	
     **Output:**
 	

--- a/src/core/src/main/java/org/locationtech/geogig/repository/DefaultRepositoryResolver.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/DefaultRepositoryResolver.java
@@ -26,6 +26,7 @@ import org.locationtech.geogig.storage.fs.IniFileConfigDatabase;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
 import com.google.common.io.Resources;
 
 public class DefaultRepositoryResolver extends RepositoryResolver {
@@ -64,8 +65,13 @@ public class DefaultRepositoryResolver extends RepositoryResolver {
     @Override
     public String getName(URI repoURI) {
         File file = toFile(repoURI);
-        if (file.getName().equals(".geogig")) {
-            file = file.getParentFile();
+        try {
+            file = file.getCanonicalFile();
+            if (file.getName().equals(".geogig")) {
+                file = file.getParentFile();
+            }
+        } catch (IOException e) {
+            Throwables.propagate(e);
         }
         return file.getName();
     }

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/repository/RepositoryProvider.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/repository/RepositoryProvider.java
@@ -18,6 +18,8 @@ import com.google.common.base.Optional;
 
 public interface RepositoryProvider {
 
+    static final String BASE_REPOSITORY_ROUTE = "repos";
+
     /**
      * Key used too lookup the {@link RepositoryProvider} instance in the
      * {@link Request#getAttributes() request attributes}

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/InitWebOp.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/InitWebOp.java
@@ -17,6 +17,7 @@ import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
 import org.locationtech.geogig.api.porcelain.InitOp;
 import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.repository.RepositoryResolver;
+import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
@@ -86,7 +87,7 @@ public class InitWebOp extends AbstractWebAPICommand {
                     out.getWriter().writeStartElement("repo");
                     out.writeElement("name", repositoryName);
                     out.encodeAlternateAtomLink(out.getWriter(), context.getBaseURL(),
-                            repositoryName);
+                            RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + repositoryName);
                     out.getWriter().writeEndElement();
                     out.finish();
                 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RenameRepository.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/commands/RenameRepository.java
@@ -18,6 +18,7 @@ import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
 import org.locationtech.geogig.api.porcelain.ConfigOp;
 import org.locationtech.geogig.api.porcelain.ConfigOp.ConfigAction;
 import org.locationtech.geogig.api.porcelain.ConfigOp.ConfigScope;
+import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.CommandResponse;
@@ -90,7 +91,8 @@ public class RenameRepository extends AbstractWebAPICommand {
                 out.start();
                 out.getWriter().writeStartElement("repo");
                 out.writeElement("name", repositoryName);
-                out.encodeAlternateAtomLink(out.getWriter(), context.getBaseURL(), repositoryName);
+                out.encodeAlternateAtomLink(out.getWriter(), context.getBaseURL(),
+                        RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + repositoryName);
                 out.getWriter().writeEndElement();
                 out.finish();
             }

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/InitWebOpTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/InitWebOpTest.java
@@ -17,6 +17,7 @@ import static org.junit.Assert.assertTrue;
 import org.codehaus.jettison.json.JSONObject;
 import org.junit.Test;
 import org.locationtech.geogig.rest.repository.RESTUtils;
+import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.AbstractWebOpTest;
 import org.locationtech.geogig.web.api.CommandSpecException;
@@ -64,7 +65,7 @@ public class InitWebOpTest extends AbstractWebOpTest {
         cmd.run(testContext.get());
 
         String expectedURL = RESTUtils.buildHref(testContext.get().getBaseURL(),
-                TestRepository.REPO_NAME,
+                RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + TestRepository.REPO_NAME,
                 MediaType.APPLICATION_JSON);
 
         assertNotNull(testContext.get().getGeoGIG().getRepository());

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/RenameRepositoryTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/RenameRepositoryTest.java
@@ -16,6 +16,7 @@ import org.junit.Test;
 import org.locationtech.geogig.api.plumbing.ResolveRepositoryName;
 import org.locationtech.geogig.rest.RestletException;
 import org.locationtech.geogig.rest.repository.RESTUtils;
+import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.AbstractWebOpTest;
 import org.locationtech.geogig.web.api.ParameterSet;
@@ -62,7 +63,8 @@ public class RenameRepositoryTest extends AbstractWebOpTest {
 
         assertEquals("newRepoName", repoName);
 
-        String expectedURL = RESTUtils.buildHref(testContext.get().getBaseURL(), "newRepoName",
+        String expectedURL = RESTUtils.buildHref(testContext.get().getBaseURL(),
+                RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + "newRepoName",
                 MediaType.APPLICATION_JSON);
 
         JSONObject response = getJSONResponse().getJSONObject("response");

--- a/src/web/app/src/main/java/org/locationtech/geogig/web/DirectoryRepositoryProvider.java
+++ b/src/web/app/src/main/java/org/locationtech/geogig/web/DirectoryRepositoryProvider.java
@@ -141,6 +141,7 @@ public class DirectoryRepositoryProvider implements RepositoryProvider {
         }
     }
 
+    @Override
     public Iterator<String> findRepositories() {
         try {
             loadRepositories();

--- a/src/web/app/src/main/java/org/locationtech/geogig/web/Main.java
+++ b/src/web/app/src/main/java/org/locationtech/geogig/web/Main.java
@@ -109,25 +109,23 @@ public class Main extends Application {
                 request.getAttributes().put(RepositoryProvider.KEY, repoProvider);
             }
         };
-        final Router singleRepoRouter;
 
-        if (multiRepo) {
-            singleRepoRouter = new Router();
-            router.attach("/", new RepositoryFinder(repoProvider));
-            router.attach("/{repository}", singleRepoRouter);
-        } else {
-            singleRepoRouter = router;
-        }
+        router.attach("/tasks", TaskStatusResource.class);
+        router.attach("/tasks/{taskId}.{extension}", TaskStatusResource.class);
+        router.attach("/tasks/{taskId}", TaskStatusResource.class);
+        router.attach("/tasks/{taskId}/download", TaskResultDownloadResource.class);
+
+        router.attach("/" + RepositoryProvider.BASE_REPOSITORY_ROUTE,
+                new RepositoryFinder(repoProvider));
+
+        final Router singleRepoRouter = new Router();
+        router.attach("/" + RepositoryProvider.BASE_REPOSITORY_ROUTE + "/{repository}",
+                singleRepoRouter);
 
         Router repo = new RepositoryRouter();
         Router osm = new OSMRouter();
         Router postgis = new PGRouter();
         singleRepoRouter.attach("", DeleteRepository.class);
-
-        singleRepoRouter.attach("/tasks", TaskStatusResource.class);
-        singleRepoRouter.attach("/tasks/{taskId}.{extension}", TaskStatusResource.class);
-        singleRepoRouter.attach("/tasks/{taskId}", TaskStatusResource.class);
-        singleRepoRouter.attach("/tasks/{taskId}/download", TaskResultDownloadResource.class);
 
         singleRepoRouter.attach("/osm", osm);
         singleRepoRouter.attach("/postgis", postgis);

--- a/src/web/app/src/main/java/org/locationtech/geogig/web/RepositoryFinder.java
+++ b/src/web/app/src/main/java/org/locationtech/geogig/web/RepositoryFinder.java
@@ -91,15 +91,15 @@ public class RepositoryFinder extends Finder {
             @Override
             protected void write(XMLStreamWriter w) throws XMLStreamException {
                 w.writeStartElement("repos");
-                Iterator<String> repos = ((DirectoryRepositoryProvider) repoProvider)
-                        .findRepositories();
+                Iterator<String> repos = repoProvider.findRepositories();
                 while (repos.hasNext()) {
                     String repoName = repos.next();
                     w.writeStartElement("repo");
                     w.writeStartElement("name");
                     w.writeCharacters(repoName);
                     w.writeEndElement();
-                    encodeAlternateAtomLink(w, repoName);
+                    encodeAlternateAtomLink(w,
+                            RepositoryProvider.BASE_REPOSITORY_ROUTE + "/" + repoName);
                     w.writeEndElement();
                 }
                 w.writeEndElement();

--- a/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
@@ -99,7 +99,7 @@ public class WebAPICucumberHooks {
 
     @Given("^There is an empty repository named ([^\"]*)$")
     public void setUpEmptyRepo(String name) throws Throwable {
-        String urlSpec = "/" + name + "/init";
+        String urlSpec = "/repos/" + name + "/init";
         Response response = context.callDontSaveResponse(Method.PUT, urlSpec);
         assertStatusCode(response, Status.SUCCESS_CREATED.getCode());
     }
@@ -363,8 +363,7 @@ public class WebAPICucumberHooks {
     }
 
     private String getAsyncTaskAsXML(final Integer taskId) throws IOException {
-        // TODO: this must be changed to /tasks/%d once we fix the top level routing
-        String url = String.format("/repo1/tasks/%d", taskId);
+        String url = String.format("/tasks/%d", taskId);
         Response taskResponse = context.callDontSaveResponse(Method.GET, url);
         String text = taskResponse.getEntity().getText();
         // System.err.println(text);

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/CreateRepository.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/CreateRepository.feature
@@ -1,19 +1,19 @@
 @RepositoryManagement
 Feature: Create Repository
-  Creating a repository on the server is done through the "/{repository}/init" command
+  Creating a repository on the server is done through the "/repos/{repository}/init" command
   The command must be executed using the HTTP PUT method
   If a repository with the provided name already exists, then a 409 "Conflict" error code shall be returned
   If the command succeeds, the response status code is 201 "Created"
 
   Scenario: Verify wrong HTTP method issues 405 "Method not allowed"
     Given There is an empty multirepo server
-    When I call "GET /repo1/init"
+    When I call "GET /repos/repo1/init"
     Then the response status should be '405'
     And the response allowed methods should be "PUT"
 
   Scenario: Verify trying to create an existing repo issues 409 "Conflict"
     Given There is a default multirepo server
-    When I call "PUT /repo1/init"
+    When I call "PUT /repos/repo1/init"
     Then the response status should be '409'
     And the response ContentType should be "application/xml"
     And the xpath "/response/success/text()" equals "false"
@@ -21,7 +21,7 @@ Feature: Create Repository
 
   Scenario: Create repository on empty server
     Given There is an empty multirepo server
-    When I call "PUT /repo1/init"
+    When I call "PUT /repos/repo1/init"
     Then the response status should be '201'
     And the response ContentType should be "application/xml"
     And the response xml matches
@@ -30,7 +30,7 @@ Feature: Create Repository
         <success>true</success>
         <repo>
           <name>repo1</name>
-          <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="/repo1.xml" type="application/xml"/>
+          <atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="/repos/repo1.xml" type="application/xml"/>
         </repo>
       </response>
       """

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/DeleteRepository.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/DeleteRepository.feature
@@ -2,42 +2,42 @@
 Feature: Delete Repository
 	Deleting a repository through the web API is a non reversible operation.
   * In order to avoid accidental deletion of repositories, it is a two-step process:
-  * first a GET call to "/{repository}/delete" returns an automatically generated token with the format:
+  * first a GET call to "/repos/{repository}/delete" returns an automatically generated token with the format:
   * <response><success>true</success><token>d713df9c703733e2</token></response>.
-  * To actually delete the repository, a HTTP DELETE method call to "/{repository}?token={token}" must be issued, with a valid and non expired token.
+  * To actually delete the repository, a HTTP DELETE method call to "/repos/{repository}?token={token}" must be issued, with a valid and non expired token.
   * An attempt to delete a non existent repository, results in a 404 "Not found" error code.
   * A successfull DELETE operation returns a 200 status code,
   * the XML response body is <deleted>true</deleted>, the JSON response body is '{"deleted":true}'
   
   Scenario: Requesting delete token with wrong HTTP Method issues 405 "Method not allowed"
     Given There is a default multirepo server
-     When I call "POST /repo1/delete"
+     When I call "POST /repos/repo1/delete"
      Then the response status should be '405'
       And the response allowed methods should be "GET"
       
   Scenario: Requesting a delete token for a non existent repository issues 404 "Not found"
     Given There is a default multirepo server
-     When I call "GET /nonExistentRepo/delete"
+     When I call "GET /repos/nonExistentRepo/delete"
      Then the response status should be '404'
       And the response ContentType should be "text/plain"
       And the response body should contain "Repository not found"
 
   Scenario: Try deleting a non existent repository issues 404 "Not found"
     Given There is a default multirepo server
-     When I call "DELETE /nonExistentRepo?token=someToken"
+     When I call "DELETE /repos/nonExistentRepo?token=someToken"
      Then the response status should be '404'
       And the response ContentType should be "text/plain"
       And the response body should contain "error:No repository to delete."
 
   Scenario: Succesfully delete a repository
     Given There is a default multirepo server
-     When I call "GET /repo2/delete"
+     When I call "GET /repos/repo2/delete"
      Then the response status should be '200'
       And the response ContentType should be "application/xml"
       And the xpath "/response/success/text()" equals "true"
       And the xml response should contain "/response/token"
      Then I save the response "/response/token/text()" as "@token"
-     When I call "DELETE /repo2?token={@token}"
+     When I call "DELETE /repos/repo2?token={@token}"
      Then the response status should be '200'
       And the response ContentType should be "application/xml"
       And the xpath "/deleted/text()" equals "repo2"

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageExport.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageExport.feature
@@ -7,17 +7,17 @@ Feature: Export GeoPackage
   extension, allowing to transparently log every change to a tracked layer in an audit table that can later be
   replyed on top of the repository.  
   
-  API Spec: GET /<repo>/export[.xml|.json]?format=gpkg[&root=<refspec>][&path=<layerName>[,<layerName>]+][&bbox=<boundingBox>][&interchange=<true|false>]
+  API Spec: GET /repos/<repo>/export[.xml|.json]?format=gpkg[&root=<refspec>][&path=<layerName>[,<layerName>]+][&bbox=<boundingBox>][&interchange=<true|false>]
   
   Scenario: Verify wrong HTTP method issues 405 "Method not allowed"
     Given There is an empty multirepo server
-     When I call "POST /repo1/export?format=gpkg"
+     When I call "POST /repos/repo1/export?format=gpkg"
      Then the response status should be '405'
       And the response allowed methods should be "GET"
       
   Scenario: Verify missing "format=gpkg" argument issues 400 "Bad request"
     Given There is a default multirepo server
-     When I call "GET /repo1/export"
+     When I call "GET /repos/repo1/export"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the xpath "/response/success/text()" equals "false"
@@ -25,7 +25,7 @@ Feature: Export GeoPackage
 
   Scenario: Verify unsupported output format argument issues 400 "Bad request"
     Given There is a default multirepo server
-     When I call "GET /repo1/export?format=badFormat"
+     When I call "GET /repos/repo1/export?format=badFormat"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the xpath "/response/success/text()" equals "false"
@@ -33,31 +33,29 @@ Feature: Export GeoPackage
 
   Scenario: Verify export on a non existent repository issues 404 "Not found"
     Given There is an empty multirepo server
-     When I call "GET /badRepo/export?format=gpkg"
+     When I call "GET /repos/badRepo/export?format=gpkg"
      Then the response status should be '404'
       And the response ContentType should be "text/plain"
       And the response body should contain "Repository not found"
 
   Scenario: Export defaults: all layers from current head
     Given There is a default multirepo server
-     When I call "GET /repo1/export?format=gpkg"
+     When I call "GET /repos/repo1/export?format=gpkg"
      Then the response is an XML async task @taskId
       And the task @taskId description contains "Export to Geopackage database"
       And when the task @taskId finishes
      Then the task @taskId status is FINISHED
       And the task @taskId result contains "atom:link/@href" with value "/tasks/{@taskId}/download"
-      #change to /tasks/{@taskId}/download once we fix the top level routes
-     When I call "GET /repo1/tasks/{@taskId}/download"
+     When I call "GET /tasks/{@taskId}/download"
      Then the result is a valid GeoPackage file
      
   Scenario: Export from an empty HEAD produces a valid empty geopackage
     Given There is an empty repository named emptyRepo
-     When I call "GET /emptyRepo/export?format=gpkg"
+     When I call "GET /repos/emptyRepo/export?format=gpkg"
      Then the response is an XML async task @taskId
       And the task @taskId description contains "Export to Geopackage database"
       And when the task @taskId finishes
      Then the task @taskId status is FINISHED
       And the task @taskId result contains "atom:link/@href" with value "/tasks/{@taskId}/download"
-      #change to /tasks/{@taskId}/download once we fix the top level routes
-     When I call "GET /repo1/tasks/{@taskId}/download"
+     When I call "GET /tasks/{@taskId}/download"
      Then the result is a valid GeoPackage file

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageImport.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageImport.feature
@@ -5,17 +5,17 @@ Feature: Import GeoPackage
   The GeoPackage file is sent as a POST form arument named "fileUpload". 
   Other URL arguments can be used to control some aspects of the import.
   
-  API Spec: POST /<repo>/import?format=gpkg[&add=<true|false>][&alter=<true|false>]
+  API Spec: POST /repos/<repo>/import?format=gpkg[&add=<true|false>][&alter=<true|false>]
   
   Scenario: Verify wrong HTTP method issues 405 "Method not allowed"
     Given There is an empty multirepo server
-     When I call "GET /repo1/import?format=gpkg"
+     When I call "GET /repos/repo1/import?format=gpkg"
      Then the response status should be '405'
       And the response allowed methods should be "POST"
       
   Scenario: Verify missing "format=gpkg" argument issues 400 "Bad request"
     Given There is a default multirepo server
-     When I call "POST /repo1/import"
+     When I call "POST /repos/repo1/import"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the response xml matches
@@ -25,7 +25,7 @@ Feature: Import GeoPackage
 
   Scenario: Verify unsupported output format argument issues 400 "Bad request"
     Given There is a default multirepo server
-     When I call "POST /repo1/import?format=badFormat"
+     When I call "POST /repos/repo1/import?format=badFormat"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the response xml matches
@@ -36,7 +36,7 @@ Feature: Import GeoPackage
   Scenario: Verify import to a non existent repository issues 404 "Not found"
     Given There is an empty multirepo server
       And I have a geopackage file @gpkgFile
-     When I post @gpkgFile as "fileUpload" to "/badRepo/import?format=gpkg"
+     When I post @gpkgFile as "fileUpload" to "/repos/badRepo/import?format=gpkg"
      Then the response status should be '404'
       And the response ContentType should be "text/plain"
       And the response body should contain "Repository not found"
@@ -44,7 +44,7 @@ Feature: Import GeoPackage
   Scenario: Import to an empty repository
     Given There is an empty repository named targetRepo
       And I have a geopackage file @gpkgFile
-     When I post @gpkgFile as "fileUpload" to "/targetRepo/import?format=gpkg"
+     When I post @gpkgFile as "fileUpload" to "/repos/targetRepo/import?format=gpkg"
      Then the response status should be '200'
       And the response is an XML async task @taskId
       And the task @taskId description contains "Importing GeoPackage database file."

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/ListRepositories.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/ListRepositories.feature
@@ -6,14 +6,14 @@ Feature: List repositories
 
   Scenario: List repositories on a server with no repositories
     Given There is an empty multirepo server
-     When I call "GET /"
+     When I call "GET /repos/"
      Then the response status should be '200'
       And the response ContentType should be "application/xml"
       And the xml response should not contain "/repos/repo"
 
   Scenario: Get list of repositories in default format
     Given There is a default multirepo server
-     When I call "GET /"
+     When I call "GET /repos/"
      Then the response status should be '200'
       And the response ContentType should be "application/xml"
       And the xml response should contain "/repos/repo/name" 2 times

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/RenameRepository.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/RenameRepository.feature
@@ -1,26 +1,26 @@
 @RepositoryManagement
 Feature: Rename repository
-  Repositories being served throught the Web API are served through the "/<repository name>" entry point.
+  Repositories being served throught the Web API are served through the "/repos/<repository name>" entry point.
   The name of a repository is unique across a Web API instance.
-  Renaming a repository is done through a "POST /<repository name>/rename?name={new name}" call.
+  Renaming a repository is done through a "POST /repos/<repository name>/rename?name={new name}" call.
 
   Scenario: Calling rename to a non existing repo issues 404 "Not Found"
     Given There is an empty multirepo server
-     When I call "POST /nonExistingRepo/rename?name=renamedRepo"
+     When I call "POST /repos/nonExistingRepo/rename?name=renamedRepo"
      Then the response status should be '404'
       And the response ContentType should be "text/plain"
       And the response body should contain "Repository not found"
 
   Scenario: Calling rename on a repo using the wrong HTTP method issues 405 "Method not allowed"
     Given There is a default multirepo server
-     When I call "GET /repo1/rename?name=renamedRepo"
+     When I call "GET /repos/repo1/rename?name=renamedRepo"
      Then the response status should be '405'
       And the response allowed methods should be "POST"
       
 
   Scenario: Trying to assign a duplicated name to a repo issues 400 "Bad request"
     Given There is a default multirepo server
-     When I call "POST /repo1/rename?name=repo2"
+     When I call "POST /repos/repo1/rename?name=repo2"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the xpath "/response/success/text()" equals "false"
@@ -28,9 +28,9 @@ Feature: Rename repository
 
   Scenario: Renaming a repository returns a link to the new location issues 301 "Moved permanently"
     Given There is a default multirepo server
-     When I call "POST /repo1/rename?name=repo1Renamed"
+     When I call "POST /repos/repo1/rename?name=repo1Renamed"
      Then the response status should be '301'
       And the response ContentType should be "application/xml"
       And the xpath "/response/success/text()" equals "true"
       And the xpath "/response/repo/name/text()" equals "repo1Renamed"
-      And the xpath "/response/repo/atom:link/@href" equals "/repo1Renamed.xml"
+      And the xpath "/response/repo/atom:link/@href" equals "/repos/repo1Renamed.xml"


### PR DESCRIPTION
Put repositories under a /repos route and all tasks under a top-level /tasks route.