### PR TITLE
Update GeoPackage import to support audit logs.

### DIFF
--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/RepositoryTestCase.java
@@ -54,7 +54,6 @@ import org.opengis.feature.type.Name;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterables;

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgCommonArgs.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgCommonArgs.java
@@ -19,8 +19,9 @@ public class GeopkgCommonArgs {
     /**
      * The database to connect to. Default: database
      */
-    @Parameter(names = { "--database", "-D" }, description = "The database to connect to.  Default: database.geopkg")
-    public String database = "database.geopkg";
+    @Parameter(names = { "--database",
+            "-D" }, description = "The database to connect to.  Default: database.gpkg")
+    public String database = "database.gpkg";
 
     /**
      * User name. Default: user

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgExport.java
@@ -57,7 +57,7 @@ public class GeopkgExport extends DataStoreExport implements CLICommand {
         super.runInternal(cli);
 
         if (interchangeFormat) {
-            final String sourceTreeIsh = args.get(0);
+            final String sourcePathspec = args.get(0);
             final String targetTableName = args.get(1);
             File file = new File(commonArgs.database);
 
@@ -65,7 +65,7 @@ public class GeopkgExport extends DataStoreExport implements CLICommand {
             try {
 
                 repo.command(GeopkgAuditExport.class).setDatabase(file)
-                        .setSourceTreeish(sourceTreeIsh).setTargetTableName(targetTableName)
+                        .setSourcePathspec(sourcePathspec).setTargetTableName(targetTableName)
                         .setProgressListener(cli.getProgressListener()).call();
 
             } catch (Exception e) {

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgPull.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/geopkg/GeopkgPull.java
@@ -11,7 +11,6 @@ package org.locationtech.geogig.geotools.cli.geopkg;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import org.locationtech.geogig.api.ProgressListener;
 import org.locationtech.geogig.cli.AbstractCommand;
@@ -19,7 +18,6 @@ import org.locationtech.geogig.cli.CommandFailedException;
 import org.locationtech.geogig.cli.GeogigCLI;
 import org.locationtech.geogig.cli.InvalidParameterException;
 import org.locationtech.geogig.cli.annotation.RequiresRepository;
-import org.locationtech.geogig.geotools.geopkg.AuditReport;
 import org.locationtech.geogig.geotools.geopkg.GeopkgAuditImport;
 import org.locationtech.geogig.repository.Repository;
 
@@ -41,6 +39,10 @@ public class GeopkgPull extends AbstractCommand {
     @ParametersDelegate
     final GeopkgCommonArgs commonArgs = new GeopkgCommonArgs();
 
+    @Parameter(names = { "-t",
+            "--table" }, description = "Feature table to import.  Required if tables are from multiple commits.")
+    private String table = null;
+
     @Parameter(names = { "-m", "--message" }, description = "Commit message to ")
     private String commitMessage;
 
@@ -57,11 +59,9 @@ public class GeopkgPull extends AbstractCommand {
         final File file = new File(commonArgs.database);
 
         ProgressListener listener = cli.getProgressListener();
-
-        List<AuditReport> report;
         try {
-            report = repository.command(GeopkgAuditImport.class).setDatabase(file)
-                    .setCommitMessage(commitMessage).setNoCommit(noCommit)
+            repository.command(GeopkgAuditImport.class).setDatabase(file)
+                    .setCommitMessage(commitMessage).setNoCommit(noCommit).setTable(table)
                     .setProgressListener(listener).call();
 
         } catch (IllegalArgumentException | IllegalStateException e) {

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/AuditTable.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/AuditTable.java
@@ -14,13 +14,13 @@ import org.locationtech.geogig.api.ObjectId;
 public class AuditTable {
     private final String tableName, featureTreePath, auditTable;
 
-    private final ObjectId rootTreeId;
+    private final ObjectId commitId;
 
-    AuditTable(String tableName, String featureTreePath, String auditTable, ObjectId rootTree) {
+    AuditTable(String tableName, String featureTreePath, String auditTable, ObjectId commitId) {
         this.tableName = tableName;
         this.featureTreePath = featureTreePath;
         this.auditTable = auditTable;
-        rootTreeId = rootTree;
+        this.commitId = commitId;
     }
 
     public String getTableName() {
@@ -35,7 +35,7 @@ public class AuditTable {
         return auditTable;
     }
 
-    public ObjectId getRootTreeId() {
-        return rootTreeId;
+    public ObjectId getCommitId() {
+        return commitId;
     }
 }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeogigMetadata.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeogigMetadata.java
@@ -81,7 +81,7 @@ class GeogigMetadata {
                 st.execute(log(sql));
 
                 sql = format(
-                        "CREATE TABLE IF NOT EXISTS %s (table_name VARCHAR, mapped_path VARCHAR, audit_table VARCHAR, root_tree_id VARCHAR)",
+                        "CREATE TABLE IF NOT EXISTS %s (table_name VARCHAR, mapped_path VARCHAR, audit_table VARCHAR, commit_id VARCHAR)",
                         AUDIT_METADATA_TABLE);
 
                 st.execute(log(sql));
@@ -104,8 +104,7 @@ class GeogigMetadata {
     }
 
     public List<AuditTable> getAuditTables() throws SQLException {
-        final String sql = format(
-                "SELECT table_name, mapped_path, audit_table, root_tree_id FROM %s",
+        final String sql = format("SELECT table_name, mapped_path, audit_table, commit_id FROM %s",
                 AUDIT_METADATA_TABLE);
 
         List<AuditTable> tables = new ArrayList<>();
@@ -115,11 +114,11 @@ class GeogigMetadata {
                     String tableName = rs.getString(1);
                     String featureTreePath = rs.getString(2);
                     String auditTable = rs.getString(3);
-                    String rootId = rs.getString(4);
-                    ObjectId rootTreeId = ObjectId.valueOf(rootId);
+                    String commitId = rs.getString(4);
+                    ObjectId commitObjectId = ObjectId.valueOf(commitId);
 
                     AuditTable tableInfo = new AuditTable(tableName, featureTreePath, auditTable,
-                            rootTreeId);
+                            commitObjectId);
                     tables.add(tableInfo);
                 }
             }
@@ -128,7 +127,7 @@ class GeogigMetadata {
     }
 
     public void createAudit(final String tableName, final String mappedPath,
-            final ObjectId rootTreeId) throws SQLException {
+            final ObjectId commitObjectId) throws SQLException {
         cx.setAutoCommit(false);
         try {
             String sql = format("INSERT OR REPLACE INTO %s VALUES(?, ?, ?, ?)",
@@ -140,7 +139,7 @@ class GeogigMetadata {
                 st.setString(1, tableName);
                 st.setString(2, mappedPath);
                 st.setString(3, audit_table);
-                st.setString(4, rootTreeId.toString());
+                st.setString(4, commitObjectId.toString());
 
                 st.executeUpdate();
             }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgAuditExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgAuditExport.java
@@ -25,7 +25,7 @@ public class GeopkgAuditExport extends AbstractGeoGigOp<Void> {
 
     private File databaseFile;
 
-    private String sourceTreeIsh;
+    private String sourcePathspec;
 
     private String targetTableName;
 
@@ -34,8 +34,8 @@ public class GeopkgAuditExport extends AbstractGeoGigOp<Void> {
         return this;
     }
 
-    public GeopkgAuditExport setSourceTreeish(String sourceTreeIsh) {
-        this.sourceTreeIsh = sourceTreeIsh;
+    public GeopkgAuditExport setSourcePathspec(String sourcePathspec) {
+        this.sourcePathspec = sourcePathspec;
         return this;
     }
 
@@ -53,10 +53,10 @@ public class GeopkgAuditExport extends AbstractGeoGigOp<Void> {
         ProgressListener progress = getProgressListener();
 
         InterchangeFormat interchange;
-        interchange = new InterchangeFormat(databaseFile, repository).setProgressListener(progress);
+        interchange = new InterchangeFormat(databaseFile, context()).setProgressListener(progress);
 
         try {
-            interchange.export(sourceTreeIsh, targetTableName);
+            interchange.export(sourcePathspec, targetTableName);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgAuditImport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgAuditImport.java
@@ -13,21 +13,27 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkState;
 
 import java.io.File;
-import java.util.List;
 
 import org.locationtech.geogig.api.AbstractGeoGigOp;
 import org.locationtech.geogig.api.ProgressListener;
-import org.locationtech.geogig.api.porcelain.AddOp;
-import org.locationtech.geogig.api.porcelain.CommitOp;
-import org.locationtech.geogig.api.porcelain.NothingToCommitException;
+import org.locationtech.geogig.api.RevCommit;
+import org.locationtech.geogig.api.porcelain.MergeConflictsException;
 
-public class GeopkgAuditImport extends AbstractGeoGigOp<List<AuditReport>> {
+import com.google.common.base.Throwables;
+
+public class GeopkgAuditImport extends AbstractGeoGigOp<RevCommit> {
 
     private String commitMessage;
+
+    private String authorName = null;
+
+    private String authorEmail = null;
 
     private boolean noCommit = false;
 
     private File geopackageFile;
+
+    private String table = null;
 
     public GeopkgAuditImport setDatabase(File geopackageFile) {
         this.geopackageFile = geopackageFile;
@@ -48,8 +54,23 @@ public class GeopkgAuditImport extends AbstractGeoGigOp<List<AuditReport>> {
         return this;
     }
 
+    public GeopkgAuditImport setTable(String table) {
+        this.table = table;
+        return this;
+    }
+
+    public GeopkgAuditImport setAuthorName(String authorName) {
+        this.authorName = authorName;
+        return this;
+    }
+
+    public GeopkgAuditImport setAuthorEmail(String authorEmail) {
+        this.authorEmail = authorEmail;
+        return this;
+    }
+
     @Override
-    protected List<AuditReport> _call() throws IllegalArgumentException, IllegalStateException {
+    protected RevCommit _call() throws IllegalArgumentException, IllegalStateException {
         checkArgument(null != geopackageFile, "Geopackage database not provided");
         checkArgument(geopackageFile.exists(), "Database %s does not exist", geopackageFile);
         checkArgument(noCommit || commitMessage != null, "Commit message not provided");
@@ -58,31 +79,29 @@ public class GeopkgAuditImport extends AbstractGeoGigOp<List<AuditReport>> {
         checkState(index().isClean(),
                 "The staging ares has uncommitted changes. It must be clean for the import to run cleanly.");
 
-        List<AuditReport> tableReports;
+        RevCommit newCommit = null;
 
         try {
             InterchangeFormat interchange;
             ProgressListener progress = getProgressListener();
-            interchange = new InterchangeFormat(geopackageFile, repository())
+            interchange = new InterchangeFormat(geopackageFile, context())
                     .setProgressListener(progress);
 
-            tableReports = interchange.importAuditLog();
-
-            if (!noCommit) {
-                progress.setDescription("Committing changes...");
-                command(AddOp.class).call();
-                try {
-                    command(CommitOp.class).setMessage(commitMessage).call();
-                } catch (NothingToCommitException e) {
-                    progress.setDescription(e.getMessage());
-                }
+            if (table == null) {
+                newCommit = interchange.importAuditLog(commitMessage, authorName, authorEmail);
+            } else {
+                newCommit = interchange.importAuditLog(commitMessage, authorName, authorEmail,
+                        table);
             }
+
+        } catch (MergeConflictsException e) {
+            Throwables.propagate(e);
         } catch (Exception e) {
             throw new IllegalStateException("Unable to export: " + e.getMessage(), e);
         } finally {
 
         }
 
-        return tableReports;
+        return newCommit;
     }
 }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgDataStoreAuditImportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgDataStoreAuditImportOp.java
@@ -1,0 +1,46 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Johnathan Garrett (Prominent Edge) - initial implementation
+ */
+package org.locationtech.geogig.geotools.geopkg;
+
+import java.io.File;
+
+import org.locationtech.geogig.api.RevCommit;
+import org.locationtech.geogig.cli.CommandFailedException;
+import org.locationtech.geogig.geotools.plumbing.DataStoreImportOp;
+
+/**
+ * Imports layers from a GeoPackage file to the repository.
+ * 
+ * @see DataStoreImportOp
+ * @see GeopkgAuditImport
+ */
+public class GeopkgDataStoreAuditImportOp extends DataStoreImportOp<RevCommit> {
+
+    private File geopackage;
+
+    public GeopkgDataStoreAuditImportOp setDatabaseFile(File geopackage) {
+        this.geopackage = geopackage;
+        return this;
+    }
+
+    @Override
+    protected RevCommit _call() {
+        RevCommit result;
+        try {
+            result = command(GeopkgAuditImport.class).setDatabase(geopackage)
+                    .setAuthorName(authorName).setAuthorEmail(authorEmail)
+                    .setCommitMessage(commitMessage).setNoCommit(false).setTable(table).call();
+
+        } catch (IllegalArgumentException | IllegalStateException e) {
+            throw new CommandFailedException(e.getMessage(), e);
+        }
+        return result;
+    }
+}

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgDataStoreExportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgDataStoreExportOp.java
@@ -49,13 +49,13 @@ public class GeopkgDataStoreExportOp extends DataStoreExportOp<File> {
      * after the data has been exported for the given layer. {@inheritDoc}
      */
     @Override
-    protected void export(final String treeSpec, final DataStore targetStore,
+    protected void export(final String refSpec, final DataStore targetStore,
             final String targetTableName, final ProgressListener progress) {
 
-        super.export(treeSpec, targetStore, targetTableName, progress);
+        super.export(refSpec, targetStore, targetTableName, progress);
 
         if (enableInterchangeFormat) {
-            command(GeopkgAuditExport.class).setSourceTreeish(treeSpec)
+            command(GeopkgAuditExport.class).setSourcePathspec(refSpec)
                     .setTargetTableName(targetTableName).setDatabase(geopackage).call();
         }
     }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/DataStoreImportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/DataStoreImportOp.java
@@ -12,11 +12,8 @@ package org.locationtech.geogig.geotools.plumbing;
 import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.locationtech.geogig.api.AbstractGeoGigOp;
-import org.locationtech.geogig.api.RevCommit;
-import org.locationtech.geogig.api.RevTree;
 import org.locationtech.geogig.api.porcelain.AddOp;
 import org.locationtech.geogig.api.porcelain.CommitOp;
-import org.locationtech.geogig.repository.WorkingTree;
 import org.opengis.feature.Feature;
 
 import com.google.common.base.Supplier;
@@ -27,7 +24,7 @@ import com.google.common.base.Supplier;
  * by {@link CommitOp} to make the import atomic.
  *
  */
-public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
+public abstract class DataStoreImportOp<T> extends AbstractGeoGigOp<T> {
 
     /**
      * Extends the {@link com.google.common.base.Supplier} interface to provide for a way to request
@@ -41,35 +38,35 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
         void cleanupResources();
     }
 
-    private DataStoreSupplier dataStoreSupplier;
+    protected DataStoreSupplier dataStoreSupplier;
 
     // commit options
     @Nullable
-    private String authorEmail;
+    protected String authorEmail;
 
     @Nullable
-    private String authorName;
+    protected String authorName;
 
     @Nullable
-    private String commitMessage;
+    protected String commitMessage;
 
     // import options
     @Nullable // except if all == false
-    private String table;
+    protected String table;
 
-    private boolean all = false;
+    protected boolean all = false;
 
-    private boolean add = false;
+    protected boolean add = false;
 
-    private boolean alter = false;
+    protected boolean alter = false;
 
-    private boolean forceFeatureType = false;
-
-    @Nullable
-    private String dest;
+    protected boolean forceFeatureType = false;
 
     @Nullable
-    private String fidAttribute;
+    protected String dest;
+
+    @Nullable
+    protected String fidAttribute;
 
     /**
      * Set the source {@link DataStore DataStore}, from which features should be imported.
@@ -78,57 +75,13 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *        {@link DataStore DataStore} containing features to import into the repository.
      * @return A reference to this Operation.
      */
-    public DataStoreImportOp setDataStore(DataStoreSupplier dataStore) {
+    public DataStoreImportOp<T> setDataStore(DataStoreSupplier dataStore) {
         this.dataStoreSupplier = dataStore;
         return this;
     }
 
     @Override
-    protected RevCommit _call() {
-
-        final DataStore dataStore = dataStoreSupplier.get();
-
-        RevCommit revCommit;
-
-        /**
-         * Import needs to: 1) Import the data 2) Add changes to be staged 3) Commit staged changes
-         */
-        try {
-            // import data into the repository
-            final ImportOp importOp = getImportOp(dataStore);
-            importOp.setProgressListener(getProgressListener());
-            final RevTree revTree = importOp.call();
-            // add the imported data to the staging area
-            final WorkingTree workingTree = callAdd();
-            // commit the staged changes
-            revCommit = callCommit();
-        } finally {
-            dataStore.dispose();
-            dataStoreSupplier.cleanupResources();
-        }
-
-        return revCommit;
-    }
-
-    private WorkingTree callAdd() {
-        final AddOp addOp = context.command(AddOp.class);
-        addOp.setProgressListener(getProgressListener());
-        return addOp.call();
-    }
-
-    private RevCommit callCommit() {
-        final CommitOp commitOp = context.command(CommitOp.class).setAll(true)
-                .setAuthor(authorName, authorEmail).setMessage(commitMessage);
-        commitOp.setProgressListener(getProgressListener());
-        return commitOp.call();
-    }
-
-    private ImportOp getImportOp(DataStore dataStore) {
-        final ImportOp importOp = context.command(ImportOp.class);
-        return importOp.setDataStore(dataStore).setTable(table).setAll(all).setOverwrite(!add)
-                .setAdaptToDefaultFeatureType(!forceFeatureType).setAlter(alter)
-                .setDestinationPath(dest).setFidAttribute(fidAttribute);
-    }
+    protected abstract T _call();
 
     /**
      * Set the email address of the committer in the commit.
@@ -146,7 +99,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      * @see org.locationtech.geogig.api.porcelain.CommitOp#setAuthor(java.lang.String,
      *      java.lang.String)
      */
-    public DataStoreImportOp setAuthorEmail(String authorEmail) {
+    public DataStoreImportOp<T> setAuthorEmail(String authorEmail) {
         this.authorEmail = authorEmail;
         return this;
     }
@@ -167,7 +120,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      * @see org.locationtech.geogig.api.porcelain.CommitOp#setAuthor(java.lang.String,
      *      java.lang.String)
      */
-    public DataStoreImportOp setAuthorName(String authorName) {
+    public DataStoreImportOp<T> setAuthorName(String authorName) {
         this.authorName = authorName;
         return this;
     }
@@ -187,7 +140,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see org.locationtech.geogig.api.porcelain.CommitOp#setMessage(java.lang.String)
      */
-    public DataStoreImportOp setCommitMessage(String commitMessage) {
+    public DataStoreImportOp<T> setCommitMessage(String commitMessage) {
         this.commitMessage = commitMessage;
         return this;
     }
@@ -213,7 +166,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see ImportOp#setOverwrite(boolean)
      */
-    public DataStoreImportOp setAdd(boolean add) {
+    public DataStoreImportOp<T> setAdd(boolean add) {
         this.add = add;
         return this;
     }
@@ -235,7 +188,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      * @see ImportOp#setTable(java.lang.String)
      * @see DataStoreImportOp#setTable(java.lang.String)
      */
-    public DataStoreImportOp setAll(boolean all) {
+    public DataStoreImportOp<T> setAll(boolean all) {
         this.all = all;
         return this;
     }
@@ -256,7 +209,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see ImportOp#setAlter(boolean)
      */
-    public DataStoreImportOp setAlter(boolean alter) {
+    public DataStoreImportOp<T> setAlter(boolean alter) {
         this.alter = alter;
         return this;
     }
@@ -277,7 +230,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see ImportOp#setFidAttribute(java.lang.String)
      */
-    public DataStoreImportOp setFidAttribute(String fidAttribute) {
+    public DataStoreImportOp<T> setFidAttribute(String fidAttribute) {
         this.fidAttribute = fidAttribute;
         return this;
     }
@@ -299,7 +252,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      * @see ImportOp#setAll(boolean)
      * @see DataStoreImportOp#setAll(boolean)
      */
-    public DataStoreImportOp setTable(String table) {
+    public DataStoreImportOp<T> setTable(String table) {
         this.table = table;
         return this;
     }
@@ -321,7 +274,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see ImportOp#setAdaptToDefaultFeatureType(boolean)
      */
-    public DataStoreImportOp setForceFeatureType(boolean forceFeatureType) {
+    public DataStoreImportOp<T> setForceFeatureType(boolean forceFeatureType) {
         this.forceFeatureType = forceFeatureType;
         return this;
     }
@@ -341,7 +294,7 @@ public class DataStoreImportOp extends AbstractGeoGigOp<RevCommit> {
      *
      * @see ImportOp#setDestinationPath(java.lang.String)
      */
-    public DataStoreImportOp setDest(String dest) {
+    public DataStoreImportOp<T> setDest(String dest) {
         this.dest = dest;
         return this;
     }

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/DefaultDataStoreImportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/DefaultDataStoreImportOp.java
@@ -1,0 +1,57 @@
+package org.locationtech.geogig.geotools.plumbing;
+
+import org.geotools.data.DataStore;
+import org.locationtech.geogig.api.RevCommit;
+import org.locationtech.geogig.api.porcelain.AddOp;
+import org.locationtech.geogig.api.porcelain.CommitOp;
+import org.locationtech.geogig.repository.WorkingTree;
+
+public class DefaultDataStoreImportOp extends DataStoreImportOp<RevCommit> {
+
+    @Override
+    protected RevCommit _call() {
+        final DataStore dataStore = dataStoreSupplier.get();
+
+        RevCommit revCommit;
+
+        /**
+         * Import needs to: 1) Import the data 2) Add changes to be staged 3) Commit staged changes
+         */
+        try {
+            // import data into the repository
+            final ImportOp importOp = getImportOp(dataStore);
+            importOp.setProgressListener(getProgressListener());
+            importOp.call();
+            // add the imported data to the staging area
+            callAdd();
+            // commit the staged changes
+            revCommit = callCommit();
+        } finally {
+            dataStore.dispose();
+            dataStoreSupplier.cleanupResources();
+        }
+
+        return revCommit;
+    }
+
+    private WorkingTree callAdd() {
+        final AddOp addOp = context.command(AddOp.class);
+        addOp.setProgressListener(getProgressListener());
+        return addOp.call();
+    }
+
+    private RevCommit callCommit() {
+        final CommitOp commitOp = context.command(CommitOp.class).setAll(true)
+                .setAuthor(authorName, authorEmail).setMessage(commitMessage);
+        commitOp.setProgressListener(getProgressListener());
+        return commitOp.call();
+    }
+
+    private ImportOp getImportOp(DataStore dataStore) {
+        final ImportOp importOp = context.command(ImportOp.class);
+        return importOp.setDataStore(dataStore).setTable(table).setAll(all).setOverwrite(!add)
+                .setAdaptToDefaultFeatureType(!forceFeatureType).setAlter(alter)
+                .setDestinationPath(dest).setFidAttribute(fidAttribute);
+    }
+
+}

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/AsyncContext.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/AsyncContext.java
@@ -168,6 +168,10 @@ public class AsyncContext {
             return Optional.absent();
         }
 
+        public Context getContext() {
+            return command.command.context();
+        }
+
         public Status getStatus() {
             return command.status;
         }

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/geotools/DataStoreImportContextService.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/geotools/DataStoreImportContextService.java
@@ -9,6 +9,9 @@
  */
 package org.locationtech.geogig.rest.geotools;
 
+import org.locationtech.geogig.api.Context;
+import org.locationtech.geogig.api.RevCommit;
+import org.locationtech.geogig.geotools.plumbing.DataStoreImportOp;
 import org.locationtech.geogig.geotools.plumbing.DataStoreImportOp.DataStoreSupplier;
 import org.locationtech.geogig.web.api.ParameterSet;
 
@@ -43,4 +46,15 @@ public interface DataStoreImportContextService {
      * @return An appropriate command description.
      */
     public String getCommandDescription();
+
+    /**
+     * Retrieves the {@link DataStoreImportOp} implementation to use for the import.
+     * 
+     * @param context the command context to use.
+     * @param options the options for the command
+     * 
+     * @return the import command to use.
+     */
+    public DataStoreImportOp<RevCommit> createCommand(final Context context,
+            final ParameterSet options);
 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/geotools/DataStoreImportRepresentation.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/geotools/DataStoreImportRepresentation.java
@@ -19,6 +19,7 @@ import org.locationtech.geogig.geotools.plumbing.DataStoreImportOp;
 import org.locationtech.geogig.rest.AsyncCommandRepresentation;
 import org.locationtech.geogig.rest.AsyncContext;
 import org.locationtech.geogig.rest.CommandRepresentationFactory;
+import org.locationtech.geogig.web.api.ResponseWriter;
 import org.restlet.data.MediaType;
 
 /**
@@ -36,10 +37,8 @@ public class DataStoreImportRepresentation extends AsyncCommandRepresentation<Re
     @Override
     protected void writeResultBody(XMLStreamWriter w, RevCommit result) throws XMLStreamException {
         if (result != null) {
-            w.writeStartElement("RevCommit");
-            element(w, "id", result.getId());
-            element(w, "treeId", result.getTreeId().toString());
-            w.writeEndElement();
+            ResponseWriter out = new ResponseWriter(w);
+            out.writeCommit(result, "commit", null, null, null);
         }
     }
 

--- a/src/web/api/src/main/resources/META-INF/services/org.locationtech.geogig.rest.CommandRepresentationFactory
+++ b/src/web/api/src/main/resources/META-INF/services/org.locationtech.geogig.rest.CommandRepresentationFactory
@@ -1,4 +1,5 @@
 org.locationtech.geogig.rest.osm.OSMReportRepresentation$Factory
+org.locationtech.geogig.rest.geopkg.GeoPkgImportContext$RepresentationFactory
 org.locationtech.geogig.rest.geotools.ImportRepresentation$Factory
 org.locationtech.geogig.rest.geotools.DataStoreImportRepresentation$Factory
 org.locationtech.geogig.rest.geopkg.GeoPkgExportOutputFormat$RepresentationFactory

--- a/src/web/api/src/test/java/org/locationtech/geogig/rest/geopkg/GeoPackageImportIntegrationTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/rest/geopkg/GeoPackageImportIntegrationTest.java
@@ -9,6 +9,11 @@
  */
 package org.locationtech.geogig.rest.geopkg;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.locationtech.geogig.web.api.TestData.point1;
+import static org.locationtech.geogig.web.api.TestData.pointsType;
+
 import java.io.File;
 import java.util.Iterator;
 import java.util.List;
@@ -16,28 +21,40 @@ import java.util.Set;
 import java.util.concurrent.ExecutionException;
 
 import org.codehaus.jettison.json.JSONObject;
+import org.geotools.data.DataStore;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.Transaction;
+import org.geotools.data.memory.MemoryDataStore;
+import org.geotools.data.simple.SimpleFeatureStore;
 import org.json.JSONException;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.geogig.api.GeoGIG;
+import org.locationtech.geogig.api.GeogigTransaction;
 import org.locationtech.geogig.api.NodeRef;
+import org.locationtech.geogig.api.RevCommit;
 import org.locationtech.geogig.api.plumbing.LsTreeOp;
+import org.locationtech.geogig.api.plumbing.LsTreeOp.Strategy;
+import org.locationtech.geogig.api.plumbing.TransactionBegin;
+import org.locationtech.geogig.api.plumbing.TransactionEnd;
+import org.locationtech.geogig.geotools.geopkg.GeopkgAuditExport;
 import org.locationtech.geogig.rest.AsyncContext;
 import org.locationtech.geogig.rest.AsyncContext.Status;
 import org.locationtech.geogig.rest.geotools.Import;
 import org.locationtech.geogig.web.api.AbstractWebAPICommand;
 import org.locationtech.geogig.web.api.AbstractWebOpTest;
-import org.locationtech.geogig.web.api.CommandBuilder;
 import org.locationtech.geogig.web.api.CommandContext;
 import org.locationtech.geogig.web.api.ParameterSet;
 import org.locationtech.geogig.web.api.TestData;
 import org.locationtech.geogig.web.api.TestParams;
+import org.opengis.filter.Filter;
 import org.skyscreamer.jsonassert.JSONAssert;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
@@ -72,18 +89,16 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         return Import.class;
     }
 
-    @Override
-    protected boolean requiresTransaction() {
-        return false;
-    }
-
     @Test()
     public void testFormatArgumentRquired() throws Exception {
         GeoGIG repo = context.getGeoGIG();
         TestData testData = new TestData(repo);
         testData.init().loadDefaultData();
 
-        Import op = buildCommand(TestParams.of());
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        Import op = buildCommand(
+                TestParams.of("transactionId", transaction.getTransactionId().toString()));
         op.asyncContext = testAsyncContext;
         ex.expect(IllegalArgumentException.class);
         ex.expectMessage("missing required 'format' parameter");
@@ -96,7 +111,10 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         TestData testData = new TestData(repo);
         testData.init().loadDefaultData();
 
-        Import op = buildCommand("format", "gpkg");
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        Import op = buildCommand("format", "gpkg", "transactionId",
+                transaction.getTransactionId().toString());
         op.asyncContext = testAsyncContext;
 
         AsyncContext.AsyncCommand<?> result = run(op);
@@ -111,7 +129,10 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         TestData testData = new TestData(repo);
         testData.init().loadDefaultData();
 
-        Import op = buildCommand("format", "gpkg", "mockFileUpload", "blah");
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        Import op = buildCommand("format", "gpkg", "mockFileUpload", "blah", "transactionId",
+                transaction.getTransactionId().toString());
         op.asyncContext = testAsyncContext;
 
         AsyncContext.AsyncCommand<?> result = run(op);
@@ -121,39 +142,17 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
     }
 
     @Test
-    public void testImportAll() throws Throwable {
-        final File dbFile = generateDbFile();
-        // parameter setup
-        ParameterSet params = TestParams.of("format", "gpkg");
-        ((TestParams) params).setFileUpload(dbFile);
-        // setup and empty repo
-        GeoGIG repo = context.getGeoGIG();
-        TestData testData = new TestData(repo);
-        testData.init();
-        // verify there are no nodes in the repository
-        verifyNoCommitedNodes();
-
-        Import op = buildCommand(params);
-        op.asyncContext = testAsyncContext;
-
-        AsyncContext.AsyncCommand<?> result = run(op);
-        Assert.assertNotNull(result.getStatus());
-        Status resultStatus = waitForTask(result);
-        Assert.assertEquals(Status.FINISHED, resultStatus);
-        // verify the dbFile is gone
-        verifyDbFileDeleted(dbFile);
-        // verify data was imported
-        verifyImport(Sets.newHashSet("Points", "Lines", "Polygons"));
-    }
-
-    @Test
     public void testImportTable() throws Throwable {
-        final File dbFile = generateDbFile();
-        // parameter setup
-        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines");
-        ((TestParams) params).setFileUpload(dbFile);
         // setup and empty repo
         GeoGIG repo = context.getGeoGIG();
+        final File dbFile = generateDbFile();
+
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        // parameter setup
+        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines", "transactionId",
+                transaction.getTransactionId().toString());
+        ((TestParams) params).setFileUpload(dbFile);
         TestData testData = new TestData(repo);
         testData.init();
         // verify there are no nodes in the repository
@@ -166,6 +165,8 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         Assert.assertNotNull(result.getStatus());
         Status resultStatus = waitForTask(result);
         Assert.assertEquals(Status.FINISHED, resultStatus);
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
         // verify the dbFile is gone
         verifyDbFileDeleted(dbFile);
         // verify data was imported
@@ -174,12 +175,15 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
 
     @Test
     public void testImportTableWithDest() throws Throwable {
-        final File dbFile = generateDbFile();
-        // parameter setup
-        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines");
-        ((TestParams) params).setFileUpload(dbFile);
         // setup and empty repo
         GeoGIG repo = context.getGeoGIG();
+        final File dbFile = generateDbFile();
+
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+        // parameter setup
+        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines",
+                "transactionId", transaction.getTransactionId().toString());
+        ((TestParams) params).setFileUpload(dbFile);
         TestData testData = new TestData(repo);
         testData.init();
         // verify there are no nodes in the repository
@@ -192,6 +196,8 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         Assert.assertNotNull(result.getStatus());
         Status resultStatus = waitForTask(result);
         Assert.assertEquals(Status.FINISHED, resultStatus);
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
         // verify the dbFile is gone
         verifyDbFileDeleted(dbFile);
         // verify data was imported
@@ -200,15 +206,18 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
 
     @Test
     public void testImportTableWithDestDuplicate() throws Throwable {
+        // setup and empty repo
+        GeoGIG repo = context.getGeoGIG();
         final File dbFile = generateDbFile();
+
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
         // need to make a copy because the file will get deleted after import
         final File dbFileCopy = File.createTempFile("geogig-test-clone", ".gpkg");
         Files.copy(dbFile, dbFileCopy);
         // parameter setup
-        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines");
+        ParameterSet params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines",
+                "transactionId", transaction.getTransactionId().toString());
         ((TestParams) params).setFileUpload(dbFile);
-        // setup and empty repo
-        GeoGIG repo = context.getGeoGIG();
         TestData testData = new TestData(repo);
         testData.init();
         // verify there are no nodes in the repository
@@ -221,12 +230,17 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         Assert.assertNotNull(result.getStatus());
         Status resultStatus = waitForTask(result);
         Assert.assertEquals(Status.FINISHED, resultStatus);
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
         // verify the dbFile is gone
         verifyDbFileDeleted(dbFile);
         // verify data was imported
         verifyImport(Sets.newHashSet("newLines"));
         // do it again but with a different dest
-        params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines2");
+
+        transaction = repo.command(TransactionBegin.class).call();
+        params = TestParams.of("format", "gpkg", "layer", "Lines", "dest", "newLines2",
+                "transactionId", transaction.getTransactionId().toString());
         // set the DB file to the copy since the original should be gone
         ((TestParams) params).setFileUpload(dbFileCopy);
         op = buildCommand(params);
@@ -236,6 +250,8 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         Assert.assertNotNull(result.getStatus());
         resultStatus = waitForTask(result);
         Assert.assertEquals(Status.FINISHED, resultStatus);
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
         // verify the dbFileCopy is gone
         verifyDbFileDeleted(dbFileCopy);
         // verify data was imported
@@ -243,7 +259,7 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
     }
 
     @Test
-    public void testImportAllWithManualTransaction() throws Throwable {
+    public void testImportAll() throws Throwable {
         // get a DB file to import
         final File dbFile = generateDbFile();
         // setup and empty repo
@@ -253,18 +269,11 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         // verify there are no nodes in the repository
         verifyNoCommitedNodes();
 
-        // Begin a Transaction manually
-        CommandBuilder.build("beginTransaction", new TestParams()).run(context);
-        String expected = "{'response':{'success':true,'Transaction':{}}}";
-        JSONObject beginResponse = getJSONResponse();
-        JSONAssert.assertEquals(expected, beginResponse.toString(), false);
-        JSONObject txnResponse = beginResponse.getJSONObject("response")
-                .getJSONObject("Transaction");
-        Assert.assertTrue("Expected ID string in Transaction Response", txnResponse.has("ID"));
-        String txnId = txnResponse.getString("ID");
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
 
         // now call import with the manual transaction
-        ParameterSet params = TestParams.of("format", "gpkg", "transactionId", txnId);
+        ParameterSet params = TestParams.of("format", "gpkg", "transactionId",
+                transaction.getTransactionId().toString());
         ((TestParams) params).setFileUpload(dbFile);
         Import op = buildCommand(params);
         op.asyncContext = testAsyncContext;
@@ -277,13 +286,160 @@ public class GeoPackageImportIntegrationTest extends AbstractWebOpTest {
         verifyDbFileDeleted(dbFile);
         // verify import hasn't been committed yet
         verifyNoCommitedNodes();
-        // end the transaction and verify the import
-        CommandBuilder.build("endTransaction", TestParams.of("transactionId", txnId)).run(context);
-        JSONObject endResponse = getJSONResponse();
-        expected = "{'response':{'success':true,'Transaction':{'ID':'" + txnId + "'}}}";
-        JSONAssert.assertEquals(expected, endResponse.toString(), true);
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
         // verify data was imported
         verifyImport(Sets.newHashSet("Points", "Lines", "Polygons"));
+    }
+
+    @Test
+    public void testImportInterchange() throws Throwable {
+        // get a DB file to import
+        GeoPackageTestSupport support = new GeoPackageTestSupport();
+        File file = support.createEmptyDatabase();
+
+        MemoryDataStore memStore = TestData.newMemoryDataStore();
+        memStore.addFeatures(ImmutableList.of(TestData.point1));
+
+        DataStore gpkgStore = support.createDataStore(file);
+        try {
+            support.export(memStore.getFeatureSource(pointsType.getName().getLocalPart()),
+                    gpkgStore);
+        } finally {
+            gpkgStore.dispose();
+        }
+
+        // setup and empty repo
+        GeoGIG repo = context.getGeoGIG();
+        TestData testData = new TestData(repo);
+        testData.init();
+        testData.addAndCommit("Initial commit", point1);
+        
+        repo.command(GeopkgAuditExport.class).setDatabase(file).setSourcePathspec("master:Points")
+                .setTargetTableName("Points").call();
+        
+        // modify point in the geopackage
+        gpkgStore = support.createDataStore(file);
+        Transaction gttx = new DefaultTransaction();
+        try {
+            SimpleFeatureStore store = (SimpleFeatureStore) gpkgStore.getFeatureSource("Points");
+            Preconditions.checkState(store.getQueryCapabilities().isUseProvidedFIDSupported());
+            store.setTransaction(gttx);
+            store.modifyFeatures("ip", TestData.point1_modified.getAttribute("ip"), Filter.INCLUDE);
+            gttx.commit();
+        } finally {
+            gttx.close();
+            gpkgStore.dispose();
+        }
+
+        testData.addAndCommit("Add point2", TestData.point2);
+        
+
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        // now call import with the manual transaction
+        ParameterSet params = TestParams.of("interchange", "true", "authorName", "Tester",
+                "authorEmail", "tester@example.com", "format", "gpkg", "message",
+                "Imported geopackage.", "layer", "Points", "transactionId",
+                transaction.getTransactionId().toString());
+        ((TestParams) params).setFileUpload(file);
+        Import op = buildCommand(params);
+        op.asyncContext = testAsyncContext;
+
+        AsyncContext.AsyncCommand<?> result = run(op);
+        Assert.assertNotNull(result.getStatus());
+        Status resultStatus = waitForTask(result);
+        Assert.assertEquals(Status.FINISHED, resultStatus);
+
+        Object resultObject = result.get();
+        assertTrue(resultObject instanceof RevCommit);
+
+        RevCommit mergeCommit = (RevCommit) resultObject;
+        assertEquals("Merge: Imported geopackage.", mergeCommit.getMessage());
+        assertEquals(2, mergeCommit.getParentIds().size());
+        assertEquals("Tester", mergeCommit.getAuthor().getName().get());
+        assertEquals("tester@example.com", mergeCommit.getAuthor().getEmail().get());
+
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
+
+        // verify both points are in the repo.
+        Iterator<NodeRef> nodeIterator = context.getGeoGIG().command(LsTreeOp.class)
+                .setReference("Points").setStrategy(Strategy.FEATURES_ONLY).call();
+
+        List<String> nodeList = Lists.transform(Lists.newArrayList(nodeIterator),
+                (nr) -> nr.name());
+        assertEquals(2, nodeList.size());
+        assertTrue(nodeList.contains("1"));
+        assertTrue(nodeList.contains("2"));
+    }
+
+    @Test
+    public void testImportInterchangeConflicts() throws Throwable {
+        // get a DB file to import
+        GeoPackageTestSupport support = new GeoPackageTestSupport();
+        File file = support.createEmptyDatabase();
+
+        MemoryDataStore memStore = TestData.newMemoryDataStore();
+        memStore.addFeatures(ImmutableList.of(TestData.point1));
+
+        DataStore gpkgStore = support.createDataStore(file);
+        try {
+            support.export(memStore.getFeatureSource(pointsType.getName().getLocalPart()),
+                    gpkgStore);
+        } finally {
+            gpkgStore.dispose();
+        }
+
+        // setup and empty repo
+        GeoGIG repo = context.getGeoGIG();
+        TestData testData = new TestData(repo);
+        testData.init();
+        testData.addAndCommit("Initial commit", TestData.point1);
+
+        repo.command(GeopkgAuditExport.class).setDatabase(file).setSourcePathspec("master:Points")
+                .setTargetTableName("Points").call();
+
+        // modify point in the geopackage
+        gpkgStore = support.createDataStore(file);
+        Transaction gttx = new DefaultTransaction();
+        try {
+            SimpleFeatureStore store = (SimpleFeatureStore) gpkgStore.getFeatureSource("Points");
+            Preconditions.checkState(store.getQueryCapabilities().isUseProvidedFIDSupported());
+            store.setTransaction(gttx);
+            store.modifyFeatures("ip", TestData.point1_modified.getAttribute("ip"), Filter.INCLUDE);
+            gttx.commit();
+        } finally {
+            gttx.close();
+            gpkgStore.dispose();
+        }
+
+        testData.remove(TestData.point1);
+        testData.add();
+        testData.commit("Removed point1");
+
+        GeogigTransaction transaction = repo.command(TransactionBegin.class).call();
+
+        // now call import with the manual transaction
+        ParameterSet params = TestParams.of("interchange", "true", "authorName", "Tester",
+                "authorEmail", "tester@example.com", "format", "gpkg", "message",
+                "Imported geopackage.", "layer", "Points", "transactionId",
+                transaction.getTransactionId().toString());
+        ((TestParams) params).setFileUpload(file);
+        Import op = buildCommand(params);
+        op.asyncContext = testAsyncContext;
+
+        AsyncContext.AsyncCommand<?> result = run(op);
+        Assert.assertNotNull(result.getStatus());
+        Status resultStatus = waitForTask(result);
+        Assert.assertEquals(Status.FAILED, resultStatus);
+
+        JSONObject response = getJSONResponse();
+        JSONObject task = response.getJSONObject("task");
+        JSONObject merge = task.getJSONObject("result").getJSONObject("Merge");
+        assertEquals(1, merge.getInt("conflicts"));
+        JSONObject conflictedFeature = merge.getJSONObject("Feature");
+        assertEquals("CONFLICT", conflictedFeature.getString("change"));
+        assertEquals("Points/1", conflictedFeature.getString("id"));
     }
 
     private Status waitForTask(AsyncContext.AsyncCommand<?> result) {

--- a/src/web/api/src/test/java/org/locationtech/geogig/rest/geopkg/GeoPackageTestSupport.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/rest/geopkg/GeoPackageTestSupport.java
@@ -9,7 +9,8 @@
  */
 package org.locationtech.geogig.rest.geopkg;
 
-import static com.google.common.base.Preconditions.*;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import static org.locationtech.geogig.web.api.TestData.line1;
 import static org.locationtech.geogig.web.api.TestData.line2;
 import static org.locationtech.geogig.web.api.TestData.line3;
@@ -59,7 +60,7 @@ public class GeoPackageTestSupport {
         this.tmpFolder = tmpFolder;
     }
 
-    private File newFile() throws IOException {
+    public File newFile() throws IOException {
         File dbFile = File.createTempFile("geogig_geopackage_test", ".gpkg", tmpFolder);
         dbFile.deleteOnExit();
         return dbFile;
@@ -113,7 +114,7 @@ public class GeoPackageTestSupport {
         return file;
     }
 
-    private void export(SimpleFeatureSource source, DataStore gpkg) throws IOException {
+    public void export(SimpleFeatureSource source, DataStore gpkg) throws IOException {
 
         Transaction gttx = new DefaultTransaction();
         try {

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/TestData.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/TestData.java
@@ -117,7 +117,7 @@ public class TestData {
 
     public static final SimpleFeatureType pointsType, linesType, polysType;
 
-    public static final SimpleFeature point1, point2, point3;
+    public static final SimpleFeature point1, point2, point3, point4;
 
     public static final SimpleFeature point1_modified, point2_modified, point3_modified;
 
@@ -134,23 +134,24 @@ public class TestData {
             throw Throwables.propagate(e);
         }
 
-        point1 = feature(pointsType, "Points.1", "StringProp1_1", 1000, "POINT(0 0)");
-        point2 = feature(pointsType, "Points.2", "StringProp1_2", 2000, "POINT(-10 -10)");
-        point3 = feature(pointsType, "Points.3", "StringProp1_3", 3000, "POINT(10 10)");
+        point1 = feature(pointsType, "1", "StringProp1_1", 1000, "POINT(0 0)");
+        point2 = feature(pointsType, "2", "StringProp1_2", 2000, "POINT(-10 -10)");
+        point3 = feature(pointsType, "3", "StringProp1_3", 3000, "POINT(10 10)");
+        point4 = feature(pointsType, "4", "StringProp1_4", 4000, "POINT(15 15)");
 
-        point1_modified = feature(pointsType, "Points.1", "StringProp1_1", 1500, "POINT(0 0)");
-        point2_modified = feature(pointsType, "Points.2", "StringProp1_2", 2000, "POINT(-15 -10)");
-        point3_modified = feature(pointsType, "Points.3", "StringProp1_3_M", 3000, "POINT(10 10)");
+        point1_modified = feature(pointsType, "1", "StringProp1_1", 1500, "POINT(0 0)");
+        point2_modified = feature(pointsType, "2", "StringProp1_2", 2000, "POINT(-15 -10)");
+        point3_modified = feature(pointsType, "3", "StringProp1_3_M", 3000, "POINT(10 10)");
 
-        line1 = feature(linesType, "Lines.1", "StringProp2_1", 1000, "LINESTRING (-1 -1, 1 1)");
-        line2 = feature(linesType, "Lines.2", "StringProp2_2", 2000, "LINESTRING (-11 -11, -9 -9)");
-        line3 = feature(linesType, "Lines.3", "StringProp2_3", 3000, "LINESTRING (9 9, 11 11)");
+        line1 = feature(linesType, "1", "StringProp2_1", 1000, "LINESTRING (-1 -1, 1 1)");
+        line2 = feature(linesType, "2", "StringProp2_2", 2000, "LINESTRING (-11 -11, -9 -9)");
+        line3 = feature(linesType, "3", "StringProp2_3", 3000, "LINESTRING (9 9, 11 11)");
 
-        poly1 = feature(polysType, "Polygons.1", "StringProp3_1", 1000,
+        poly1 = feature(polysType, "1", "StringProp3_1", 1000,
                 "POLYGON ((-1 -1, -1 1, 1 1, 1 -1, -1 -1))");
-        poly2 = feature(polysType, "Polygons.2", "StringProp3_2", 2000,
+        poly2 = feature(polysType, "2", "StringProp3_2", 2000,
                 "POLYGON ((-11 -11, -11 -9, -9 -9, -9 -11, -11 -11))");
-        poly3 = feature(polysType, "Polygons.3", "StringProp3_3", 3000,
+        poly3 = feature(polysType, "3", "StringProp3_3", 3000,
                 "POLYGON ((9 9, 9 11, 11 11, 11 9, 9 9))");
 
     }
@@ -206,17 +207,17 @@ public class TestData {
      * 
      * <pre>
      * <code>
-     *             (adds Points.2, Lines.2, Polygons.2)
+     *             (adds Points/2, Lines/2, Polygons/2)
      *    branch1 o-------------------------------------
      *           /                                      \
      *          /                                        \  no ff merge
      *  master o------------------------------------------o-----------------o
      *          \  (initial commit has                                     / no ff merge
-     *           \     Points.1, Lines.1, Polygons.1)                     /
+     *           \     Points/1, Lines/1, Polygons/1)                     /
      *            \                                                      /  
      *             \                                                    /
      *     branch2  o--------------------------------------------------
-     *             (adds Points.3, Lines.3, Polygons.3)
+     *             (adds Points/3, Lines/3, Polygons/3)
      *        
      * </code>
      * </pre>

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/CheckoutTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/CheckoutTest.java
@@ -41,13 +41,13 @@ public class CheckoutTest extends AbstractWebOpTest {
     @Test
     public void testBuildParameters() {
         ParameterSet options = TestParams.of("branch", "branch1", "ours", "true", "theirs", "true",
-                "path", "Points/Points.1");
+                "path", "Points/1");
 
         Checkout op = (Checkout) buildCommand(options);
         assertEquals("branch1", op.branchOrCommit);
         assertTrue(op.ours);
         assertTrue(op.theirs);
-        assertEquals("Points/Points.1", op.path);
+        assertEquals("Points/1", op.path);
     }
 
     @Test

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/LsTreeTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/commands/LsTreeTest.java
@@ -66,9 +66,9 @@ public class LsTreeTest extends AbstractWebOpTest {
         JSONObject response = getJSONResponse().getJSONObject("response");
         assertTrue(response.getBoolean("success"));
         JSONArray nodes = response.getJSONArray("node");
-        String expected = "[{'path':'Points'},{'path':'Points/Points.1'},{'path':'Points/Points.2'},{'path':'Points/Points.3'},"
-                + "{'path':'Lines'},{'path':'Lines/Lines.1'},{'path':'Lines/Lines.2'},{'path':'Lines/Lines.3'},"
-                + "{'path':'Polygons'},{'path':'Polygons/Polygons.1'},{'path':'Polygons/Polygons.2'},{'path':'Polygons/Polygons.3'}]";
+        String expected = "[{'path':'Points'},{'path':'Points/1'},{'path':'Points/2'},{'path':'Points/3'},"
+                + "{'path':'Lines'},{'path':'Lines/1'},{'path':'Lines/2'},{'path':'Lines/3'},"
+                + "{'path':'Polygons'},{'path':'Polygons/1'},{'path':'Polygons/2'},{'path':'Polygons/3'}]";
         JSONAssert.assertEquals(expected, nodes.toString(), false);
     }
 
@@ -101,9 +101,9 @@ public class LsTreeTest extends AbstractWebOpTest {
         JSONObject response = getJSONResponse().getJSONObject("response");
         assertTrue(response.getBoolean("success"));
         JSONArray nodes = response.getJSONArray("node");
-        String expected = "[{'path':'Points/Points.1'},{'path':'Points/Points.2'},{'path':'Points/Points.3'},"
-                + "{'path':'Lines/Lines.1'},{'path':'Lines/Lines.2'},{'path':'Lines/Lines.3'},"
-                + "{'path':'Polygons/Polygons.1'},{'path':'Polygons/Polygons.2'},{'path':'Polygons/Polygons.3'}]";
+        String expected = "[{'path':'Points/1'},{'path':'Points/2'},{'path':'Points/3'},"
+                + "{'path':'Lines/1'},{'path':'Lines/2'},{'path':'Lines/3'},"
+                + "{'path':'Polygons/1'},{'path':'Polygons/2'},{'path':'Polygons/3'}]";
         JSONAssert.assertEquals(expected, nodes.toString(), false);
     }
 
@@ -155,7 +155,7 @@ public class LsTreeTest extends AbstractWebOpTest {
         JSONObject response = getJSONResponse().getJSONObject("response");
         assertTrue(response.getBoolean("success"));
         JSONArray nodes = response.getJSONArray("node");
-        String expected = "[{'path':'Points.1'},{'path':'Points.2'},{'path':'Points.3'}]";
+        String expected = "[{'path':1},{'path':2},{'path':3}]";
         JSONAssert.assertEquals(expected, nodes.toString(), false);
     }
 }

--- a/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
@@ -27,18 +27,32 @@ import java.io.OutputStream;
 import java.io.StringReader;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
+import java.util.UUID;
 
 import javax.xml.transform.Source;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamSource;
 
+import org.geotools.data.DataStore;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.DefaultTransaction;
+import org.geotools.data.Transaction;
+import org.geotools.data.simple.SimpleFeatureStore;
 import org.geotools.geopkg.FeatureEntry;
 import org.geotools.geopkg.GeoPackage;
+import org.locationtech.geogig.api.GeoGIG;
+import org.locationtech.geogig.api.GeogigTransaction;
+import org.locationtech.geogig.api.plumbing.TransactionBegin;
+import org.locationtech.geogig.api.plumbing.TransactionEnd;
+import org.locationtech.geogig.geotools.geopkg.GeopkgAuditExport;
 import org.locationtech.geogig.rest.AsyncContext;
 import org.locationtech.geogig.rest.Variants;
 import org.locationtech.geogig.rest.geopkg.GeoPackageTestSupport;
+import org.locationtech.geogig.web.api.TestData;
 import org.mortbay.log.Log;
+import org.opengis.filter.Filter;
 import org.restlet.data.Method;
 import org.restlet.data.Response;
 import org.restlet.data.Status;
@@ -49,6 +63,7 @@ import org.xmlunit.matchers.EvaluateXPathMatcher;
 import org.xmlunit.matchers.HasXPathMatcher;
 import org.xmlunit.xpath.JAXPXPathEngine;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.ImmutableMap;
@@ -137,7 +152,13 @@ public class WebAPICucumberHooks {
         SetMultimap<String, String> expected = HashMultimap.create();
         {
             List<Map<String, String>> asMaps = expectedFeatures.asMaps(String.class, String.class);
-            asMaps.forEach((m) -> m.forEach((k, v) -> expected.put(k, v)));
+            for (Map<String, String> featureMap : asMaps) {
+                for (Entry<String, String> entry : featureMap.entrySet()) {
+                    if (entry.getValue().length() > 0) {
+                        expected.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
         }
 
         SetMultimap<String, String> actual = context.listRepo(repositoryName, headRef);
@@ -166,6 +187,49 @@ public class WebAPICucumberHooks {
         Method method = Method.valueOf(httpMethod);
         // System.err.println(methodAndURL);
         context.call(method, resourceUri);
+    }
+
+    /**
+     * Creates a transaction on the given repository and stores the transaction id in the given
+     * variable for later use.
+     * 
+     * @param variableName the variable name to store the transaction id.
+     * @param repoName the repository on which to create the transaction.
+     */
+    @Given("^I have a transaction as \"([^\"]*)\" on the \"([^\"]*)\" repo$")
+    public void beginTransactionAsVariable(final String variableName, final String repoName) {
+        GeogigTransaction transaction = context.getRepo(repoName).command(TransactionBegin.class)
+                .call();
+
+        context.setVariable(variableName, transaction.getTransactionId().toString());
+    }
+
+    /**
+     * Ends the given transaction on the given repository.
+     * 
+     * @param variableName the variable where the transaction id is stored.
+     * @param repoName the repository on which the transaction was created.
+     */
+    @When("^I end the transaction with id \"([^\"]*)\" on the \"([^\"]*)\" repo$")
+    public void endTransaction(final String variableName, final String repoName) {
+        GeoGIG repo = context.getRepo(repoName);
+        GeogigTransaction transaction = new GeogigTransaction(repo.getContext(),
+                UUID.fromString(context.getVariable(variableName)));
+        repo.command(TransactionEnd.class).setTransaction(transaction).call();
+    }
+
+    /**
+     * Removes Points/1 from the repository.
+     * 
+     * @param repoName the repository to remove the feature from.
+     */
+    @When("^I remove Points/1 from \"([^\"]*)\"$")
+    public void removeFeature(final String repoName) throws Exception {
+        GeoGIG repo = context.getRepo(repoName);
+        TestData data = new TestData(repo);
+        data.remove(TestData.point1);
+        data.add();
+        data.commit("Removed point1");
     }
 
     /**
@@ -459,6 +523,71 @@ public class WebAPICucumberHooks {
         GeoPackageTestSupport support = new GeoPackageTestSupport(context.getTempFolder());
         File dbfile = support.createDefaultTestData();
         context.setVariable(fileVariableName, dbfile.getAbsolutePath());
+    }
+
+    /**
+     * Exports the Points feature type to a geopackage from the given repository and stores the file
+     * name in the given variable.
+     * 
+     * @param repoName the repository to export from.
+     * @param fileVariableName the variable to store the geopackage file name in.
+     */
+    @Given("^I export Points from \"([^\"]*)\" to a geopackage file with audit logs as (@[^\"]*)$")
+    public void gpkg_ExportAuditLogs(final String repoName, final String fileVariableName)
+            throws Throwable {
+        GeoPackageTestSupport support = new GeoPackageTestSupport(context.getTempFolder());
+        GeoGIG geogig = context.getRepo(repoName);
+        File file = support.createDefaultTestData();
+        geogig.command(GeopkgAuditExport.class).setDatabase(file).setTargetTableName("Points")
+                .setSourcePathspec("Points").call();
+        context.setVariable(fileVariableName, file.getAbsolutePath());
+    }
+
+    /**
+     * Adds Points/4 feature to the geopackage file referred to by the provided variable name.
+     * 
+     * @param fileVariableName the variable which stores the location of the geopackage file.
+     */
+    @When("^I add Points/4 to the geopackage file (@[^\"]*)$")
+    public void gpkg_AddFeature(final String fileVariableName) throws Throwable {
+        GeoPackageTestSupport support = new GeoPackageTestSupport();
+        File file = new File(context.getVariable(fileVariableName));
+        DataStore gpkgStore = support.createDataStore(file);
+        Transaction gttx = new DefaultTransaction();
+        try {
+            SimpleFeatureStore store = (SimpleFeatureStore) gpkgStore.getFeatureSource("Points");
+            Preconditions.checkState(store.getQueryCapabilities().isUseProvidedFIDSupported());
+            store.setTransaction(gttx);
+            store.addFeatures(DataUtilities.collection(TestData.point4));
+            gttx.commit();
+        } finally {
+            gttx.close();
+            gpkgStore.dispose();
+        }
+    }
+
+    /**
+     * Modifies all the Point features in the geopackage file referred to by the provided variable
+     * name.
+     * 
+     * @param fileVariableName the variable which stores the location of the geopackage file.
+     */
+    @When("^I modify the Point features in the geopackage file (@[^\"]*)$")
+    public void gpkg_ModifyFeature(final String fileVariableName) throws Throwable {
+        GeoPackageTestSupport support = new GeoPackageTestSupport();
+        File file = new File(context.getVariable(fileVariableName));
+        DataStore gpkgStore = support.createDataStore(file);
+        Transaction gttx = new DefaultTransaction();
+        try {
+            SimpleFeatureStore store = (SimpleFeatureStore) gpkgStore.getFeatureSource("Points");
+            Preconditions.checkState(store.getQueryCapabilities().isUseProvidedFIDSupported());
+            store.setTransaction(gttx);
+            store.modifyFeatures("ip", TestData.point1_modified.getAttribute("ip"), Filter.INCLUDE);
+            gttx.commit();
+        } finally {
+            gttx.close();
+            gpkgStore.dispose();
+        }
     }
 
     /**

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageExport.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageExport.feature
@@ -48,14 +48,3 @@ Feature: Export GeoPackage
       And the task @taskId result contains "atom:link/@href" with value "/tasks/{@taskId}/download"
      When I call "GET /tasks/{@taskId}/download"
      Then the result is a valid GeoPackage file
-     
-  Scenario: Export from an empty HEAD produces a valid empty geopackage
-    Given There is an empty repository named emptyRepo
-     When I call "GET /repos/emptyRepo/export?format=gpkg"
-     Then the response is an XML async task @taskId
-      And the task @taskId description contains "Export to Geopackage database"
-      And when the task @taskId finishes
-     Then the task @taskId status is FINISHED
-      And the task @taskId result contains "atom:link/@href" with value "/tasks/{@taskId}/download"
-     When I call "GET /tasks/{@taskId}/download"
-     Then the result is a valid GeoPackage file

--- a/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageImport.feature
+++ b/src/web/functional/src/test/resources/org/geogig/web/functional/GeoPackageImport.feature
@@ -14,8 +14,9 @@ Feature: Import GeoPackage
       And the response allowed methods should be "POST"
       
   Scenario: Verify missing "format=gpkg" argument issues 400 "Bad request"
-    Given There is a default multirepo server
-     When I call "POST /repos/repo1/import"
+    Given There is an empty repository named repo1
+      And I have a transaction as "@txId" on the "repo1" repo
+     When I call "POST /repos/repo1/import?transactionId={@txId}"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the response xml matches
@@ -24,8 +25,9 @@ Feature: Import GeoPackage
       """
 
   Scenario: Verify unsupported output format argument issues 400 "Bad request"
-    Given There is a default multirepo server
-     When I call "POST /repos/repo1/import?format=badFormat"
+    Given There is an empty repository named repo1
+      And I have a transaction as "@txId" on the "repo1" repo
+     When I call "POST /repos/repo1/import?format=badFormat&transactionId={@txId}"
      Then the response status should be '400'
       And the response ContentType should be "application/xml"
       And the response xml matches
@@ -44,18 +46,82 @@ Feature: Import GeoPackage
   Scenario: Import to an empty repository
     Given There is an empty repository named targetRepo
       And I have a geopackage file @gpkgFile
-     When I post @gpkgFile as "fileUpload" to "/repos/targetRepo/import?format=gpkg"
+      And I have a transaction as "@txId" on the "targetRepo" repo
+     When I post @gpkgFile as "fileUpload" to "/repos/targetRepo/import?format=gpkg&transactionId={@txId}"
      Then the response status should be '200'
       And the response is an XML async task @taskId
       And the task @taskId description contains "Importing GeoPackage database file."
       And when the task @taskId finishes
      Then the task @taskId status is FINISHED
-      And the xml response should contain "/task/result/RevCommit/id"
-      And the xml response should contain "/task/result/RevCommit/treeId"
+      And the xml response should contain "/task/result/commit/id"
+      And the xml response should contain "/task/result/commit/tree"
+      And I end the transaction with id "@txId" on the "targetRepo" repo
       And the targetRepo repository's HEAD should have the following features:
           | Points | Lines | Polygons | 
           |    1   |   1   |    1     | 
           |    2   |   2   |    2     | 
           |    3   |   3   |    3     | 
+          
+  Scenario: Import an interchange geopackage with fast-forward merge
+    Given There is a default multirepo server
+      And I export Points from "repo1" to a geopackage file with audit logs as @gpkgFile
+      And I have a transaction as "@txId" on the "repo1" repo
+     When I add Points/4 to the geopackage file @gpkgFile
+      And I post @gpkgFile as "fileUpload" to "/repos/repo1/import?format=gpkg&message=Imported%20Geopackage&interchange=true&transactionId={@txId}"
+     Then the response status should be '200'
+      And the response is an XML async task @taskId
+      And the task @taskId description contains "Importing GeoPackage database file."
+      And when the task @taskId finishes
+     Then the task @taskId status is FINISHED
+      And the xml response should contain "/task/result/commit/id"
+      And the xml response should contain "/task/result/commit/tree"
+      And the xpath "/task/result/commit/message" equals "Imported Geopackage"
+      And I end the transaction with id "@txId" on the "repo1" repo
+      And the repo1 repository's HEAD should have the following features:
+          | Points | Lines | Polygons | 
+          |    1   |   1   |    1     | 
+          |    2   |   2   |    2     | 
+          |    3   |   3   |    3     | 
+          |    4   |       |          |
+      
+  Scenario: Import an interchange geopackage with non-conflicting merge
+    Given There is a default multirepo server
+      And I export Points from "repo1" to a geopackage file with audit logs as @gpkgFile
+     When I add Points/4 to the geopackage file @gpkgFile
+      And I remove Points/1 from "repo1"
+      And I have a transaction as "@txId" on the "repo1" repo
+      And I post @gpkgFile as "fileUpload" to "/repos/repo1/import?format=gpkg&message=Imported%20Geopackage&interchange=true&transactionId={@txId}"
+     Then the response status should be '200'
+      And the response is an XML async task @taskId
+      And the task @taskId description contains "Importing GeoPackage database file."
+      And when the task @taskId finishes
+     Then the task @taskId status is FINISHED
+      And the xml response should contain "/task/result/commit/id"
+      And the xml response should contain "/task/result/commit/tree"
+      And the xpath "/task/result/commit/message" equals "Merge: Imported Geopackage"
+      And I end the transaction with id "@txId" on the "repo1" repo
+      And the repo1 repository's HEAD should have the following features:
+          | Points | Lines | Polygons | 
+          |    2   |   1   |    1     | 
+          |    3   |   2   |    2     | 
+          |    4   |   3   |    3     | 
+      
+  Scenario: Import an interchange geopackage with conflicting merge
+    Given There is a default multirepo server
+      And I export Points from "repo1" to a geopackage file with audit logs as @gpkgFile
+     When I modify the Point features in the geopackage file @gpkgFile
+      And I remove Points/1 from "repo1"
+      And I have a transaction as "@txId" on the "repo1" repo
+      And I post @gpkgFile as "fileUpload" to "/repos/repo1/import?format=gpkg&message=Imported%20Geopackage&interchange=true&transactionId={@txId}"
+     Then the response status should be '200'
+      And the response is an XML async task @taskId
+      And the task @taskId description contains "Importing GeoPackage database file."
+      And when the task @taskId finishes
+     Then the task @taskId status is FAILED
+      And the xml response should contain "/task/result/Merge/ours"
+      And the xml response should contain "/task/result/Merge/theirs"
+      And the xml response should contain "/task/result/Merge/ancestor"
+      And the xpath "/task/result/Merge/conflicts" equals "1"
+
 
 #<task><id>1</id><status>FINISHED</status><transactionId>c4da5a9b-5b09-4cb6-9055-e340d02b57ac</transactionId><description>Importing GeoPackage database file.</description><atom:link xmlns:atom="http://www.w3.org/2005/Atom" rel="alternate" href="/tasks/1.xml" type="application/xml"/><result><RevCommit><id>a1cde458d0658e096998b740b2eaa7b10796e624</id><treeId>37987a1d4afbf60be906d55576392965654d5d9c</treeId></RevCommit></result></task>


### PR DESCRIPTION
Audit logs keep track of which commit the export came from so that it can be safely merged and conflicts can be resolved during import.