### PR TITLE
Abstract out the compression of serialized object to a wrapper Object…

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/storage/ObjectSerializingFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/ObjectSerializingFactory.java
@@ -23,51 +23,6 @@ import org.locationtech.geogig.api.RevObject;
  */
 public interface ObjectSerializingFactory {
 
-    // /**
-    // * Creates an instance of a commit reader.
-    // *
-    // * @return commit reader
-    // */
-    //
-    // public ObjectReader<RevCommit> createCommitReader();
-    //
-    // /**
-    // * Creates an instance of a RevTree reader.
-    // */
-    // public ObjectReader<RevTree> createRevTreeReader();
-    //
-    // /**
-    // * Creates an instance of a Feature reader that can parse features.
-    // *
-    // * @return feature reader
-    // */
-    // public ObjectReader<RevFeature> createFeatureReader();
-    //
-    // /**
-    // * Creates an instance of a Feature reader that can parse features.
-    // *
-    // * @param hints feature creation hints
-    // * @return feature reader
-    // */
-    // public ObjectReader<RevFeature> createFeatureReader(final Map<String, Serializable> hints);
-    //
-    // /**
-    // * Creates an instance of a feature type reader that can parse feature types.
-    // *
-    // * @return feature type reader
-    // */
-    // public ObjectReader<RevFeatureType> createFeatureTypeReader();
-    //
-    // public <T extends RevObject> ObjectWriter<T> createObjectWriter(TYPE type);
-    //
-    // /**
-    // * @param type
-    // * @return
-    // */
-    // public <T extends RevObject> ObjectReader<T> createObjectReader(TYPE type);
-    //
-    // public ObjectReader<RevObject> createObjectReader();
-
     void write(RevObject o, OutputStream out) throws IOException;
 
     RevObject read(ObjectId id, InputStream in) throws IOException;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactory.java
@@ -1,0 +1,51 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Erik Merkle (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.datastream;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import org.locationtech.geogig.api.ObjectId;
+import org.locationtech.geogig.api.RevObject;
+import org.locationtech.geogig.storage.ObjectSerializingFactory;
+
+import com.google.common.base.Preconditions;
+import com.ning.compress.lzf.LZFInputStream;
+import com.ning.compress.lzf.LZFOutputStream;
+
+/**
+ * Wrapper Factory that deflates/inflates data written to/read from streams using LZF compression.
+ */
+public class LZFSerializationFactory implements ObjectSerializingFactory {
+
+    private final ObjectSerializingFactory factory;
+
+    public LZFSerializationFactory(final ObjectSerializingFactory factory) {
+        Preconditions.checkNotNull(factory);
+        this.factory = factory;
+    }
+
+    @Override
+    public RevObject read(ObjectId id, InputStream rawData) throws IOException {
+        // decompress the stream
+        try (LZFInputStream inflatedInputeStream = new LZFInputStream(rawData)) {
+            return factory.read(id, inflatedInputeStream);
+        }
+    }
+
+    @Override
+    public void write(RevObject o, OutputStream out) throws IOException {
+        // compress the stream
+        try (LZFOutputStream deflatedOutputStream = new LZFOutputStream(out)) {
+            factory.write(o, deflatedOutputStream);
+        }
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/storage/fs/FileObjectDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/fs/FileObjectDatabase.java
@@ -36,6 +36,7 @@ import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConflictsDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
+import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
@@ -82,7 +83,7 @@ public class FileObjectDatabase extends AbstractObjectDatabase implements Object
 
     protected FileObjectDatabase(final Platform platform, final String databaseName,
             final ConfigDatabase configDB) {
-        super(DataStreamSerializationFactoryV1.INSTANCE);
+        super(new LZFSerializationFactory(DataStreamSerializationFactoryV1.INSTANCE));
         checkNotNull(platform);
         checkNotNull(databaseName);
         this.platform = platform;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapObjectStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapObjectStore.java
@@ -25,13 +25,13 @@ import org.locationtech.geogig.storage.AbstractObjectDatabase;
 import org.locationtech.geogig.storage.AbstractObjectStore;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
+import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-import com.ning.compress.lzf.LZFInputStream;
 
 /**
  * Provides an implementation of a GeoGig object database that utilizes the heap for the storage of
@@ -44,7 +44,7 @@ public class HeapObjectStore extends AbstractObjectStore {
     private ConcurrentMap<ObjectId, byte[]> objects;
 
     public HeapObjectStore() {
-        super(DataStreamSerializationFactoryV2.INSTANCE);
+        super(new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE));
     }
 
     /**
@@ -199,8 +199,7 @@ public class HeapObjectStore extends AbstractObjectStore {
                     raw = objects.get(id);
                     if (raw != null) {
                         try {
-                            RevObject obj = serializer.read(id,
-                                    new LZFInputStream(new ByteArrayInputStream(raw)));
+                            RevObject obj = serializer.read(id, new ByteArrayInputStream(raw));
                             found = type.isAssignableFrom(obj.getClass()) ? type.cast(obj) : null;
                         } catch (IOException e) {
                             throw Throwables.propagate(e);

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase.java
@@ -840,8 +840,7 @@ abstract class JEObjectDatabase extends AbstractObjectDatabase implements Object
                     OperationStatus status;
                     status = cursor.getSearchKey(key, data, LockMode.READ_UNCOMMITTED);
                     if (SUCCESS.equals(status)) {
-                        InputStream rawData;
-                        rawData = new LZFInputStream(new ByteArrayInputStream(data.getData()));
+                        InputStream rawData = new ByteArrayInputStream(data.getData());
                         found = reader.read(id, rawData);
                         if (filter.isAssignableFrom(found.getClass())) {
                             listener.found(found.getId(), data.getSize());

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase_v0_1.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase_v0_1.java
@@ -13,6 +13,7 @@ import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
+import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 
 import com.google.inject.Inject;
 
@@ -26,7 +27,8 @@ public final class JEObjectDatabase_v0_1 extends JEObjectDatabase {
 
     public JEObjectDatabase_v0_1(final ConfigDatabase configDB,
             final EnvironmentBuilder envProvider, final boolean readOnly, final String envName) {
-        super(DataStreamSerializationFactoryV1.INSTANCE, configDB, envProvider, readOnly, envName);
+        super(new LZFSerializationFactory(DataStreamSerializationFactoryV1.INSTANCE), configDB,
+                envProvider, readOnly, envName);
     }
 
     @Override

--- a/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase_v0_2.java
+++ b/src/storage/bdbje/src/main/java/org/locationtech/geogig/storage/bdbje/JEObjectDatabase_v0_2.java
@@ -13,6 +13,7 @@ import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.RepositoryConnectionException;
 import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
+import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 
 import com.google.inject.Inject;
 
@@ -26,7 +27,8 @@ public final class JEObjectDatabase_v0_2 extends JEObjectDatabase {
 
     public JEObjectDatabase_v0_2(final ConfigDatabase configDB,
             final EnvironmentBuilder envProvider, final boolean readOnly, final String envName) {
-        super(DataStreamSerializationFactoryV2.INSTANCE, configDB, envProvider, readOnly, envName);
+        super(new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE), configDB,
+                envProvider, readOnly, envName);
     }
 
     @Override

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/DataSourceManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/DataSourceManager.java
@@ -33,7 +33,7 @@ class DataSourceManager extends ConnectionManager<Environment.ConnectionConfig, 
         hc.setConnectionInitSql("SELECT NOW()");
         hc.setConnectionTestQuery("SELECT NOW()");
         hc.setDriverClassName("org.postgresql.Driver");
-
+        
         final String jdbcUrl = getUrl(config);
         hc.setJdbcUrl(jdbcUrl);
 

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRevObjectEncoder.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRevObjectEncoder.java
@@ -1,0 +1,85 @@
+/* Copyright (c) 2016 Boundless.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.postgresql;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+
+import org.locationtech.geogig.api.ObjectId;
+import org.locationtech.geogig.api.RevObject;
+import org.locationtech.geogig.storage.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
+import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
+import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
+
+/**
+ * An encoder for {@link RevObject} instances that delegates the the best available
+ * {@link ObjectSerializingFactory} while maintaining backwards compatibility.
+ * <p>
+ * The purpose of this encoder is to abstract out {@link PGObjectDatabase} from the details of
+ * serialization, allowing improved {@link ObjectSerializingFactory} implementations to be added
+ * transparently, while maintaining backwards compatibility with objects encoded with prior versions
+ * of the serialization format.
+ * <p>
+ * Serialized representations of {@code RevObject}s created by this encoder are composed of a
+ * one-byte header followed by the encoded result of the concrete {@link ObjectSerializingFactory}
+ * this encoder delegates to.
+ * <p>
+ * When deserializing a byte array from postgres, the header is used to identify which serializer
+ * "version" the object was encoded with, and delegate to the proper serialiser. This way, there can
+ * be objects of mixed serialization formats in the same database transparently, so upgrading the
+ * serialization format requires no extra maintainance.
+ */
+public class PGRevObjectEncoder {
+    /**
+     * The serialized object is added a header that's one unsigned byte with the index of the
+     * corresponding factory in this array
+     */
+    private static final ObjectSerializingFactory[] SUPPORTED_FORMATS = { //
+            new LZFSerializationFactory(DataStreamSerializationFactoryV1.INSTANCE), //
+            new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE) //
+    };
+
+    private static final int MAX_FORMAT_CODE = SUPPORTED_FORMATS.length - 1;
+
+    /**
+     * The serialization factory used for writing is the highest supported version one
+     */
+    private static final ObjectSerializingFactory WRITER = SUPPORTED_FORMATS[MAX_FORMAT_CODE];
+
+    /**
+     * Reads object from its binary representation as stored in the database.
+     */
+    public RevObject decode(final ObjectId id, final byte[] bytes) {
+        try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
+            final int serialVersionHeader = in.read();
+            assert serialVersionHeader >= 0 && serialVersionHeader <= MAX_FORMAT_CODE;
+            final ObjectSerializingFactory serializer = SUPPORTED_FORMATS[serialVersionHeader];
+            RevObject revObject = serializer.read(id, in);
+            return revObject;
+        } catch (IOException e) {
+            throw new RuntimeException("Error reading object " + id, e);
+        }
+    }
+
+    public byte[] encode(final RevObject o) {
+        final int storageVersionHeader = MAX_FORMAT_CODE;
+        try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
+            bout.write(storageVersionHeader);
+            WRITER.write(o, bout);
+            byte[] bytes = bout.toByteArray();
+            return bytes;
+        } catch (Exception e) {
+            throw new RuntimeException("Error encoding object " + o, e);
+        }
+    }
+
+}


### PR DESCRIPTION
…SerializationFactory.

The LZF compression/decompression for RevObject was leaking
to a couple places inside ObectStore implementations. Abstracted
it out to a decorator LZFSerializationFactory and left the
ObjectStore implementation code agnostic of the compression method
used (other than to setting their own serializer kind).

The PostgreSQL storage backend now delegates to it's own encoder
to take care of adding the backwards compatibility object header.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>