### PR TITLE
Fix Pgsql defaultplugins

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/di/PluginsModule.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/PluginsModule.java
@@ -34,10 +34,10 @@ public class PluginsModule extends AbstractModule {
     @Override
     protected void configure() {
 
-        bind(ConfigDatabase.class).toProvider(PluginConfigDatabaseProvider.class).in(
-                Scopes.SINGLETON);
-        bind(ObjectDatabase.class).toProvider(PluginObjectDatabaseProvider.class).in(
-                Scopes.SINGLETON);
+        bind(ConfigDatabase.class).toProvider(PluginConfigDatabaseProvider.class)
+                .in(Scopes.SINGLETON);
+        bind(ObjectDatabase.class).toProvider(PluginObjectDatabaseProvider.class)
+                .in(Scopes.SINGLETON);
         bind(RefDatabase.class).toProvider(PluginRefDatabaseProvider.class).in(Scopes.SINGLETON);
         bind(GraphDatabase.class).toProvider(PluginGraphDatabaseProvider.class)
                 .in(Scopes.SINGLETON);
@@ -64,7 +64,8 @@ public class PluginsModule extends AbstractModule {
             if (uri.isPresent()) {
                 config = RepositoryResolver.resolveConfigDatabase(uri.get(), context);
             } else {
-                config = new IniFileConfigDatabase(platform);
+                // if there's no repository URI, then we can only do global operations
+                config = IniFileConfigDatabase.globalOnly(platform);
             }
             return config;
         }
@@ -107,9 +108,9 @@ public class PluginsModule extends AbstractModule {
                     return objectFormat;
                 }
             }
-            throw new IllegalStateException(String.format(
-                    "No storage provider found for %s='%s' and %s='%s'", formatKey, format,
-                    versionKey, version));
+            throw new IllegalStateException(
+                    String.format("No storage provider found for %s='%s' and %s='%s'", formatKey,
+                            format, versionKey, version));
         }
 
     }
@@ -153,9 +154,9 @@ public class PluginsModule extends AbstractModule {
                 }
             }
 
-            throw new IllegalStateException(String.format(
-                    "No storage provider found for %s='%s' and %s='%s'", formatKey, format,
-                    versionKey, version));
+            throw new IllegalStateException(
+                    String.format("No storage provider found for %s='%s' and %s='%s'", formatKey,
+                            format, versionKey, version));
         }
     }
 
@@ -197,9 +198,9 @@ public class PluginsModule extends AbstractModule {
                 }
             }
 
-            throw new IllegalStateException(String.format(
-                    "No storage provider found for %s='%s' and %s='%s'", formatKey, format,
-                    versionKey, version));
+            throw new IllegalStateException(
+                    String.format("No storage provider found for %s='%s' and %s='%s'", formatKey,
+                            format, versionKey, version));
         }
     }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/storage/fs/IniFileConfigDatabaseTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/fs/IniFileConfigDatabaseTest.java
@@ -9,18 +9,47 @@
  */
 package org.locationtech.geogig.storage.fs;
 
+import org.junit.Assert;
+import org.junit.Test;
 import org.locationtech.geogig.api.Platform;
+import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConfigDatabaseTest;
+import org.locationtech.geogig.storage.ConfigException;
 
 public class IniFileConfigDatabaseTest extends ConfigDatabaseTest<IniFileConfigDatabase> {
 
+    private Platform platform;
+
     protected IniFileConfigDatabase createDatabase(final Platform platform) {
+        this.platform = platform;
         return new IniFileConfigDatabase(platform);
     }
 
     @Override
     protected void destroy(IniFileConfigDatabase config) {
         //
+    }
+
+    @Test
+    public void testGlobalOnly() {
+        ConfigDatabase globalOnly = IniFileConfigDatabase.globalOnly(platform);
+        testGlobalOnly(() -> globalOnly.get("section.key"));
+        testGlobalOnly(() -> globalOnly.getAll());
+        testGlobalOnly(() -> globalOnly.get("section.key", String.class));
+        testGlobalOnly(() -> globalOnly.getAllSection("section"));
+        testGlobalOnly(() -> globalOnly.getAllSubsections("section.sub"));
+        testGlobalOnly(() -> globalOnly.put("section.key", "val"));
+        testGlobalOnly(() -> globalOnly.remove("section.key"));
+        testGlobalOnly(() -> globalOnly.removeSection("section"));
+    }
+
+    private void testGlobalOnly(Runnable call) {
+        try {
+            call.run();
+            Assert.fail("Expected ConfigException");
+        } catch (ConfigException e) {
+            Assert.assertEquals(ConfigException.StatusCode.INVALID_LOCATION, e.statusCode);
+        }
     }
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
@@ -14,7 +14,6 @@ import java.net.URI;
 import org.locationtech.geogig.api.Context;
 import org.locationtech.geogig.api.GeoGIG;
 import org.locationtech.geogig.api.GlobalContextBuilder;
-import org.locationtech.geogig.di.PluginDefaults;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.RepositoryConnectionException;
@@ -53,17 +52,11 @@ public class PGRepositoryResolver extends RepositoryResolver {
         if (config.getRepositoryId() != null) {
             Optional<String> refsFormat = configDb.getGlobal("storage.refs");
             if (!refsFormat.isPresent()) {
-                configDb.putGlobal(PGStorageProvider.FORMAT_NAME + ".version",
-                        PGStorageProvider.VERSION);
-                configDb.putGlobal("storage.refs", PGStorageProvider.FORMAT_NAME);
-                configDb.putGlobal("storage.objects", PGStorageProvider.FORMAT_NAME);
-                configDb.putGlobal("storage.graph", PGStorageProvider.FORMAT_NAME);
+                configDb.put(PGStorageProvider.FORMAT_NAME + ".version", PGStorageProvider.VERSION);
+                configDb.put("storage.refs", PGStorageProvider.FORMAT_NAME);
+                configDb.put("storage.objects", PGStorageProvider.FORMAT_NAME);
+                configDb.put("storage.graph", PGStorageProvider.FORMAT_NAME);
             }
-
-            PluginDefaults pluginDefaults = repoContext.pluginDefaults();
-            pluginDefaults.setGraph(PGStorageProvider.GRAPH);
-            pluginDefaults.setRefs(PGStorageProvider.REFS);
-            pluginDefaults.setObjects(PGStorageProvider.OBJECTS);
         }
         return configDb;
     }


### PR DESCRIPTION
Fixed #93 

PGRepositoryResolver was changing the DefaultPlugin settings,
leading to serving mixed repository types being broken.

This patch removes the DefaultPlugins override and makes
InitOp to respect whatever defaults is provided by the
ConfigDatabase returned by the  RepositoryResolver.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>