### PR TITLE
Fix POM deployment config

### DIFF
--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -385,13 +385,11 @@
   <distributionManagement>
     <repository>
       <id>boundless</id>
-      <uniqueVersion>false</uniqueVersion>
       <name>Boundless Release Repository</name>
       <url>https://repo.boundlessgeo.com/release/</url>
     </repository>
     <snapshotRepository>
       <id>boundless</id>
-      <uniqueVersion>false</uniqueVersion>
       <name>Boundless Snapshot Repository</name>
       <url>https://repo.boundlessgeo.com/snapshot/</url>
     </snapshotRepository>

--- a/src/storage/postgres/pom.xml
+++ b/src/storage/postgres/pom.xml
@@ -28,7 +28,6 @@
     <dependency>
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
-      <version>${hikaricp.version}</version>
     </dependency>
     
     <!-- Test scope dependencies -->


### PR DESCRIPTION
  - remove <uniqueVersion> config as it is no longer supported in Maven 3
  - remove unnecessary ${hikaricp.version} specification