### PR TITLE
Various encoding-related fixes

### DIFF
--- a/src/cli-app/src/main/java/org/locationtech/geogig/cli/GeogigPy4JEntryPoint.java
+++ b/src/cli-app/src/main/java/org/locationtech/geogig/cli/GeogigPy4JEntryPoint.java
@@ -13,6 +13,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintStream;
+import java.io.ByteArrayOutputStream;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
@@ -41,26 +42,25 @@ public class GeogigPy4JEntryPoint {
 
         private static final int PAGE_SIZE = 1000;
 
-        StringBuffer sb = new StringBuffer();
+        ByteArrayOutputStream bytes = new ByteArrayOutputStream();
 
         @Override
         public void write(int b) throws IOException {
-            char c = (char) b;
-            String s = String.valueOf(c);
-            sb.append(s);
+            bytes.write((byte)b);
         }
 
         public void clear() {
-            sb = new StringBuffer();
+            bytes = new ByteArrayOutputStream();
         }
 
-        public String asString() {
-            return sb.toString();
+        public String asString() throws IOException {
+            return bytes.toString("UTF-8");
         }
 
-        public Iterator<String> getIterator() {
+        public Iterator<String> getIterator() throws IOException {
             Splitter page = Splitter.fixedLength(PAGE_SIZE);
-            return page.split(sb.toString()).iterator();
+            String buffer = bytes.toString("UTF-8");
+            return page.split(buffer).iterator();
         }
 
     }
@@ -89,7 +89,7 @@ public class GeogigPy4JEntryPoint {
 
     /**
      * Runs a command on a given repository
-     * 
+     *
      * @param folder the repository folder
      * @param args the args to run, including the command itself and additional parameters
      * @return
@@ -169,7 +169,7 @@ public class GeogigPy4JEntryPoint {
 
     /**
      * Sets the progress listener that will receive progress updates
-     * 
+     *
      * @param listener
      */
     public void setProgressListener(GeoGigPy4JProgressListener listener) {

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/shp/ShpExport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/shp/ShpExport.java
@@ -54,7 +54,7 @@ import com.google.common.base.Optional;
 
 /**
  * Exports features from a feature type into a shapefile.
- * 
+ *
  * @see ExportOp
  */
 @ReadOnly
@@ -79,6 +79,12 @@ public class ShpExport extends AbstractShpCommand implements CLICommand {
             "--featuretype" }, description = "Export only features with the specified feature type if several types are found")
     @Nullable
     public String sFeatureTypeId;
+
+    /**
+     * Charset to use for encoding attributes in DBF file
+     */
+    @Parameter(names = { "--charset" }, description = "Use the specified charset to encode attributes. Default is ISO-8859-1.")
+    public String charset = "ISO-8859-1";
 
     /**
      * Executes the export command using the provided options.
@@ -111,6 +117,7 @@ public class ShpExport extends AbstractShpCommand implements CLICommand {
         params.put(ShapefileDataStoreFactory.URLP.key, targetShapefileAsUrl);
         params.put(ShapefileDataStoreFactory.CREATE_SPATIAL_INDEX.key, Boolean.FALSE);
         params.put(ShapefileDataStoreFactory.ENABLE_SPATIAL_INDEX.key, Boolean.FALSE);
+        params.put(ShapefileDataStoreFactory.DBFCHARSET.key, charset);
 
         ShapefileDataStore dataStore = (ShapefileDataStore) dataStoreFactory
                 .createNewDataStore(params);

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/shp/ShpExportDiff.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/cli/shp/ShpExportDiff.java
@@ -51,7 +51,7 @@ import com.google.common.base.Optional;
 
 /**
  * Exports features from a feature type into a shapefile.
- * 
+ *
  * @see ExportOp
  */
 @Parameters(commandNames = "export-diff", commandDescription = "Export changed features to Shapefile")
@@ -65,6 +65,12 @@ public class ShpExportDiff extends AbstractShpCommand implements CLICommand {
 
     @Parameter(names = { "--old" }, description = "Export features from the old version instead of the most recent one")
     public boolean old;
+
+    /**
+     * Charset to use for encoding attributes in DBF file
+     */
+    @Parameter(names = { "--charset" }, description = "Use the specified charset to encode attributes. Default is ISO-8859-1.")
+    public String charset = "ISO-8859-1";
 
     /**
      * Executes the export command using the provided options.
@@ -93,6 +99,7 @@ public class ShpExportDiff extends AbstractShpCommand implements CLICommand {
         params.put(ShapefileDataStoreFactory.URLP.key, file.toURI().toURL());
         params.put(ShapefileDataStoreFactory.CREATE_SPATIAL_INDEX.key, Boolean.FALSE);
         params.put(ShapefileDataStoreFactory.ENABLE_SPATIAL_INDEX.key, Boolean.FALSE);
+        params.put(ShapefileDataStoreFactory.DBFCHARSET.key, charset);
 
         ShapefileDataStore dataStore = (ShapefileDataStore) dataStoreFactory
                 .createNewDataStore(params);
@@ -153,7 +160,7 @@ public class ShpExportDiff extends AbstractShpCommand implements CLICommand {
             final SimpleFeatureType featureType) {
 
         Function<Feature, Optional<Feature>> function = (feature) -> {
-            
+
             SimpleFeatureBuilder builder = new SimpleFeatureBuilder(featureType);
             for (Property property : feature.getProperties()) {
                 if (property instanceof GeometryAttribute) {


### PR DESCRIPTION
This introduces `--charset` option in `shp export` and `shp export-diff` commands to allow exporting shapefiles with desired encoding.

Second commit fixes multibyte characters handling in Py4J connector. 