### PR TITLE
fix typo on merge conflicts message

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/repository/Index.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/Index.java
@@ -268,7 +268,7 @@ public class Index implements StagingArea {
                 }
 
                 if (pathsForConflictCleanup.size() > 0L) {
-                    progress.setDescription(String.format("Removing %,d merged conflcits...",
+                    progress.setDescription(String.format("Removing %,d merged conflicts...",
                             pathsForConflictCleanup.size()));
                     // Stopwatch sw = Stopwatch.createStarted();
                     conflictsDb.removeConflicts(null, pathsForConflictCleanup);


### PR DESCRIPTION
when doing a merge, a misspelled "conflicts" is given out to the console. This fixes the typo.