### PR TITLE
Fix cloning from absolute paths

### DIFF
--- a/doc/manpages/source/clone.rst
+++ b/doc/manpages/source/clone.rst
@@ -8,13 +8,13 @@ geogig-clone documentation
 
 SYNOPSIS
 ********
-geogig clone [--branch <name>] <repository> [<directory>] [--filter <file>] [--depth <depth>]
+geogig clone [--branch <name>] <repository> [<directory>|<clone URI>] [--filter <file>] [--depth <depth>]
 
 
 DESCRIPTION
 ***********
 
-Clones a repository into a newly created directory, creates remote-tracking branches for each branch in the cloned repository (visible using geogig branch -r), and creates and checks out an initial branch that is forked from the cloned repository's currently active branch.
+Clones a repository to create a new one, creates remote-tracking branches for each branch in the cloned repository (visible using geogig branch -r), and creates and checks out an initial branch that is forked from the cloned repository's currently active branch.  If no directory or clone URI is specified, the clone will be created in the current working directory and will have the same name as the source repository.
 
 After the clone, a plain geogig fetch without arguments will update all the remote-tracking branches, and a geogig pull without arguments will in addition merge the remote master branch into the current master branch, if any.
 

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Clone.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Clone.java
@@ -105,7 +105,7 @@ public class Clone extends AbstractCommand implements CLICommand {
         final Platform platform = cli.getPlatform();
         final String remoteArg = args.get(0);
         try {
-            remoteURI = checkAbsolute(remoteArg, platform);
+            remoteURI = RepositoryResolver.resolveRepoUriFromString(platform, remoteArg);
         } catch (URISyntaxException e) {
             throw new CommandFailedException("Can't parse remote URI '" + remoteArg + "'", true);
         }
@@ -114,7 +114,7 @@ public class Clone extends AbstractCommand implements CLICommand {
         if (args.size() == 2) {
             targetArg = args.get(1);
             try {
-                cloneURI = checkAbsolute(targetArg, platform);
+                cloneURI = RepositoryResolver.resolveRepoUriFromString(platform, targetArg);
             } catch (URISyntaxException e) {
                 throw new CommandFailedException("Can't parse target URI '" + targetArg + "'",
                         true);
@@ -164,22 +164,5 @@ public class Clone extends AbstractCommand implements CLICommand {
             cloneRepo.close();
         }
         console.println("Done.");
-    }
-
-    private URI checkAbsolute(String repoUri, Platform platform) throws URISyntaxException {
-        URI uri;
-
-        uri = new URI(repoUri.replace('\\', '/').replaceAll(" ", "%20"));
-
-        String scheme = uri.getScheme();
-        if (null == scheme) {
-            uri = new File(platform.pwd(), repoUri).toURI();
-        } else if ("file".equals(scheme)) {
-            File f = new File(uri);
-            if (!f.isAbsolute()) {
-                uri = new File(platform.pwd(), repoUri).toURI();
-            }
-        }
-        return uri;
     }
 }

--- a/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
+++ b/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
@@ -233,6 +233,14 @@ public class DefaultStepDefinitions {
         assertTrue("Repository does not exist: " + uri, exists);
     }
 
+    @Then("^the repository at \"([^\"]*)\" shall not exist$")
+    public void the_repository_at_shall_not_exist(String repoUri) throws Throwable {
+        repoUri = replaceKnownVariables(repoUri);
+        URI uri = URI.create(repoUri);
+        boolean exists = RepositoryResolver.lookup(uri).repoExists(uri);
+        assertFalse("Repository exists: " + uri, exists);
+    }
+
     @Given("^I have a remote ref called \"([^\"]*)\"$")
     public void i_have_a_remote_ref_called(String expected) throws Throwable {
         String ref = "refs/remotes/origin/" + expected;

--- a/src/cli/src/test/resources/features/remote/Clone.feature
+++ b/src/cli/src/test/resources/features/remote/Clone.feature
@@ -8,6 +8,13 @@ Feature: "clone" command
      When I run the command "clone"
      Then it should answer "You must specify a repository to clone."
       And it should exit with non-zero exit code
+      
+  Scenario: Try to clone into the current directory
+    Given I am in an empty directory
+      And there is a remote repository
+     When I run the command "clone ${remoterepo} ."
+     Then it should answer "Cannot clone into your current working directory."
+      And it should exit with non-zero exit code
      
   Scenario: Try to clone with too many parameters
     Given I am in an empty directory
@@ -41,7 +48,13 @@ Feature: "clone" command
       And the response should contain "Commit4"
       And the response should not contain "Commit3"
       And the response should not contain "Commit2"
-      And the response should contain "Commit1"      
+      And the response should contain "Commit1"  
+      
+  Scenario: Try to clone a remote repository that does not exist
+    Given I am in an empty directory
+     When I run the command "clone nonexistentrepo ${localrepo}"
+     Then the response should contain "nonexistentrepo is not a geogig repository"
+      And the repository at "${localrepo}" shall not exist 
       
   Scenario: Try to make a shallow clone of a remote repository
     Given I am in an empty directory

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/ResolveGeogigURI.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/ResolveGeogigURI.java
@@ -101,7 +101,7 @@ public class ResolveGeogigURI extends AbstractGeoGigOp<Optional<URI>> {
      *         if not inside a working directory
      */
     private static URI lookupGeogigDirectory(@Nullable File file) throws IOException {
-        if (file == null) {
+        if (file == null || !file.exists()) {
             return null;
         }
         if (file.isDirectory()) {

--- a/src/core/src/main/java/org/locationtech/geogig/repository/DefaultRepositoryResolver.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/DefaultRepositoryResolver.java
@@ -47,7 +47,8 @@ public class DefaultRepositoryResolver extends RepositoryResolver {
             File file = toFile(repoURI);
             boolean exists = file.exists();
             boolean directory = file.isDirectory();
-            boolean parentExists = file.getParentFile().exists();
+            boolean parentExists = file.getParentFile() != null ? file.getParentFile().exists()
+                    : false;
             return (exists && directory) || parentExists;
         }
         return "file".equals(scheme);
@@ -241,6 +242,13 @@ public class DefaultRepositoryResolver extends RepositoryResolver {
         }
 
         File workingDir = toFile(repositoryLocation);
+        if (workingDir.getName().equals(".geogig")) {
+            workingDir = workingDir.getParentFile();
+        }
+        // If there are other files in the repository folder, only delete the .geogig directory.
+        if (workingDir.listFiles().length > 1) {
+            workingDir = new File(workingDir, ".geogig");
+        }
         deleteDirectoryAndContents(workingDir);
 
         return true;

--- a/src/core/src/main/java/org/locationtech/geogig/repository/RepositoryResolver.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/RepositoryResolver.java
@@ -9,7 +9,11 @@
  */
 package org.locationtech.geogig.repository;
 
+import java.io.File;
 import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
@@ -80,6 +84,29 @@ public abstract class RepositoryResolver {
     public static ConfigDatabase resolveConfigDatabase(URI repoURI, Context repoContext) {
         RepositoryResolver initializer = RepositoryResolver.lookup(repoURI);
         return initializer.getConfigDatabase(repoURI, repoContext);
+    }
+
+    public static URI resolveRepoUriFromString(Platform platform, String repoURI)
+            throws URISyntaxException {
+        URI uri;
+
+        uri = new URI(repoURI.replace('\\', '/').replaceAll(" ", "%20"));
+
+        String scheme = uri.getScheme();
+        if (null == scheme) {
+            Path p = Paths.get(repoURI);
+            if (p.isAbsolute()) {
+                uri = p.toUri();
+            } else {
+                uri = new File(platform.pwd(), repoURI).toURI();
+            }
+        } else if ("file".equals(scheme)) {
+            File f = new File(uri);
+            if (!f.isAbsolute()) {
+                uri = new File(platform.pwd(), repoURI).toURI();
+            }
+        }
+        return uri;
     }
 
     /**

--- a/src/web/app/src/main/java/org/locationtech/geogig/web/cli/commands/Serve.java
+++ b/src/web/app/src/main/java/org/locationtech/geogig/web/cli/commands/Serve.java
@@ -9,7 +9,6 @@
  */
 package org.locationtech.geogig.web.cli.commands;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
 import java.net.URI;
@@ -24,8 +23,8 @@ import org.locationtech.geogig.cli.annotation.RequiresRepository;
 import org.locationtech.geogig.plumbing.ResolveGeogigURI;
 import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.Hints;
-import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryResolver;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.rest.repository.SingleRepositoryProvider;
 import org.locationtech.geogig.web.Main;
@@ -70,7 +69,7 @@ public class Serve extends AbstractCommand {
 
         URI repoURI = null;
         try {
-            repoURI = checkAbsolute(loc, cli.getPlatform());
+            repoURI = RepositoryResolver.resolveRepoUriFromString(cli.getPlatform(), loc);
         } catch (URISyntaxException e) {
             throw new CommandFailedException("Unable to parse the root repository URI.", e);
         }
@@ -111,22 +110,5 @@ public class Serve extends AbstractCommand {
         }
 
         return geogig.getRepository();
-    }
-
-    private URI checkAbsolute(String repoUri, Platform platform) throws URISyntaxException {
-        URI uri;
-
-        uri = new URI(repoUri.replace('\\', '/').replaceAll(" ", "%20"));
-
-        String scheme = uri.getScheme();
-        if (null == scheme) {
-            uri = new File(platform.pwd(), repoUri).toURI();
-        } else if ("file".equals(scheme)) {
-            File f = new File(uri);
-            if (!f.isAbsolute()) {
-                uri = new File(platform.pwd(), repoUri).toURI();
-            }
-        }
-        return uri;
     }
 }


### PR DESCRIPTION
- Fixes cloning from an absolute path.  Prior to this fix, trying to clone from an absolute path would result in an IllegalStateException because it would incorrectly build the new repo URI.
- When clone fails, the command will now clean up the repository that was created.
- You can no longer clone into the current working directory.
- If no target is specified, clone will use the source repository's name as the name of the new repository.