### PR TITLE
removing mapdb dependencies from pom.xml

### DIFF
--- a/src/osm/pom.xml
+++ b/src/osm/pom.xml
@@ -40,12 +40,6 @@
       <artifactId>org.eclipse.jdt.annotation</artifactId>
     </dependency>
 
-    <dependency>
-      <!-- for mapdb point cache -->
-      <groupId>org.mapdb</groupId>
-      <artifactId>mapdb</artifactId>
-    </dependency>
-
     <!-- used to implement a point cache as a temporary database -->
     <dependency>
       <groupId>com.sleepycat</groupId>

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -298,12 +298,6 @@
       </dependency>
 
       <dependency>
-        <groupId>org.mapdb</groupId>
-        <artifactId>mapdb</artifactId>
-        <version>2.0-beta8</version>
-      </dependency>
-
-      <dependency>
         <groupId>com.microsoft</groupId>
         <artifactId>sqljdbc4</artifactId>
         <version>${sqljdbc4.version}</version>


### PR DESCRIPTION
This removes the mapdb dependencies from pom.xml files. The libs aren't referenced from source code anymore.