### PR TITLE
Fix parsing of PostgreSQL URIs

### DIFF
--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -102,7 +102,8 @@
     <slf4j.version>1.7.5</slf4j.version>
     <sqljdbc4.version>3.0</sqljdbc4.version>
     <osmosis.version>0.43.1</osmosis.version>
-    <hikaricp.version>2.4.2</hikaricp.version>    
+    <hikaricp.version>2.4.2</hikaricp.version>
+    <springweb.version>4.2.5.RELEASE</springweb.version>
 
     <test.maxHeapSize>512M</test.maxHeapSize>
     <maven.build.timestamp.format>dd-MMM-yyyy HH:mm</maven.build.timestamp.format>
@@ -360,7 +361,11 @@
         <artifactId>py4j</artifactId>
         <version>0.8.1</version>
       </dependency>
-
+      <dependency>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <version>${springweb.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/src/storage/postgres/pom.xml
+++ b/src/storage/postgres/pom.xml
@@ -29,7 +29,6 @@
       <groupId>com.zaxxer</groupId>
       <artifactId>HikariCP</artifactId>
     </dependency>
-    
     <!-- Test scope dependencies -->
 
     <dependency>
@@ -78,6 +77,11 @@
       <artifactId>geogig-cli</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-web</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/EnvironmentBuilderTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/EnvironmentBuilderTest.java
@@ -1,0 +1,126 @@
+/* (c) 2016 Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+package org.locationtech.geogig.storage.postgresql;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.junit.Test;
+import org.springframework.web.util.UriComponentsBuilder;
+
+public class EnvironmentBuilderTest {
+
+    private static final String UTF8 = StandardCharsets.UTF_8.name();
+
+    private URI buildUri(String host, @Nullable Integer port, String dbName, @Nullable String schema, String repoName,
+            String user, String password) throws URISyntaxException, UnsupportedEncodingException {
+        /**
+         * Using Spring's URI builder utils here because java.net.URI doesn't handle special characters in the query
+         * parameter encoding correctly. If we want to build a URI with host=localhost, port=5432, dbName=myDb,
+         * schema=mySchema, repoName=myRepo, user=myUser and password=myPass&word, the URI should look like this:
+         * <p>
+         * postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%26word
+         * <p>
+         * If we use java.net.URI to create a URI from an unencoded String like this:
+         * <p>
+         * "postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass&word"
+         * <p>
+         * java.net.URI will try to Encode the String, but will interpret the `&` in the password value as a query
+         * parameter delimiter, in this case yielding 3 query parameters: user, password and myPass.
+         * <p>
+         * If we URLEncode the password value before building the URI, using this string:
+         * <p>
+         * "postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%26word"
+         * <p>
+         * java.net.URI will try to Encode the String anyway, thus double encoding the password value, resulting in:
+         * <p>
+         * postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%2526word
+         * <p>
+         * java.net.URI doesn't have a way to construct a URI with a pre-encoded query parameter value, so there isn't
+         * a way to use it to correctly encode special characters in query parameter values. Using Spring-web's
+         * URIComponentsBuilder, we can URLEncode the parameter values first, then build a URIComponents such that
+         * the URI doesn't double encode the query parameter by using URIComponentsBuilder.build(true), which tells
+         * the builder that the URI is already encoded.
+         */
+        UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
+        // set the scheme
+        builder.scheme("postgresql");
+        // set the host and port
+        builder.host(host);
+        if (port != null && port > 0) {
+            builder.port(port);
+        } else {
+            builder.port(5432);
+        }
+        // build the path in the form of "/dbName/schema/repoName"
+        StringBuilder pathBuilder = new StringBuilder(128);
+        pathBuilder.append("/").append(dbName).append("/");
+        if (schema != null) {
+            pathBuilder.append(schema);
+        } else {
+            pathBuilder.append("public");
+        }
+        pathBuilder.append("/").append(repoName);
+        builder.path(pathBuilder.toString());
+        // now build the query parameters
+        builder.queryParam("user", URLEncoder.encode(user, UTF8));
+        builder.queryParam("password", URLEncoder.encode(password, UTF8));
+        return builder.build(true).toUri();
+    }
+
+    private void test(String host, @Nullable Integer port, String dbName, @Nullable String schema, String repoName,
+            String user, String password) throws URISyntaxException, UnsupportedEncodingException {
+        // build the URI
+        URI uri = buildUri(host, port, dbName, schema, repoName, user, password);
+        // Build an Environment
+        EnvironmentBuilder builder = new EnvironmentBuilder(uri);
+        Environment.ConnectionConfig config = builder.build().connectionConfig;
+        // assert properties
+        assertEquals("Unexpected HOST value", host, config.getServer());
+        if (port != null) {
+            assertEquals("Unexpected PORT value", port.intValue(), config.getPortNumber());
+        } else {
+            assertEquals("Unexpected PORT value", 5432, config.getPortNumber());
+        }
+        assertEquals("Unexpected DB NAME value", dbName, config.getDatabaseName());
+        if (schema != null) {
+            assertEquals("Unexpected SCHEMA value", schema, config.getSchema());
+        } else {
+            assertEquals("Unexpected SCHEMA value", "public", config.getSchema());
+        }
+        assertEquals("Unexpected USER value", user, config.getUser());
+        assertEquals("Unexpected PASSWORD value", password, config.getPassword());
+    }
+
+    @Test
+    public void testextractShortKeys() throws URISyntaxException, UnsupportedEncodingException {
+        // test some basic values
+        test("testHost", null, "testDb", null, "testRepo", "testUser", "testPassword");
+    }
+
+    @Test
+    public void testextractShortKeys_withPassword_hash() throws URISyntaxException, UnsupportedEncodingException {
+        // test some basic values
+        test("testHost", null, "testDb", null, "testRepo", "testUser", "test#Password");
+    }
+
+    @Test
+    public void testextractShortKeys_withPassword_ampersand() throws URISyntaxException, UnsupportedEncodingException {
+        // test some basic values
+        test("testHost", null, "testDb", null, "testRepo", "testUser", "test&Password");
+    }
+
+    @Test
+    public void testextractShortKeys_withPassword_multiSpecial() throws URISyntaxException, UnsupportedEncodingException {
+        // test some basic values
+        test("testHost", null, "testDb", null, "testRepo", "testUser", "!@#$%^&*()");
+    }
+}


### PR DESCRIPTION
Addresses https://github.com/locationtech/geogig/issues/150

Use ~~Apache HttpClient URIBuilder~~ Spring Web URI utilities to handle proper encoding of URIs for PostgreSQL passwords with special characters.