### PR TITLE
Simplify WorkingTree.insert()

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/AutoCloseableIterator.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/AutoCloseableIterator.java
@@ -11,6 +11,7 @@ package org.locationtech.geogig.repository;
 
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.function.Consumer;
 
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
@@ -93,6 +94,29 @@ public interface AutoCloseableIterator<T> extends Iterator<T>, AutoCloseable {
         };
     }
 
+    public static <T, I extends Iterator<T>> AutoCloseableIterator<T> fromIterator(
+            I source, Consumer<I> closeAction) {
+        
+        return new AutoCloseableIterator<T>() {
+
+            @Override
+            public boolean hasNext() {
+                return source.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return source.next();
+            }
+
+            @Override
+            public void close() {
+                closeAction.accept(source);
+            }
+
+        };
+    }
+
     /**
      * Transforms each element in the source iterator with the provided function.
      * 
@@ -119,7 +143,7 @@ public interface AutoCloseableIterator<T> extends Iterator<T>, AutoCloseable {
             public void close() {
                 source.close();
             }
-            
+
         };
     }
 
@@ -204,5 +228,3 @@ public interface AutoCloseableIterator<T> extends Iterator<T>, AutoCloseable {
         };
     }
 }
-
-

--- a/src/api/src/main/java/org/locationtech/geogig/repository/FeatureInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/FeatureInfo.java
@@ -13,6 +13,8 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevFeatureType;
 
+import com.google.common.base.Preconditions;
+
 /**
  * A class to compactly store information about a feature, including its path and feature type. This
  * is to be used in the context of applying patches or performing a merge operation, where this type
@@ -28,6 +30,8 @@ public class FeatureInfo {
 
     private String path;
 
+    private boolean isDelete;
+
     /**
      * Constructs a new {@code FeatureInfo} with the provided parameters.
      * 
@@ -35,10 +39,27 @@ public class FeatureInfo {
      * @param featureTypeId the {@link ObjectId} of the feature's type
      * @param path the path of the feature
      */
-    public FeatureInfo(RevFeature feature, ObjectId featureTypeId, String path) {
+    private FeatureInfo(RevFeature feature, ObjectId featureTypeId, String path, boolean isDelete) {
         this.path = path;
         this.feature = feature;
         this.featureTypeId = featureTypeId;
+        this.isDelete = isDelete;
+    }
+
+    public boolean isDelete() {
+        return isDelete;
+    }
+
+    public static FeatureInfo insert(RevFeature feature, ObjectId featureTypeId, String path) {
+        Preconditions.checkNotNull(feature);
+        Preconditions.checkNotNull(featureTypeId);
+        Preconditions.checkNotNull(path);
+        return new FeatureInfo(feature, featureTypeId, path, false);
+    }
+
+    public static FeatureInfo delete(final String path) {
+        Preconditions.checkNotNull(path);
+        return new FeatureInfo(null, null, path, true);
     }
 
     /**

--- a/src/api/src/test/java/org/locationtech/geogig/repository/FeatureInfoTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/repository/FeatureInfoTest.java
@@ -57,7 +57,7 @@ public class FeatureInfoTest {
             public void forEach(Consumer<Object> consumer) {
             }
         };
-        FeatureInfo info = new FeatureInfo(testFeature, oid1, "Points/1");
+        FeatureInfo info = FeatureInfo.insert(testFeature, oid1, "Points/1");
         assertEquals(testFeature, info.getFeature());
         assertEquals(oid1, info.getFeatureTypeId());
         assertEquals("Points/1", info.getPath());

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/Insert.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/Insert.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.cli.plumbing;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -22,14 +23,21 @@ import org.locationtech.geogig.cli.CLICommand;
 import org.locationtech.geogig.cli.Console;
 import org.locationtech.geogig.cli.GeogigCLI;
 import org.locationtech.geogig.model.FieldType;
+import org.locationtech.geogig.model.RevFeatureBuilder;
 import org.locationtech.geogig.model.RevFeatureType;
+import org.locationtech.geogig.model.RevFeatureTypeBuilder;
 import org.locationtech.geogig.plumbing.ResolveFeatureType;
+import org.locationtech.geogig.repository.DefaultProgressListener;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.NodeRef;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.WorkingTree;
 import org.locationtech.geogig.storage.text.TextValueSerializer;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.feature.type.FeatureType;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -38,6 +46,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
+import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Files;
@@ -70,13 +79,27 @@ public class Insert extends AbstractCommand implements CLICommand {
         }
         Map<String, List<Feature>> features = readFeatures(lines);
 
+        Repository repository = geogig.getRepository();
+        WorkingTree workingTree = repository.workingTree();
+
         long count = 0;
-        for (String key : features.keySet()) {
-            List<Feature> treeFeatures = features.get(key);
-            geogig.getRepository()
-                    .workingTree()
-                    .insert(key, treeFeatures.iterator(), cli.getProgressListener(), null,
-                            treeFeatures.size());
+        for (String parentPath : features.keySet()) {
+            List<Feature> treeFeatures = features.get(parentPath);
+            Map<FeatureType, RevFeatureType> types = new HashMap<>();
+            Iterator<FeatureInfo> finfos = Iterators.transform(treeFeatures.iterator(), (f) -> {
+                FeatureType ft = f.getType();
+                RevFeatureType rft = types.get(ft);
+                if (rft == null) {
+                    rft = RevFeatureTypeBuilder.build(ft);
+                    types.put(ft, rft);
+                    repository.objectDatabase().put(rft);
+                }
+                String path = NodeRef.appendChild(parentPath, f.getIdentifier().getID());
+                FeatureInfo fi = FeatureInfo.insert(RevFeatureBuilder.build(f), rft.getId(), path);
+                return fi;
+            });
+
+            workingTree.insert(finfos, DefaultProgressListener.NULL);
             count += treeFeatures.size();
         }
 
@@ -127,16 +150,16 @@ public class Insert extends AbstractCommand implements CLICommand {
             Optional<RevFeatureType> opt = geogig.command(ResolveFeatureType.class)
                     .setRefSpec("WORK_HEAD:" + tree).call();
             checkParameter(opt.isPresent(), "The parent tree does not exist: " + tree);
-            SimpleFeatureBuilder builder = new SimpleFeatureBuilder((SimpleFeatureType) opt.get()
-                    .type());
+            SimpleFeatureBuilder builder = new SimpleFeatureBuilder(
+                    (SimpleFeatureType) opt.get().type());
             featureTypes.put(tree, builder);
         }
         SimpleFeatureBuilder ftb = featureTypes.get(tree);
         SimpleFeatureType ft = ftb.getFeatureType();
         for (int i = 1; i < featureChanges.size(); i++) {
             String[] tokens = featureChanges.get(i).split("\t");
-            Preconditions.checkArgument(tokens.length == 2, "Wrong attribute definition: "
-                    + featureChanges.get(i));
+            Preconditions.checkArgument(tokens.length == 2,
+                    "Wrong attribute definition: " + featureChanges.get(i));
             String fieldName = tokens[0];
             AttributeDescriptor desc = ft.getDescriptor(fieldName);
             Preconditions.checkNotNull(desc, "Wrong attribute in feature description");

--- a/src/core/src/main/java/org/locationtech/geogig/data/FindFeatureTypeTrees.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/FindFeatureTypeTrees.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.data;
 import java.util.Iterator;
 import java.util.List;
 
+import org.locationtech.geogig.di.CanRunDuringConflict;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.plumbing.LsTreeOp;
 import org.locationtech.geogig.plumbing.RevParse;
@@ -26,6 +27,7 @@ import com.google.common.collect.Iterators;
 /**
  * 
  */
+@CanRunDuringConflict
 public class FindFeatureTypeTrees extends AbstractGeoGigOp<List<NodeRef>> {
 
     private String refSpec;

--- a/src/core/src/main/java/org/locationtech/geogig/hooks/GeoGigAPI.java
+++ b/src/core/src/main/java/org/locationtech/geogig/hooks/GeoGigAPI.java
@@ -23,8 +23,8 @@ import org.locationtech.geogig.porcelain.DiffOp;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.Repository;
 import org.opengis.feature.Feature;
 

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/DiffTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/DiffTree.java
@@ -33,8 +33,8 @@ import org.locationtech.geogig.plumbing.diff.PreOrderDiffWalk.ForwardingConsumer
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.slf4j.Logger;

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/diff/Patch.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/diff/Patch.java
@@ -105,7 +105,7 @@ public class Patch {
      * @param featureType the feature type of the added feature
      */
     public void addAddedFeature(String path, RevFeature feature, RevFeatureType featureType) {
-        addedFeatures.add(new FeatureInfo(feature, featureType.getId(), path));
+        addedFeatures.add(FeatureInfo.insert(feature, featureType.getId(), path));
         addFeatureType(featureType);
     }
 
@@ -117,7 +117,7 @@ public class Patch {
      * @param featureType the feature type of the removed feature
      */
     public void addRemovedFeature(String path, RevFeature feature, RevFeatureType featureType) {
-        removedFeatures.add(new FeatureInfo(feature, featureType.getId(), path));
+        removedFeatures.add(FeatureInfo.insert(feature, featureType.getId(), path));
         addFeatureType(featureType);
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
@@ -388,7 +388,7 @@ public class MergeStatusBuilder extends MergeScenarioConsumer {
             String path = in.readUTF();
             ObjectId featureTypeId = OID.read(in);
             RevFeature feature = (RevFeature) DataStreamSerializationFactoryV2.INSTANCE.read(in);
-            return new FeatureInfo(feature, featureTypeId, path);
+            return FeatureInfo.insert(feature, featureTypeId, path);
         }
 
     }

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportMergeScenarioOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportMergeScenarioOp.java
@@ -268,7 +268,7 @@ public class ReportMergeScenarioOp extends AbstractGeoGigOp<MergeScenarioReport>
                     report.addUnconflicted();
                 } else {
                     ObjectId featureTypeId = oursDiff.getNewObject().getMetadataId();
-                    FeatureInfo merged = new FeatureInfo(mergedFeature, featureTypeId, path);
+                    FeatureInfo merged = FeatureInfo.insert(mergedFeature, featureTypeId, path);
                     consumer.merged(merged);
                     report.addMerged();
                 }

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/ApplyPatchOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/ApplyPatchOp.java
@@ -19,6 +19,7 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.feature.simple.SimpleFeatureTypeBuilder;
 import org.locationtech.geogig.model.Ref;
 import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.model.RevFeatureBuilder;
 import org.locationtech.geogig.model.RevFeatureType;
 import org.locationtech.geogig.model.RevFeatureTypeBuilder;
 import org.locationtech.geogig.plumbing.RevObjectParse;
@@ -195,8 +196,10 @@ public class ApplyPatchOp extends AbstractGeoGigOp<Patch> {
 
             }
 
-            SimpleFeature featureToInsert = featureBuilder.buildFeature(NodeRef.nodeFromPath(path));
-            workTree.insert(NodeRef.parentPath(path), featureToInsert);
+            SimpleFeature f = featureBuilder.buildFeature(NodeRef.nodeFromPath(path));
+            RevFeature featureToInsert = RevFeatureBuilder.build(f);
+            FeatureInfo featureInfo = FeatureInfo.insert(featureToInsert, newRevFeatureType.getId(), path);
+            workTree.insert(featureInfo);
 
         }
         ImmutableList<FeatureTypeDiff> alteredTrees = patch.getAlteredTrees();

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CleanOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CleanOp.java
@@ -22,8 +22,8 @@ import org.locationtech.geogig.plumbing.FindTreeChild;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.WorkingTree;
 
 import com.google.common.base.Optional;

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CreatePatchOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CreatePatchOp.java
@@ -23,8 +23,8 @@ import org.locationtech.geogig.plumbing.diff.Patch;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 
 import com.google.common.base.Suppliers;
 import com.google.common.collect.Maps;

--- a/src/core/src/test/java/org/locationtech/geogig/model/CommitBuilderTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/CommitBuilderTest.java
@@ -12,9 +12,6 @@ package org.locationtech.geogig.model;
 import java.util.List;
 
 import org.junit.Test;
-import org.locationtech.geogig.model.CommitBuilder;
-import org.locationtech.geogig.model.ObjectId;
-import org.locationtech.geogig.model.RevCommit;
 
 import com.google.common.collect.ImmutableList;
 

--- a/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
@@ -22,7 +22,6 @@ import java.util.TreeMap;
 import java.util.UUID;
 
 import org.geotools.data.DataUtilities;
-import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.geometry.jts.WKTReader2;
 import org.junit.Test;
 import org.locationtech.geogig.model.CommitBuilder;
@@ -41,7 +40,6 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
-import org.opengis.feature.type.GeometryDescriptor;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -295,21 +293,6 @@ public class HashObjectTest extends RepositoryTestCase {
         assertNotNull(tagId2);
         assertNotSame(tagId, tagId2);
 
-    }
-
-    protected Feature feature(SimpleFeatureType type, String id, Object... values)
-            throws ParseException {
-        SimpleFeatureBuilder builder = new SimpleFeatureBuilder(type);
-        for (int i = 0; i < values.length; i++) {
-            Object value = values[i];
-            if (type.getDescriptor(i) instanceof GeometryDescriptor) {
-                if (value instanceof String) {
-                    value = geom((String) value);
-                }
-            }
-            builder.set(i, value);
-        }
-        return builder.buildFeature(id);
     }
 
     private Geometry geom(String wkt) throws ParseException {

--- a/src/core/src/test/java/org/locationtech/geogig/plumbing/WriteTree2Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/plumbing/WriteTree2Test.java
@@ -44,7 +44,6 @@ import org.opengis.feature.Feature;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -54,7 +53,6 @@ import com.google.common.collect.MapDifference;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.vividsolutions.jts.geom.Envelope;
-import com.vividsolutions.jts.io.ParseException;
 
 public class WriteTree2Test extends RepositoryTestCase {
 
@@ -704,11 +702,8 @@ public class WriteTree2Test extends RepositoryTestCase {
     private Node feature(ObjectStore db, String idPrefix, int index) {
         final String id = idPrefix + "." + index;
         final Feature feature;
-        try {
-            feature = super.feature(pointsType, id, id, index, point(index));
-        } catch (ParseException e) {
-            throw Throwables.propagate(e);
-        }
+        feature = super.feature(pointsType, id, id, index, point(index));
+
         RevFeature revFeature = RevFeatureBuilder.build(feature);
         db.put(revFeature);
         Envelope bounds = (Envelope) feature.getBounds();

--- a/src/core/src/test/java/org/locationtech/geogig/remote/RemoteRepositoryTestCase.java
+++ b/src/core/src/test/java/org/locationtech/geogig/remote/RemoteRepositoryTestCase.java
@@ -33,9 +33,11 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.rules.TemporaryFolder;
-import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevCommit;
+import org.locationtech.geogig.model.RevFeatureBuilder;
+import org.locationtech.geogig.model.RevFeatureType;
+import org.locationtech.geogig.model.RevFeatureTypeBuilder;
 import org.locationtech.geogig.plumbing.LsRemote;
 import org.locationtech.geogig.plumbing.SendPack;
 import org.locationtech.geogig.porcelain.AddOp;
@@ -48,8 +50,10 @@ import org.locationtech.geogig.porcelain.PullOp;
 import org.locationtech.geogig.porcelain.PushOp;
 import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.ContextBuilder;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.GlobalContextBuilder;
+import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.repository.Remote;
 import org.locationtech.geogig.repository.Repository;
@@ -361,9 +365,12 @@ public abstract class RemoteRepositoryTestCase {
         final WorkingTree workTree = geogig.getRepository().workingTree();
         Name name = f.getType().getName();
         String parentPath = name.getLocalPart();
-        Node ref = workTree.insert(parentPath, f);
-        ObjectId objectId = ref.getObjectId();
-        return objectId;
+        RevFeatureType type = RevFeatureTypeBuilder.build(f.getType());
+        geogig.getRepository().objectDatabase().put(type);
+        String path = NodeRef.appendChild(parentPath, f.getIdentifier().getID());
+        FeatureInfo fi = FeatureInfo.insert(RevFeatureBuilder.build(f), type.getId(), path);
+        workTree.insert(fi);
+        return fi.getFeature().getId();
     }
 
     protected void insertAndAdd(GeoGIG geogig, Feature... features) throws Exception {

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/AddOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/AddOpTest.java
@@ -28,8 +28,8 @@ import org.locationtech.geogig.porcelain.MergeConflictsException;
 import org.locationtech.geogig.porcelain.MergeOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 import org.opengis.feature.Feature;
 
 import com.google.common.base.Optional;

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/BlameOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/BlameOpTest.java
@@ -18,11 +18,11 @@ import org.junit.rules.ExpectedException;
 import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.porcelain.BlameException;
 import org.locationtech.geogig.porcelain.BlameException.StatusCode;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.porcelain.BlameOp;
 import org.locationtech.geogig.porcelain.BlameReport;
 import org.locationtech.geogig.porcelain.CommitOp;
 import org.locationtech.geogig.porcelain.ValueAndCommit;
+import org.locationtech.geogig.repository.NodeRef;
 import org.opengis.feature.Feature;
 
 public class BlameOpTest extends RepositoryTestCase {

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/CheckoutOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/CheckoutOpTest.java
@@ -33,10 +33,10 @@ import org.locationtech.geogig.porcelain.CheckoutResult;
 import org.locationtech.geogig.porcelain.CommitOp;
 import org.locationtech.geogig.porcelain.ConfigOp;
 import org.locationtech.geogig.porcelain.ConfigOp.ConfigAction;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.porcelain.MergeConflictsException;
 import org.locationtech.geogig.porcelain.MergeOp;
 import org.locationtech.geogig.porcelain.RemoveOp;
+import org.locationtech.geogig.repository.NodeRef;
 import org.opengis.feature.Feature;
 
 import com.google.common.base.Optional;

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/CherryPickOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/CherryPickOpTest.java
@@ -29,10 +29,10 @@ import org.locationtech.geogig.porcelain.CherryPickOp;
 import org.locationtech.geogig.porcelain.CommitOp;
 import org.locationtech.geogig.porcelain.ConfigOp;
 import org.locationtech.geogig.porcelain.ConfigOp.ConfigAction;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.porcelain.ConflictsException;
 import org.locationtech.geogig.porcelain.LogOp;
 import org.locationtech.geogig.porcelain.NothingToCommitException;
+import org.locationtech.geogig.repository.NodeRef;
 import org.opengis.feature.Feature;
 
 import com.google.common.base.Optional;

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/DiffOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/DiffOpTest.java
@@ -13,7 +13,6 @@ import java.util.List;
 import java.util.Set;
 
 import org.junit.Test;
-import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.Ref;
 import org.locationtech.geogig.model.RevCommit;
@@ -26,8 +25,8 @@ import org.locationtech.geogig.porcelain.CommitOp;
 import org.locationtech.geogig.porcelain.DiffOp;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DiffEntry;
-import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
+import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.WorkingTree;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeature;
@@ -508,8 +507,7 @@ public class DiffOpTest extends RepositoryTestCase {
         WorkingTree workTree = repo.workingTree();
         Name name = lines1.getType().getName();
         String parentPath = name.getLocalPart();
-        @SuppressWarnings("unused")
-        Node ref = workTree.insert(parentPath, lines1B);
+        workTree.insert(featureInfo(parentPath, lines1B));
         geogig.command(AddOp.class).call();
         RevCommit commit2 = geogig.command(CommitOp.class).setAll(true).call();
 

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/repository/WorkingTreeTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/repository/WorkingTreeTest.java
@@ -10,24 +10,14 @@
 package org.locationtech.geogig.test.integration.repository;
 
 import static org.locationtech.geogig.repository.NodeRef.appendChild;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.geotools.data.DataUtilities;
-import org.geotools.data.FeatureSource;
-import org.geotools.data.Query;
-import org.geotools.data.QueryCapabilities;
-import org.geotools.data.memory.MemoryDataStore;
-import org.geotools.feature.FeatureCollection;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
-import org.locationtech.geogig.data.ForwardingFeatureSource;
 import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevFeatureType;
@@ -37,6 +27,7 @@ import org.locationtech.geogig.plumbing.FindTreeChild;
 import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DefaultProgressListener;
 import org.locationtech.geogig.repository.DiffEntry;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.FeatureToDelete;
 import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.Platform;
@@ -44,13 +35,10 @@ import org.locationtech.geogig.repository.ProgressListener;
 import org.locationtech.geogig.repository.WorkingTree;
 import org.locationtech.geogig.test.TestPlatform;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
-import org.mockito.Mockito;
 import org.opengis.feature.Feature;
-import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.type.Name;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
 
 /**
@@ -83,12 +71,10 @@ public class WorkingTreeTest extends RepositoryTestCase {
 
     @Test
     public void testInsertSingle() throws Exception {
-        Name name = points1.getType().getName();
-        String parentPath = name.getLocalPart();
-        Node ref = workTree.insert(parentPath, points1);
-        ObjectId objectId = ref.getObjectId();
+        FeatureInfo fi = featureInfo(points1);
+        workTree.insert(fi);
 
-        assertEquals(objectId,
+        assertEquals(fi.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId());
     }
 
@@ -99,20 +85,19 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        List<Node> targetList = new LinkedList<Node>();
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, 3);
+        List<FeatureInfo> targetList = insert(featureList);
 
         assertEquals(3, targetList.size());
 
-        Node ref1 = targetList.get(0);
-        Node ref2 = targetList.get(1);
-        Node ref3 = targetList.get(2);
+        FeatureInfo ref1 = targetList.get(0);
+        FeatureInfo ref2 = targetList.get(1);
+        FeatureInfo ref3 = targetList.get(2);
 
-        assertEquals(ref1.getObjectId(),
+        assertEquals(ref1.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId());
-        assertEquals(ref2.getObjectId(),
+        assertEquals(ref2.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP2)).get().getObjectId());
-        assertEquals(ref3.getObjectId(),
+        assertEquals(ref3.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP3)).get().getObjectId());
     }
 
@@ -121,13 +106,12 @@ public class WorkingTreeTest extends RepositoryTestCase {
         List<Feature> featureList = new LinkedList<Feature>();
         featureList.add(points1);
 
-        List<Node> targetList = new LinkedList<Node>();
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, 1);
+        List<FeatureInfo> targetList = insert(featureList);
 
         assertEquals(1, targetList.size());
 
-        Node ref1 = targetList.get(0);
-        assertEquals(ref1.getObjectId(),
+        FeatureInfo ref1 = targetList.get(0);
+        assertEquals(ref1.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId());
 
         featureList.clear();
@@ -135,19 +119,17 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        targetList.clear();
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, 3);
+        targetList = insert(featureList);
 
         assertEquals(2, targetList.size());
 
-        Node ref2 = targetList.get(0);
-        Node ref3 = targetList.get(1);
+        FeatureInfo ref2 = targetList.get(0);
+        FeatureInfo ref3 = targetList.get(1);
 
         assertFalse(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
-        assertEquals(ref2.getObjectId(),
+        assertEquals(ref2.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP2)).get().getObjectId());
-        assertEquals(ref3.getObjectId(),
+        assertEquals(ref3.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP3)).get().getObjectId());
     }
 
@@ -158,135 +140,20 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        List<Node> targetList = new LinkedList<Node>();
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, null);
+        List<FeatureInfo> targetList = insert(featureList);
 
         assertEquals(3, targetList.size());
 
-        Node ref1 = targetList.get(0);
-        Node ref2 = targetList.get(1);
-        Node ref3 = targetList.get(2);
+        FeatureInfo ref1 = targetList.get(0);
+        FeatureInfo ref2 = targetList.get(1);
+        FeatureInfo ref3 = targetList.get(2);
 
-        assertEquals(ref1.getObjectId(),
+        assertEquals(ref1.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId());
-        assertEquals(ref2.getObjectId(),
+        assertEquals(ref2.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP2)).get().getObjectId());
-        assertEquals(ref3.getObjectId(),
+        assertEquals(ref3.getFeature().getId(),
                 workTree.findUnstaged(appendChild(pointsName, idP3)).get().getObjectId());
-    }
-
-    @Test
-    public void testInsertCollectionZeroCollectionSize() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        List<Node> targetList = new LinkedList<Node>();
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, 0);
-
-        assertEquals(3, targetList.size());
-
-        Node ref1 = targetList.get(0);
-        Node ref2 = targetList.get(1);
-        Node ref3 = targetList.get(2);
-
-        assertEquals(ref1.getObjectId(),
-                workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId());
-        assertEquals(ref2.getObjectId(),
-                workTree.findUnstaged(appendChild(pointsName, idP2)).get().getObjectId());
-        assertEquals(ref3.getObjectId(),
-                workTree.findUnstaged(appendChild(pointsName, idP3)).get().getObjectId());
-    }
-
-    @Test
-    public void testInsertCollectionNegativeCollectionSize() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        List<Node> targetList = new LinkedList<Node>();
-
-        exception.expect(IllegalArgumentException.class);
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, targetList, -5);
-    }
-
-    @Test
-    public void testInsertNonPagingFeatureSource() throws Exception {
-        assertEquals(2, super.getGeogig().getPlatform().availableProcessors());
-
-        final List<SimpleFeature> features = ImmutableList.of((SimpleFeature) points1,
-                (SimpleFeature) points2, (SimpleFeature) points3);
-        MemoryDataStore store = new MemoryDataStore();
-        store.addFeatures(features);
-
-        final QueryCapabilities caps = Mockito.spy(new QueryCapabilities());
-        Mockito.doReturn(false).when(caps).isOffsetSupported();
-
-        @SuppressWarnings("rawtypes")
-        FeatureSource source = Mockito.spy(store.getFeatureSource(pointsName));
-        Mockito.doReturn(caps).when(source).getQueryCapabilities();
-
-        String treePath = "target_typename";
-        workTree.insert(treePath, source, Query.ALL, LISTENER);
-
-        assertEquals(3, workTree.countUnstaged(treePath).featureCount());
-
-    }
-
-    @SuppressWarnings({ "rawtypes", "unchecked" })
-    @Test
-    public void testInsertPagingFeatureSource() throws Exception {
-        assertEquals(2, super.getGeogig().getPlatform().availableProcessors());
-
-        final List<SimpleFeature> features = ImmutableList.of((SimpleFeature) points1,
-                (SimpleFeature) points2, (SimpleFeature) points3);
-        MemoryDataStore store = new MemoryDataStore();
-        store.addFeatures(features);
-
-        final QueryCapabilities caps = mock(QueryCapabilities.class);
-        when(caps.isOffsetSupported()).thenReturn(true);
-
-        FeatureSource source = new ForwardingFeatureSource(store.getFeatureSource(pointsName)) {
-            @Override
-            public QueryCapabilities getQueryCapabilities() {
-                return caps;
-            }
-
-            @Override
-            public FeatureCollection getFeatures(Query query) throws IOException {
-                Integer startIndex = query.getStartIndex();
-                if (startIndex == null) {
-                    return super.getFeatures();
-                }
-                int toIndex = (int) Math.min((long) startIndex + query.getMaxFeatures(),
-                        features.size());
-                List<SimpleFeature> result = features.subList(startIndex, toIndex);
-                return DataUtilities.collection(result);
-            }
-        };
-
-        assertTrue(source.getQueryCapabilities().isOffsetSupported());
-
-        String treePath = "target_typename";
-        workTree.insert(treePath, source, Query.ALL, LISTENER);
-
-        assertEquals(3, workTree.countUnstaged(treePath).featureCount());
-    }
-
-    @Test
-    public void testInsertCollectionNoTarget() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, null);
-
-        assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
-        assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());
-        assertTrue(workTree.findUnstaged(appendChild(pointsName, idP3)).isPresent());
     }
 
     @Test
@@ -296,90 +163,17 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         ObjectId oID1 = workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId();
 
         List<Feature> modifiedFeatures = new LinkedList<Feature>();
         modifiedFeatures.add(points1_modified);
 
-        workTree.insert(pointsName, modifiedFeatures.iterator(), LISTENER, null, 1);
+        insert(modifiedFeatures);
         assertFalse(workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId()
                 .equals(oID1));
 
-    }
-
-    @Test
-    public void testUpdateFeatures() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
-
-        ObjectId oID1 = workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId();
-
-        List<Feature> modifiedFeatures = new LinkedList<Feature>();
-        modifiedFeatures.add(points1_modified);
-
-        workTree.update(pointsName, modifiedFeatures.iterator(), LISTENER, 1);
-        assertFalse(workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId()
-                .equals(oID1));
-    }
-
-    @Test
-    public void testUpdateFeaturesNullCollectionSize() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
-
-        ObjectId oID1 = workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId();
-
-        List<Feature> modifiedFeatures = new LinkedList<Feature>();
-        modifiedFeatures.add(points1_modified);
-
-        workTree.update(pointsName, modifiedFeatures.iterator(), LISTENER, null);
-        assertFalse(workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId()
-                .equals(oID1));
-    }
-
-    @Test
-    public void testUpdateFeaturesZeroCollectionSize() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
-
-        ObjectId oID1 = workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId();
-
-        List<Feature> modifiedFeatures = new LinkedList<Feature>();
-        modifiedFeatures.add(points1_modified);
-
-        workTree.update(pointsName, modifiedFeatures.iterator(), LISTENER, 0);
-        assertFalse(workTree.findUnstaged(appendChild(pointsName, idP1)).get().getObjectId()
-                .equals(oID1));
-    }
-
-    @Test
-    public void testUpdateFeaturesNegativeCollectionSize() throws Exception {
-        List<Feature> featureList = new LinkedList<Feature>();
-        featureList.add(points1);
-        featureList.add(points2);
-        featureList.add(points3);
-
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
-
-        List<Feature> modifiedFeatures = new LinkedList<Feature>();
-        modifiedFeatures.add(points1_modified);
-
-        exception.expect(IllegalArgumentException.class);
-        workTree.update(pointsName, modifiedFeatures.iterator(), LISTENER, -5);
     }
 
     @Test
@@ -389,7 +183,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());
@@ -414,7 +208,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points1);
         featureList.add(points2);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 2);
+        insert(featureList);
 
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());
@@ -454,7 +248,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
 
         Iterator<String> featurePaths = Iterators.forArray(path1, path3, path4, path6);
 
-        workTree.delete(featurePaths);
+        workTree.delete(featurePaths, DefaultProgressListener.NULL);
 
         assertFalse(workTree.findUnstaged(path1).isPresent());
         assertTrue(workTree.findUnstaged(path2).isPresent());
@@ -471,14 +265,14 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         featureList = new LinkedList<Feature>();
         featureList.add(lines1);
         featureList.add(lines2);
         featureList.add(lines3);
 
-        workTree.insert(linesName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());
@@ -501,7 +295,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
     public void testHasRoot() throws Exception {
         insert(points1);
         Name typeName = points1.getName();
-        assertFalse(workTree.hasRoot(typeName));
+        assertFalse(workTree.hasRoot(typeName.getLocalPart()));
     }
 
     @Test
@@ -511,7 +305,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         assertEquals(3, workTree.countUnstaged(null).featureCount());
         assertEquals(1, workTree.countUnstaged(null).treeCount());
@@ -529,14 +323,14 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         featureList = new LinkedList<Feature>();
         featureList.add(lines1);
         featureList.add(lines2);
         featureList.add(lines3);
 
-        workTree.insert(linesName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());
@@ -554,14 +348,14 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         featureList = new LinkedList<Feature>();
         featureList.add(lines1);
         featureList.add(lines2);
         featureList.add(lines3);
 
-        workTree.insert(linesName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         List<NodeRef> featureTypes = workTree.getFeatureTypeTrees();
 
@@ -695,7 +489,7 @@ public class WorkingTreeTest extends RepositoryTestCase {
         featureList.add(points2);
         featureList.add(points3);
 
-        workTree.insert(pointsName, featureList.iterator(), LISTENER, null, 3);
+        insert(featureList);
 
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP1)).isPresent());
         assertTrue(workTree.findUnstaged(appendChild(pointsName, idP2)).isPresent());

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureStore.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureStore.java
@@ -10,7 +10,7 @@
 package org.locationtech.geogig.geotools.data;
 
 import java.io.IOException;
-import java.util.AbstractList;
+import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicLong;
@@ -34,8 +34,13 @@ import org.geotools.feature.simple.SimpleFeatureBuilder;
 import org.geotools.filter.identity.FeatureIdVersionedImpl;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
-import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.model.RevFeatureBuilder;
+import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.repository.AutoCloseableIterator;
 import org.locationtech.geogig.repository.DefaultProgressListener;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.ProgressListener;
 import org.locationtech.geogig.repository.WorkingTree;
@@ -51,7 +56,6 @@ import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 
@@ -219,17 +223,76 @@ class GeogigFeatureStore extends ContentFeatureStore {
             features = new EmptyFeatureReader<SimpleFeatureType, SimpleFeature>(getSchema());
         }
 
-        String path = delegate.getTypeTreePath();
+        final NodeRef typeRef = delegate.getTypeRef();
         WorkingTree wtree = getFeatureSource().getWorkingTree();
 
         GeoGigFeatureWriter writer;
         if ((flags | WRITER_ADD) == WRITER_ADD) {
-            writer = GeoGigFeatureWriter.createAppendable(features, path, wtree);
+            writer = GeoGigFeatureWriter.createAppendable(features, typeRef, wtree);
         } else {
-            writer = GeoGigFeatureWriter.create(features, path, wtree);
+            writer = GeoGigFeatureWriter.create(features, typeRef, wtree);
         }
         return writer;
     }
+
+    // @Override
+    // public final List<FeatureId> addFeatures(
+    // FeatureCollection<SimpleFeatureType, SimpleFeature> featureCollection)
+    // throws IOException {
+    //
+    // // Preconditions.checkState(getDataStore().isAllowTransactions(),
+    // // "Transactions not supported; head is not a local branch");
+    // final WorkingTree workingTree = delegate.getWorkingTree();
+    // final String path = delegate.getTypeTreePath();
+    //
+    // ProgressListener listener = new DefaultProgressListener();
+    //
+    // final List<FeatureId> insertedFids = Lists.newArrayList();
+    // List<Node> deferringTarget = new AbstractList<Node>() {
+    //
+    // @Override
+    // public boolean add(Node node) {
+    // String fid = node.getName();
+    // String version = node.getObjectId().toString();
+    // insertedFids.add(new FeatureIdVersionedImpl(fid, version));
+    // return true;
+    // }
+    //
+    // @Override
+    // public Node get(int index) {
+    // throw new UnsupportedOperationException();
+    // }
+    //
+    // @Override
+    // public int size() {
+    // return 0;
+    // }
+    // };
+    // Integer count = (Integer) null;
+    //
+    // FeatureIterator<SimpleFeature> featureIterator = featureCollection.features();
+    // try {
+    // Iterator<SimpleFeature> features;
+    // features = new FeatureIteratorIterator<SimpleFeature>(featureIterator);
+    // /*
+    // * Make sure to transform the incoming features to the native schema to avoid situations
+    // * where geogig would change the metadataId of the RevFeature nodes due to small
+    // * differences in the default and incoming schema such as namespace or missing
+    // * properties
+    // */
+    // final SimpleFeatureType nativeSchema = delegate.getNativeType();
+    //
+    // features = Iterators.transform(features, new SchemaInforcer(nativeSchema));
+    //
+    // workingTree.insert(path, features, listener, deferringTarget, count);
+    // } catch (Exception e) {
+    // throw new IOException(e);
+    // } finally {
+    // featureIterator.close();
+    // }
+    //
+    // return insertedFids;
+    // }
 
     @Override
     public final List<FeatureId> addFeatures(
@@ -239,35 +302,20 @@ class GeogigFeatureStore extends ContentFeatureStore {
         // Preconditions.checkState(getDataStore().isAllowTransactions(),
         // "Transactions not supported; head is not a local branch");
         final WorkingTree workingTree = delegate.getWorkingTree();
-        final String path = delegate.getTypeTreePath();
+        final RevTree currentWorkHead = workingTree.getTree();
 
         ProgressListener listener = new DefaultProgressListener();
 
-        final List<FeatureId> insertedFids = Lists.newArrayList();
-        List<Node> deferringTarget = new AbstractList<Node>() {
+        final SimpleFeatureType nativeSchema = delegate.getNativeType();
+        final NodeRef typeRef = delegate.getTypeRef();
+        final String treePath = typeRef.path();
+        final ObjectId featureTypeId = typeRef.getMetadataId();
 
-            @Override
-            public boolean add(Node node) {
-                String fid = node.getName();
-                String version = node.getObjectId().toString();
-                insertedFids.add(new FeatureIdVersionedImpl(fid, version));
-                return true;
-            }
+        final ObjectId newWorktreeId;
 
-            @Override
-            public Node get(int index) {
-                throw new UnsupportedOperationException();
-            }
+        List<FeatureId> insertedFids = new ArrayList<>();
 
-            @Override
-            public int size() {
-                return 0;
-            }
-        };
-        Integer count = (Integer) null;
-
-        FeatureIterator<SimpleFeature> featureIterator = featureCollection.features();
-        try {
+        try (FeatureIterator<SimpleFeature> featureIterator = featureCollection.features()) {
             Iterator<SimpleFeature> features;
             features = new FeatureIteratorIterator<SimpleFeature>(featureIterator);
             /*
@@ -276,17 +324,23 @@ class GeogigFeatureStore extends ContentFeatureStore {
              * differences in the default and incoming schema such as namespace or missing
              * properties
              */
-            final SimpleFeatureType nativeSchema = delegate.getNativeType();
-
             features = Iterators.transform(features, new SchemaInforcer(nativeSchema));
+            // the returned list is expected to be in the order provided by the argument feature
+            // collection, so lets add the fids in the transformer here
+            Iterator<FeatureInfo> featureInfos = Iterators.transform(features, (f) -> {
+                RevFeature feature = RevFeatureBuilder.build(f);
+                String fid = f.getID();
+                String path = NodeRef.appendChild(treePath, fid);
+                String version = feature.getId().toString();
+                insertedFids.add(new FeatureIdVersionedImpl(fid, version));
 
-            workingTree.insert(path, features, listener, deferringTarget, count);
+                return FeatureInfo.insert(feature, featureTypeId, path);
+            });
+
+            newWorktreeId = workingTree.insert(featureInfos, listener);
         } catch (Exception e) {
             throw new IOException(e);
-        } finally {
-            featureIterator.close();
         }
-
         return insertedFids;
     }
 
@@ -346,22 +400,28 @@ class GeogigFeatureStore extends ContentFeatureStore {
                 "Transactions not supported; head is not a local branch");
 
         final WorkingTree workingTree = delegate.getWorkingTree();
-        final String path = delegate.getTypeTreePath();
-        Iterator<SimpleFeature> features = modifyingFeatureIterator(names, values, filter);
-        /*
-         * Make sure to transform the incoming features to the native schema to avoid situations
-         * where geogig would change the metadataId of the RevFeature nodes due to small differences
-         * in the default and incoming schema such as namespace or missing properties
-         */
         final SimpleFeatureType nativeSchema = delegate.getNativeType();
+        final NodeRef typeRef = delegate.getTypeRef();
+        final String treePath = typeRef.path();
+        final ObjectId featureTypeId = typeRef.getMetadataId();
 
-        features = Iterators.transform(features, new SchemaInforcer(nativeSchema));
+        try (AutoCloseableIterator<SimpleFeature> features = modifyingFeatureIterator(names, values,
+                filter)) {
+            /*
+             * Make sure to transform the incoming features to the native schema to avoid situations
+             * where geogig would change the metadataId of the RevFeature nodes due to small
+             * differences in the default and incoming schema such as namespace or missing
+             * properties
+             */
+            Iterator<SimpleFeature> schemaEnforced = Iterators.transform(features,
+                    new SchemaInforcer(nativeSchema));
 
-        try {
             ProgressListener listener = new DefaultProgressListener();
-            Integer count = (Integer) null;
-            List<Node> target = (List<Node>) null;
-            workingTree.insert(path, features, listener, target, count);
+
+            Iterator<FeatureInfo> featureInfos = Iterators.transform(schemaEnforced,
+                    (f) -> FeatureInfo.insert(RevFeatureBuilder.build(f), featureTypeId, NodeRef.appendChild(treePath, f.getID())));
+
+            workingTree.insert(featureInfos, listener);
         } catch (Exception e) {
             throw new IOException(e);
         }
@@ -374,23 +434,27 @@ class GeogigFeatureStore extends ContentFeatureStore {
      * @return
      * @throws IOException
      */
-    private Iterator<SimpleFeature> modifyingFeatureIterator(final Name[] names,
+    private AutoCloseableIterator<SimpleFeature> modifyingFeatureIterator(final Name[] names,
             final Object[] values, final Filter filter) throws IOException {
 
-        Iterator<SimpleFeature> iterator = featureIterator(filter);
+        AutoCloseableIterator<SimpleFeature> iterator = featureIterator(filter);
 
         Function<SimpleFeature, SimpleFeature> modifyingFunction = new ModifyingFunction(names,
                 values);
 
-        Iterator<SimpleFeature> modifyingIterator = Iterators.transform(iterator,
-                modifyingFunction);
+        AutoCloseableIterator<SimpleFeature> modifyingIterator = AutoCloseableIterator
+                .transform(iterator, modifyingFunction);
         return modifyingIterator;
     }
 
-    private Iterator<SimpleFeature> featureIterator(final Filter filter) throws IOException {
+    private AutoCloseableIterator<SimpleFeature> featureIterator(final Filter filter)
+            throws IOException {
         FeatureReader<SimpleFeatureType, SimpleFeature> unchanged = getReader(filter);
-        Iterator<SimpleFeature> iterator = new FeatureReaderIterator<SimpleFeature>(unchanged);
-        return iterator;
+        FeatureReaderIterator<SimpleFeature> iterator = new FeatureReaderIterator<SimpleFeature>(
+                unchanged);
+        AutoCloseableIterator<SimpleFeature> autocloseable = AutoCloseableIterator
+                .fromIterator(iterator, (i) -> iterator.close());
+        return autocloseable;
     }
 
     @Override
@@ -412,7 +476,7 @@ class GeogigFeatureStore extends ContentFeatureStore {
 
         Iterator<String> affectedFeaturePaths = Iterators.transform(featureIterator,
                 (f) -> NodeRef.appendChild(typeTreePath, f.getID()));
-        workingTree.delete(affectedFeaturePaths);
+        workingTree.delete(affectedFeaturePaths, DefaultProgressListener.NULL);
     }
 
     /**

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ImportOp.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/ImportOp.java
@@ -20,6 +20,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.data.DataStore;
 import org.geotools.data.FeatureSource;
 import org.geotools.data.Query;
+import org.geotools.data.store.FeatureIteratorIterator;
 import org.geotools.factory.Hints;
 import org.geotools.feature.DecoratingFeature;
 import org.geotools.feature.FeatureCollection;
@@ -35,6 +36,7 @@ import org.locationtech.geogig.data.ForwardingFeatureIterator;
 import org.locationtech.geogig.data.ForwardingFeatureSource;
 import org.locationtech.geogig.geotools.plumbing.GeoToolsOpException.StatusCode;
 import org.locationtech.geogig.hooks.Hookable;
+import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.Ref;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevFeatureBuilder;
@@ -46,6 +48,7 @@ import org.locationtech.geogig.plumbing.LsTreeOp.Strategy;
 import org.locationtech.geogig.plumbing.ResolveFeatureType;
 import org.locationtech.geogig.plumbing.RevObjectParse;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.ProgressListener;
 import org.locationtech.geogig.repository.WorkingTree;
@@ -56,6 +59,8 @@ import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.PropertyDescriptor;
 import org.opengis.filter.identity.FeatureId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
@@ -73,6 +78,8 @@ import com.vividsolutions.jts.geom.impl.PackedCoordinateSequenceFactory;
  */
 @Hookable(name = "import")
 public class ImportOp extends AbstractGeoGigOp<RevTree> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ImportOp.class);
 
     private boolean all = false;
 
@@ -229,21 +236,12 @@ public class ImportOp extends AbstractGeoGigOp<RevTree> {
                 // first we modify the feature type and the existing features, if needed
                 workTree.updateTypeTree(path, featureType);
                 Iterator<Feature> transformedIterator = transformFeatures(featureType, path);
-                try {
-                    final Integer collectionSize = collectionSize(featureSource);
-                    workTree.insert(path, transformedIterator, taskProgress, null, collectionSize);
-                } catch (Exception e) {
-                    throw new GeoToolsOpException(StatusCode.UNABLE_TO_INSERT);
-                }
+                RevFeatureType type = RevFeatureTypeBuilder.build(featureType);
+                objectDatabase().put(type);
+                insert(workTree, path, transformedIterator, taskProgress, type.getId());
             }
             if (!createSchemaOnly) {
-                try {
-                    insert(workTree, path, featureSource, taskProgress);
-                } catch (GeoToolsOpException e) {
-                    throw e;
-                } catch (Exception e) {
-                    throw new GeoToolsOpException(e, StatusCode.UNABLE_TO_INSERT);
-                }
+                insert(workTree, path, featureSource, taskProgress);
             }
         }
 
@@ -470,15 +468,44 @@ public class ImportOp extends AbstractGeoGigOp<RevTree> {
         }
     }
 
-    private void insert(final WorkingTree workTree, final String path,
+    private void insert(final WorkingTree workTree, final String treePath,
             @SuppressWarnings("rawtypes") final FeatureSource featureSource,
             final ProgressListener taskProgress) {
 
         final Query query = new Query();
         CoordinateSequenceFactory coordSeq = new PackedCoordinateSequenceFactory();
         query.getHints().add(new Hints(Hints.JTS_COORDINATE_SEQUENCE_FACTORY, coordSeq));
-        workTree.insert(path, featureSource, query, taskProgress);
 
+        try (FeatureIterator fit = featureSource.getFeatures(query).features()) {
+            FeatureType schema = featureSource.getSchema();
+            RevFeatureType featureType = RevFeatureTypeBuilder.build(schema);
+            objectDatabase().put(featureType);
+            ObjectId featureTypeId = featureType.getId();
+
+            if (fit.hasNext()) {
+                Iterator<Feature> features = new FeatureIteratorIterator<>(fit);
+                insert(workTree, treePath, features, taskProgress, featureTypeId);
+            }
+        } catch (IOException e) {
+            LOG.warn("Unable to insert into " + treePath, e);
+            throw new GeoToolsOpException(e, StatusCode.UNABLE_TO_INSERT);
+        }
+    }
+
+    private void insert(final WorkingTree workTree, final String treePath,
+            Iterator<Feature> features, final ProgressListener taskProgress,
+            ObjectId featureTypeId) {
+        try {
+            Iterator<FeatureInfo> infos = Iterators.transform(features, (f) -> {
+                RevFeature rf = RevFeatureBuilder.build(f);
+                String path = NodeRef.appendChild(treePath, f.getIdentifier().getID());
+                return FeatureInfo.insert(rf, featureTypeId, path);
+            });
+            workTree.insert(infos, taskProgress);
+        } catch (Exception e) {
+            LOG.warn("Unable to insert into " + treePath, e);
+            throw new GeoToolsOpException(e, StatusCode.UNABLE_TO_INSERT);
+        }
     }
 
     private Iterator<Feature> transformIterator(Iterator<NodeRef> nodeIterator,

--- a/src/geotools/src/test/java/org/locationtech/geogig/geotools/plumbing/ImportOpTest.java
+++ b/src/geotools/src/test/java/org/locationtech/geogig/geotools/plumbing/ImportOpTest.java
@@ -37,6 +37,7 @@ import org.locationtech.geogig.plumbing.ResolveFeatureType;
 import org.locationtech.geogig.plumbing.RevObjectParse;
 import org.locationtech.geogig.porcelain.AddOp;
 import org.locationtech.geogig.repository.Context;
+import org.locationtech.geogig.repository.FeatureInfo;
 import org.locationtech.geogig.repository.NodeRef;
 import org.locationtech.geogig.repository.WorkingTree;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
@@ -237,7 +238,10 @@ public class ImportOpTest extends RepositoryTestCase {
         GeometryFactory gf = new GeometryFactory();
         SimpleFeature feature = SimpleFeatureBuilder.build(type,
                 new Object[] { gf.createPoint(new Coordinate(0, 0)), "feature0" }, "feature");
-        geogig.getRepository().workingTree().insert("dest", feature);
+        
+        FeatureInfo fi = featureInfo("dest", feature);
+        WorkingTree workingTree = geogig.getRepository().workingTree();
+        workingTree.insert(fi);
         ImportOp importOp = geogig.command(ImportOp.class);
         importOp.setDataStore(TestHelper.createTestFactory().createDataStore(ImmutableMap.of()));
         importOp.setAll(true);


### PR DESCRIPTION
There were several overloaded versions of WorkingTree.insert
makeing the interface pretty messy.

Left only insert(FeatureInfo) and insert(Iterator<FeatureInfo>)