### PR TITLE
Fix doc typo in the postgresql backend documentation

### DIFF
--- a/doc/manual/source/repo/storage.rst
+++ b/doc/manual/source/repo/storage.rst
@@ -75,9 +75,9 @@ The following commands create two repositories, ``gold`` and ``QA`` in the same 
 
 .. code-block:: console
 
- user@localhost:/home/user$ geogig --repo "posgresql://dbserver/geogig/master/gold?user=peter&password=secret" init
+ user@localhost:/home/user$ geogig --repo "postgresql://dbserver/geogig/master/gold?user=peter&password=secret" init
 
- user@localhost:/home/user$ geogig --repo "posgresql://dbserver/geogig/master/QA?user=peter&password=secret" init
+ user@localhost:/home/user$ geogig --repo "postgresql://dbserver/geogig/master/QA?user=peter&password=secret" init
 
 
 Tired already of typing the repository URI?
@@ -85,8 +85,8 @@ A nice trick is to use environment variables instead:
 
 .. code-block:: console
 
- user@localhost:/home/user$ export gold="posgresql://dbserver/geogig/master/gold?user=peter&password=secret"
- user@localhost:/home/user$ export QA="posgresql://dbserver/geogig/master/QA?user=peter&password=secret"
+ user@localhost:/home/user$ export gold="postgresql://dbserver/geogig/master/gold?user=peter&password=secret"
+ user@localhost:/home/user$ export QA="postgresql://dbserver/geogig/master/QA?user=peter&password=secret"
 
  user@localhost:/home/user$ geogig --repo $gold init
  user@localhost:/home/user$ geogig --repo $QA init

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Init.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Init.java
@@ -73,7 +73,7 @@ public class Init extends AbstractCommand implements CLICommand {
             if (cli.getRepositoryURI() == null) {
                 // current dir
                 File currDir = cli.getPlatform().pwd();
-                targetURI = currDir.getAbsoluteFile().toURI();
+                targetURI = currDir.getAbsoluteFile().getCanonicalFile().toURI();
             } else {
                 targetURI = URI.create(cli.getRepositoryURI());
             }

--- a/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
+++ b/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
@@ -28,6 +28,7 @@ import static org.locationtech.geogig.cli.test.functional.TestFeatures.pointsTyp
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -85,10 +86,10 @@ public class DefaultStepDefinitions {
 
     private CLIContext localRepo;
 
-    private String replaceKnownVariables(String s) {
+    private String replaceKnownVariables(String s) throws IOException {
         if (s.contains("${currentdir}")) {
             File pwd = localRepo.platform.pwd();
-            s = s.replace("${currentdir}", pwd.getAbsolutePath().replace("\\", "/"));
+            s = s.replace("${currentdir}", pwd.getCanonicalPath().replace("\\", "/"));
             s = s.replace("\"", "");
         }
         if (s.contains("${repoURI}")) {


### PR DESCRIPTION
 'posgresql' corrected to 'postgresql' (missing 't') 