### PR TITLE
Fix OS X test case failure due to symbolic links

### DIFF
--- a/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Init.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/porcelain/Init.java
@@ -73,7 +73,7 @@ public class Init extends AbstractCommand implements CLICommand {
             if (cli.getRepositoryURI() == null) {
                 // current dir
                 File currDir = cli.getPlatform().pwd();
-                targetURI = currDir.getAbsoluteFile().toURI();
+                targetURI = currDir.getAbsoluteFile().getCanonicalFile().toURI();
             } else {
                 targetURI = URI.create(cli.getRepositoryURI());
             }

--- a/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
+++ b/src/cli/src/test/java/org/locationtech/geogig/cli/test/functional/DefaultStepDefinitions.java
@@ -28,6 +28,7 @@ import static org.locationtech.geogig.cli.test.functional.TestFeatures.pointsTyp
 
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.charset.Charset;
@@ -85,10 +86,10 @@ public class DefaultStepDefinitions {
 
     private CLIContext localRepo;
 
-    private String replaceKnownVariables(String s) {
+    private String replaceKnownVariables(String s) throws IOException {
         if (s.contains("${currentdir}")) {
             File pwd = localRepo.platform.pwd();
-            s = s.replace("${currentdir}", pwd.getAbsolutePath().replace("\\", "/"));
+            s = s.replace("${currentdir}", pwd.getCanonicalPath().replace("\\", "/"));
             s = s.replace("\"", "");
         }
         if (s.contains("${repoURI}")) {


### PR DESCRIPTION
On OS X, /var is a symlink to /private/var.  Some places in GeoGIG use
File#getAbsolutePath() vs File#getCanonicalPath() - these give different
results for files in "/var" ("/var/..." vs "/private/var/...").

Because linux systems have /var not as a symbolic link, this wasn't an issue.

This fix makes geogig more consistent in its use of Absolute vs Canonical.

Signed-off-by: DBlasby <dblasby@boundlessgeo.com>