### PR TITLE
Update instructions for developer Eclipse set up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ cucumber-report*
 git.properties
 # Netbeans project files
 nb-configuration.xml
+.DS_store

--- a/doc/technical/source/developers.rst
+++ b/doc/technical/source/developers.rst
@@ -62,11 +62,13 @@ To work with the Eclipse IDE, follow these steps.
 
 	$mvn eclipse:eclipse
 
-- Open Eclipse and create a new workspace
+- Open Eclipse and create a new workspace by selecting *File->Switch Workspace->Other...* menu and choosing an empty directory
 
 - Select the *File->Import...* menu and then select "Existing projects from workspace". You will see the dialog shown below
 
 	.. figure:: ../img/import_eclipse.png
+
+- Select *Maven->Existing Maven Projects* and click on *Next*
 
 - In the *Select root directory* field, select the ``src`` folder where the GeoGig source code can be found (which now will also contain the Eclipse projects). The list of projects in the *Projects* field will be populated. 
 
@@ -76,7 +78,7 @@ To handle maven projects directly from Eclipse, you can use the `m2eclipse <http
 
 Once your workspace contains the GeoGig source code, configure it following these steps.
 
-- Open the preferences dialog (*Window->Preferences*) and in the left part, select the *Java->Editor->Formatter* entry.
+- Open the preferences dialog (*Eclipse->Preferences*) and in the left part, select the *Java->Code Style->Formatter* entry.
 
 	.. figure:: ../img/formatter.png
 


### PR DESCRIPTION
The instructions in the developer docs were outdated. They have been
updated in order to eliminate errors or confusion.

.DS_Store has been added to .gitignore as this file is created on OS X
during builds.

Signed-off-by: Alex Goudine <agoudine@boundlessgeo.com>