### PR TITLE
Fix Incompatible Feature Type error for equivalent CRSs

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/RevFeatureTypeImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/RevFeatureTypeImpl.java
@@ -53,7 +53,7 @@ class RevFeatureTypeImpl extends AbstractRevObject implements RevFeatureType {
         super(id);
         checkNotNull(featureType);
         CoordinateReferenceSystem defaultCrs = featureType.getCoordinateReferenceSystem();
-        if (WGS84.equals(defaultCrs)) {
+        if (WGS84.equals( (org.geotools.referencing.AbstractIdentifiedObject) defaultCrs, false)) {
             // GeoTools treats DefaultGeographic.WGS84 as a special case when calling the
             // CRS.toSRS() method, and that causes the parsed RevFeatureType to hash differently.
             // To compensate that, we replace any instance of it with a CRS built using the

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/FeatureTypeAdapterFeatureSource.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/plumbing/FeatureTypeAdapterFeatureSource.java
@@ -19,6 +19,7 @@ import org.geotools.data.QueryCapabilities;
 import org.geotools.feature.FeatureCollection;
 import org.geotools.feature.FeatureIterator;
 import org.geotools.feature.simple.SimpleFeatureBuilder;
+import org.geotools.referencing.AbstractReferenceSystem;
 import org.locationtech.geogig.data.ForwardingFeatureCollection;
 import org.locationtech.geogig.data.ForwardingFeatureIterator;
 import org.locationtech.geogig.data.ForwardingFeatureSource;
@@ -31,6 +32,7 @@ import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.feature.type.Name;
 import org.opengis.filter.sort.SortBy;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 class FeatureTypeAdapterFeatureSource<T extends FeatureType, F extends Feature>
         extends ForwardingFeatureSource<T, F> {
@@ -99,15 +101,24 @@ class FeatureTypeAdapterFeatureSource<T extends FeatureType, F extends Feature>
                     throw new GeoToolsOpException(
                             GeoToolsOpException.StatusCode.INCOMPATIBLE_FEATURE_TYPE);
                 }
+
                 GeometryDescriptor geomDescriptorOrg = delegate.getSchema().getGeometryDescriptor();
                 GeometryDescriptor geomDescriptorDest = featureType.getGeometryDescriptor();
                 if (!geomDescriptorOrg.getType().getBinding()
-                        .equals(geomDescriptorDest.getType().getBinding())
-                        || !geomDescriptorOrg.getType().getCoordinateReferenceSystem().equals(
-                                geomDescriptorDest.getType().getCoordinateReferenceSystem())) {
+                        .equals(geomDescriptorDest.getType().getBinding())) {
                     throw new GeoToolsOpException(
                             GeoToolsOpException.StatusCode.INCOMPATIBLE_FEATURE_TYPE);
                 }
+
+                AbstractReferenceSystem crsOrg = (AbstractReferenceSystem) delegate.getSchema()
+                        .getCoordinateReferenceSystem();
+                AbstractReferenceSystem crsDest = (AbstractReferenceSystem) featureType
+                        .getCoordinateReferenceSystem();
+                if (!crsOrg.equals(crsDest, false)) {
+                    throw new GeoToolsOpException(
+                            GeoToolsOpException.StatusCode.INCOMPATIBLE_FEATURE_TYPE);
+                }
+
                 FeatureIterator<F> iterator = delegate.features();
                 SimpleFeatureBuilder builder = new SimpleFeatureBuilder(
                         (SimpleFeatureType) featureType);


### PR DESCRIPTION
During import, minor differences between CRSs cause an Incompatible Feature Type error.
Inside GeoGIG, the CRS is stored along the lines of "EPSG:4326".  However, when it is
compared to an imported Shapefile, the check is too "exact" and it detects a CRS
difference when there isn't really a difference.

This fix makes the check of CRS equivelency less strict.

Signed-off-by: DBlasby <dblasby@boundlessgeo.com>