### PR TITLE
Ensure VersionInfo is not null

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/VersionInfo.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/VersionInfo.java
@@ -46,7 +46,13 @@ public class VersionInfo {
      * @param properties the properties of the current build
      */
     public VersionInfo(Properties properties) {
-        this.projectVersion = getClass().getPackage().getImplementationVersion();
+        // try to get the implementation version from this class
+        this.projectVersion = VersionInfo.class.getPackage().getImplementationVersion();
+        if (this.projectVersion == null) {
+            // no Implementation Version available
+            // should only occur if running from class files and not a JAR
+            this.projectVersion = "UNDETERMINED";
+        }
         this.branch = properties.get("git.branch").toString();
         this.commitId = properties.get("git.commit.id").toString();
         this.commitIdAbbrev = properties.get("git.commit.id.abbrev").toString();


### PR DESCRIPTION
When running Maven tests, in some situations, `VersionInfo` seems to be loaded from a classloader that is using the compiled classes directory, and not a JAR file. When this happens, the Package object returned from the classloader doesn't have implementation version info, and returns `null`. This causes the VerionTest to fail (it expects a non-null value in the ProjectVersion property, which is set in VersionInfo).
Changing VersionTest to account for this effectively means we don't verify anything for ProjectVersion, as the value is sometimes set, and sometimes null. Instead, we'll ensure the ProjectVersion is always set to something, though in the cases where Implementation Version isn't available from the classloader, we'll just use "**UNDETERMINED**"