### PR TITLE
Fix windows handling of ANSI escapes

### DIFF
--- a/doc/manpages/source/config.rst
+++ b/doc/manpages/source/config.rst
@@ -8,11 +8,11 @@ geogig-config documentation
 
 SYNOPSIS
 ********
-geogig config [--global|--local] name [value]
-geogig config [--global|--local] --get name
-geogig config [--global|--local] --unset name
-geogig config [--global|--local] --remove-section name
-geogig config [--global|--local] -l
+* geogig config [--global|--local] name [value]
+* geogig config [--global|--local] --get name
+* geogig config [--global|--local] --unset name
+* geogig config [--global|--local] --remove-section name
+* geogig config [--global|--local] -l
  
 
 
@@ -26,13 +26,13 @@ By default, the config file of the current repository will be assumed.  If the -
 OPTIONS
 *******
 
---global            Tells the config command to use the global config file, rather than the repository config file.
+--global        Tells the config command to use the global config file, rather than the repository config file.
 
 --local				Tells the config command to use the repository config file, rather than the global config file.
 
---get               Query the config file for the given section.key name.
+--get         Query the config file for the given section.key name.
 
---unset             Remove the line matching the given section.key name.
+--unset       Remove the line matching the given section.key name.
 
 --remove-section    Remove the given section from the config file.
 
@@ -43,7 +43,13 @@ GEOGIG CONFIGURATION
 
 This list is not comprehensive; some configuration options are documented in relevant man pages.
 
-bdbje.object_durability     Determines how safe to be when persisting objects in the BDB object store.  Valid values include: safe (be as safe as possible) and fast (sacrifice some safety to improve performance.)
+**ansi.enabled**
+
+  Boolean value to toggle ANSI escape sequence support. Used mainly on versions of Windows where ANSI escape sequences are not supported by the console. See installation section for instructions to enable ANSI on Windows. Valid values are true or false.
+
+**bdbje.object_durability**
+
+  Determines how safe to be when persisting objects in the BDB object store.  Valid values include: safe (be as safe as possible) and fast (sacrifice some safety to improve performance.)
 
 SEE ALSO
 ********

--- a/doc/manual/source/repo/config.rst
+++ b/doc/manual/source/repo/config.rst
@@ -41,7 +41,7 @@ To set the global value of a parameter, use the ``--global`` option.
 
    geogig config --global user.name "Author"
    geogig config --global user.email "author@example.com"
-
+   
 You can also get a display of all the configured global values by using the ``-l`` option. 
 
 .. code-block:: console
@@ -52,3 +52,15 @@ You can also get a display of all the configured global values by using the ``-l
 
    user.name=Author
    user.email=author@example.com
+
+Console text colouring can be set using the ``ansi.enabled`` parameter. Set the value to ``true`` or ``false`` to manually enable or disable ANSI support. This will override the auto-detection of ANSI support and can be set at the global level using ``--global`` or set in a repository as shown below.
+
+.. code-block:: console
+
+   geogig config ansi.enabled true
+  
+To use auto-detection of ANSI support use the ``--unset`` flag to remove the ``ansi.enabled`` parameter.
+
+.. code-block:: console
+
+   geogig config --unset ansi.enabled

--- a/doc/manual/source/start/installation.rst
+++ b/doc/manual/source/start/installation.rst
@@ -53,3 +53,44 @@ Running on Windows
 ------------------
 
 GeoGig uses `RocksDB <http://rocksdb.org/>`_ as the default storage backend.  On Windows machines, the libraries for RocksDB require the `Visual C++ Redistributable for Visual Studio 2015 <https://www.microsoft.com/en-us/download/details.aspx?id=48145>`_.  If you experience an ``UnsatisfiedLinkError`` exception when running GeoGig, make sure you have the above dependency installed on your system.
+
+Only Windows 10 supports colored text using ANSI escape sequences. On previous versions of windows, ANSI support can be enabled by installing `ANSICON <http://adoxa.altervista.org/ansicon/>`_ and setting the ``ansi.enabled`` config parameter to ``true``. See the config section :ref:`repo.config`. 
+
+Installing ANSICON
+==================
+
+#. Download the `ANSICON <http://adoxa.altervista.org/ansicon/>`_  zip. 
+
+#. Unzip the file to it's own location, such as ``C:\Program Files\Ansicon\``
+
+#. Add the ANSICON location to the Windows PATH, found under ``System -> Advanced System Properties -> Environment Variables``
+
+#. Open a ``cmd`` or ``powershell`` terminal and type ``ansicon`` to confirm the PATH variable is set correctly. If the PATH is correct  information about the Windows version will be printed in the console. This command will enable ANSICON for this terminal session only.
+
+.. code-block:: console
+
+   ansicon
+   Microsoft Windows [Version 6.3.9600]
+   (c) 2013 Microsoft Corporation. All rights reserved.
+   
+#. To make ANSICON load automatically with new terminals type:
+
+.. code-block:: console
+
+   ansicon -i 
+   
+#. ANSICON is now enabled by default in all terminals.
+
+Uninstalling ANSICON
+====================
+
+#. To remove ANSICON from the terminal defaults type:
+
+.. code-block:: console
+
+   ansicon -u
+   
+#. Remove ANSICON from the windows ``PATH``
+
+#. Delete the ANSICON folder from the location it was installed.
+

--- a/src/api/src/main/java/org/locationtech/geogig/repository/Platform.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/Platform.java
@@ -68,4 +68,5 @@ public interface Platform extends Serializable{
      *         repository's directory structure or the one provided by the system.
      */
     public File getTempDir();
+
 }

--- a/src/cli-app/pom.xml
+++ b/src/cli-app/pom.xml
@@ -78,6 +78,11 @@
       <artifactId>junit</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-all</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.locationtech.geogig</groupId>
       <artifactId>geogig-core</artifactId>
       <version>${project.version}</version>

--- a/src/cli-app/src/main/java/org/locationtech/geogig/cli/CLI.java
+++ b/src/cli-app/src/main/java/org/locationtech/geogig/cli/CLI.java
@@ -9,7 +9,12 @@
  */
 package org.locationtech.geogig.cli;
 
+import org.locationtech.geogig.porcelain.ConfigOp;
+import org.locationtech.geogig.porcelain.ConfigOp.ConfigAction;
+import org.locationtech.geogig.porcelain.ConfigOp.ConfigScope;
+import org.locationtech.geogig.repository.GeoGIG;
 import org.locationtech.geogig.repository.GlobalContextBuilder;
+import org.locationtech.geogig.repository.Hints;
 
 public class CLI {
     /**
@@ -34,6 +39,39 @@ public class CLI {
 
         final GeogigCLI cli = new GeogigCLI(consoleReader);
         cli.setRepositoryURI(repoURI);
+
+        GeoGIG geogig = cli.getGeogig();
+        boolean disableAnsi = false;
+        boolean closeIt = geogig == null;
+        if (closeIt) {
+            // we're not in a repository, need a geogig anyways to check the global config
+            geogig = cli.newGeoGIG(Hints.readOnly());
+            if (geogig.command(ConfigOp.class).setScope(ConfigScope.GLOBAL)
+                    .setAction(ConfigAction.CONFIG_GET).setName("ansi.enabled").toString()
+                    .equalsIgnoreCase("false")) {
+                disableAnsi = true;
+            } else if (geogig.command(ConfigOp.class).setScope(ConfigScope.GLOBAL)
+                    .setAction(ConfigAction.CONFIG_GET).setName("ansi.enabled").toString()
+                    .equalsIgnoreCase("true")) {
+                disableAnsi = false;
+            }
+            geogig.close();
+        } else {
+            if (geogig.getRepository().configDatabase().get("ansi.enabled").or("")
+                    .equalsIgnoreCase("false")) {
+                cli.getConsole().setForceAnsi(false);
+                disableAnsi = true;
+            } else if (geogig.getRepository().configDatabase().get("ansi.enabled").or("")
+                    .equalsIgnoreCase("true")) {
+                disableAnsi = false;
+                cli.getConsole().setForceAnsi(true);
+            }
+        }
+        if (disableAnsi) {
+            cli.getConsole().disableAnsi();
+        } else {
+            cli.getConsole().enableAnsi();
+        }
 
         addShutdownHook(cli);
         int exitCode = cli.execute(args);

--- a/src/cli-app/src/test/java/org/locationtech/geogig/cli/ConsoleTest.java
+++ b/src/cli-app/src/test/java/org/locationtech/geogig/cli/ConsoleTest.java
@@ -1,0 +1,43 @@
+package org.locationtech.geogig.cli;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class ConsoleTest {
+
+    @Before
+    public final void setUpInternal() {
+    }
+
+    @Test
+    public void forceAnsiTest() {
+        Console console = new Console();
+        console.setForceAnsi(true);
+        assertTrue(console.isAnsiSupported());
+        console.setForceAnsi(false);
+        assertFalse(console.isAnsiSupported());
+    }
+
+    @Test
+    public void testWindows10Detection() {
+        Console console = new Console();
+        boolean returned = false;
+        Throwable e = null;
+        try {
+            returned = console.checkAnsiSupported(System.out, "windows 10");
+        } catch (Throwable er) {
+            // catch attempt to create WindowsAnsiOutput
+            e = er;
+        }
+        assertTrue(returned || e instanceof UnsatisfiedLinkError);
+    }
+
+    @Test
+    public void testWindows7Detection() throws Throwable {
+        Console console = new Console();
+        assertFalse(console.checkAnsiSupported(System.out, "windows 7"));
+    }
+}


### PR DESCRIPTION
Only Windows 10 supports ANSI codes by default in terminals. Previous
windows versions do not support ANSI codes and require a third party
library (ANSICON) to support ANSI.

This fix adds auto-detection and a flag to enable/disable ANSI support.
Updated docs to reflect new functionality.

Resolves: #425
Signed-off-by: mtCarto <mthompson@boundlessgeo.com>