### PR TITLE
Add NOTICE file with dependencies

### DIFF
--- a/src/api/NOTICE
+++ b/src/api/NOTICE
@@ -1,0 +1,40 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  EJML under The Apache Software License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  Java implementation of GeographicLib under The MIT License(MIT)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/cli-app/NOTICE
+++ b/src/cli-app/NOTICE
@@ -1,0 +1,104 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig CLI App under Eclipse Distribution License
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoGig Web API under Eclipse Distribution License
+  GeoGig WebApp under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools DataStore Implementation under Eclipse Distribution License
+  GeoTools Extension under Eclipse Distribution License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HikariCP under The Apache Software License, Version 2.0
+  HTTP server connector under CDDL license or GPL license
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  Jetty AJP under Apache License Version 2
+  Jetty Server under Apache License Version 2.0
+  Jetty SSLEngine under Apache License Version 2
+  Jetty Utilities under Apache License Version 2.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUL to SLF4J bridge under MIT License
+  JUnit under Eclipse Public License 1.0
+  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  PostgreSQL Storage Backend under Eclipse Distribution License
+  Py4J under The New BSD License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Servlet Specification 2.5 API under CDDL 1.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/cli/NOTICE
+++ b/src/cli/NOTICE
@@ -1,0 +1,61 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Gherkin under MIT License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/core/NOTICE
+++ b/src/core/NOTICE
@@ -1,0 +1,50 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -15,6 +15,23 @@
   <name>GeoGig Core</name>
   <!-- Build Instructions and Profiles Handled as a normal maven java project: mvn clean install Online tests available using:
     mvn -Ponline Corertura is configured for a test coverage report: mvn cobertura:cobertura open target/site/cobertura/index.html -->
+
+  <licenses>
+    <license>
+      <name>Eclipse Distribution License</name>
+      <url>https://www.eclipse.org/org/documents/edl-v10.html</url>
+      <distribution>repo</distribution>
+      <comments>The Eclipse Distribution License is a BSD-3 style license</comments>
+    </license>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>This license only applies to varint and Google diff merge patch</comments>
+    </license>
+  </licenses>
+
+
   <dependencies>
     <dependency>
       <groupId>org.locationtech.geogig</groupId>

--- a/src/datastore/NOTICE
+++ b/src/datastore/NOTICE
@@ -1,0 +1,52 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoTools DataStore Implementation under Eclipse Distribution License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jai_core under Java Distribution License
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/geotools/NOTICE
+++ b/src/geotools/NOTICE
@@ -1,0 +1,91 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  Gherkin under MIT License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jai_core under Java Distribution License
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  JSON.simple under The Apache Software License, Version 2.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  Referencing services under Lesser General Public License (LGPL)
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/parent/NOTICE
+++ b/src/parent/NOTICE
@@ -1,0 +1,92 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  AOP alliance under Public Domain
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  HikariCP under The Apache Software License, Version 2.0
+  HTTP server connector under CDDL license or GPL license
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  Jetty AJP under Apache License Version 2
+  Jetty Server under Apache License Version 2.0
+  Jetty SSLEngine under Apache License Version 2
+  Jetty Utilities under Apache License Version 2.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUL to SLF4J bridge under MIT License
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  PostgreSQL Storage Backend under Eclipse Distribution License
+  Py4J under The New BSD License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB storage backend under Eclipse Distribution License
+  Servlet Specification 2.5 API under CDDL 1.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Storage backends under Eclipse Distribution License
+  Web modules under Eclipse Distribution License
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/parent/NOTICE.template
+++ b/src/parent/NOTICE.template
@@ -1,0 +1,22 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+#GENERATED_NOTICES#
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/parent/licenseMapping.xml
+++ b/src/parent/licenseMapping.xml
@@ -1,0 +1,1110 @@
+<?xml version="1.0" encoding="utf-8"?>
+<license-lookup xmlns="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://source.jasig.org/schemas/maven-notice-plugin/license-lookup https://source.jasig.org/schemas/maven-notice-plugin/license-lookup/license-lookup-v1.0.xsd">
+    <artifact>
+        <groupId>antisamy-bin</groupId>
+        <artifactId>org.owasp.validator</artifactId>
+        <license>BSD license</license>
+    </artifact>
+    <artifact>
+        <groupId>antlr</groupId>
+        <artifactId>antlr</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>asm</groupId>
+        <artifactId>asm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>asm</groupId>
+        <artifactId>asm-attrs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-css</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-ext</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-gui-util</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>batik</groupId>
+        <artifactId>batik-util</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>castor</groupId>
+        <artifactId>castor</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib-full</artifactId>
+        <license>Apache License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>classworlds</groupId>
+        <artifactId>classworlds</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.carrotsearch</groupId>
+        <artifactId>junit-benchmarks</artifactId>
+        <version>0.3.0-SONATYPE</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.google.code.atinject</groupId>
+        <artifactId>atinject</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.google.code.googleportlet</groupId>
+        <artifactId>googleportlet</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.googlecode.cernunnos</groupId>
+        <artifactId>cernunnos</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.ibm.icu</groupId>
+        <artifactId>icu4j</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.noelios.restlet</groupId>
+        <artifactId>com.noelios.restlet</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>com.noelios.restlet</groupId>
+        <artifactId>com.noelios.restlet.ext.servlet</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>com.noelios.restlet</groupId>
+        <artifactId>com.noelios.restlet.ext.spring</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>com.oracle</groupId>
+        <artifactId>csdk</artifactId>
+        <license>Not distributed with project</license>
+    </artifact>
+    <artifact>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.sun.xml.wsit</groupId>
+        <artifactId>wsit-rt</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.sun.xml.wsit</groupId>
+        <artifactId>xws-security</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.yahoo.platform.yui</groupId>
+        <artifactId>yuicompressor</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-beanutils</groupId>
+        <artifactId>commons-beanutils-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-cli</groupId>
+        <artifactId>commons-cli</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-codec</groupId>
+        <artifactId>commons-codec</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-collections</groupId>
+        <artifactId>commons-collections</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-digester</groupId>
+        <artifactId>commons-digester</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>de.zeigermann.xml</groupId>
+        <artifactId>xml-im-exporter</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>dom4j</groupId>
+        <artifactId>dom4j</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>doxia</groupId>
+        <artifactId>doxia-sink-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>httpunit</groupId>
+        <artifactId>httpunit</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>ical4j</groupId>
+        <artifactId>ical4j</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>jakarta-regexp</groupId>
+        <artifactId>jakarta-regexp</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javassist</groupId>
+        <artifactId>javassist</artifactId>
+        <license>Mozilla Public License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.activation</groupId>
+        <artifactId>activation</artifactId>
+        <version>1.1.1</version>
+        <name>JavaBeans(TM) Activation Framework</name>
+        <license>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.el</groupId>
+        <artifactId>el-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.portlet</groupId>
+        <artifactId>portlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet</groupId>
+        <artifactId>jsp-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>groovy-engine</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>js-engine</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.script</groupId>
+        <artifactId>script-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet</groupId>
+        <artifactId>jstl</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet</groupId>
+        <artifactId>servlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.servlet.jsp</groupId>
+        <artifactId>jsp-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.transaction</groupId>
+        <artifactId>jta</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs</artifactId>
+        <license>Commons Development and Distribution License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>jaxen</groupId>
+        <artifactId>jaxen</artifactId>
+        <license>Apache style license</license>
+    </artifact>
+    <artifact>
+        <groupId>jcifs</groupId>
+        <artifactId>jcifs</artifactId>
+        <license>GNU Lesser General Public License, version 2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>jdbm</groupId>
+        <artifactId>jdbm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>jdom</groupId>
+        <artifactId>jdom</artifactId>
+        <license>Apache style license</license>
+    </artifact>
+    <artifact>
+        <groupId>junit-addons</groupId>
+        <artifactId>junit-addons</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>ldapsdk</groupId>
+        <artifactId>ldapsdk</artifactId>
+        <license>Netscape Public License</license>
+    </artifact>
+    <artifact>
+        <groupId>nekohtml</groupId>
+        <artifactId>nekohtml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>net.jcip</groupId>
+        <artifactId>jcip-annotations</artifactId>
+        <license>Creative Commons Attribution License</license>
+    </artifact>
+    <artifact>
+        <groupId>net.jradius</groupId>
+        <artifactId>jradius-core</artifactId>
+        <license>LGPL, v3.0</license>
+    </artifact>
+    <artifact>
+        <groupId>net.jradius</groupId>
+        <artifactId>jradius-dictionary</artifactId>
+        <license>LGPL, v3.0</license>
+    </artifact>
+    <artifact>
+        <groupId>net.sf.jsr107cache</groupId>
+        <artifactId>jsr107cache</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>ognl</groupId>
+        <artifactId>ognl</artifactId>
+        <license>The OpenSymphony Software License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.antlr</groupId>
+        <artifactId>antlr-runtime</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.ant</groupId>
+        <artifactId>ant-launcher</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.bcel</groupId>
+        <artifactId>bcel</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.commons.ssl</groupId>
+        <artifactId>not-yet-commons-ssl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.derby</groupId>
+        <artifactId>derby</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.maven.doxia</groupId>
+        <artifactId>doxia-sink-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.httpcomponents</groupId>
+        <artifactId>httpclient</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>resolver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>serializer</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.xerces</groupId>
+        <artifactId>xml-apis</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.castor</groupId>
+        <artifactId>castor</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.groovy</groupId>
+        <artifactId>groovy-all-minimal</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-archiver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-cli</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-container-default</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-digest</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-i18n</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-interactivity-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-utils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.plexus</groupId>
+        <artifactId>plexus-velocity</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.swizzle</groupId>
+        <artifactId>swizzle-jira</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.swizzle</groupId>
+        <artifactId>swizzle-jirareport</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.swizzle</groupId>
+        <artifactId>swizzle-stream</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.cyberneko.html</groupId>
+        <artifactId>nekohtml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.hibernate</groupId>
+        <artifactId>ejb3-persistence</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.hibernate.javax.persistence</groupId>
+        <artifactId>hibernate-jpa-2.0-api</artifactId>
+        <license>Sun Binary Code License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.json</groupId>
+        <artifactId>org.json</artifactId>
+        <license>The JSON License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>opensaml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>openws</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.opensaml</groupId>
+        <artifactId>xmltooling</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.osaf</groupId>
+        <artifactId>caldav4j</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.owasp</groupId>
+        <artifactId>antisamy</artifactId>
+        <license>BSD License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet</groupId>
+        <artifactId>org.restlet</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet</groupId>
+        <artifactId>org.restlet.ext.spring</artifactId>
+        <license>LGPL, v2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>jcl-over-slf4j</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-api</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-log4j12</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.slf4j</groupId>
+        <artifactId>slf4j-jdk14</artifactId>
+        <license>MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.plexus</groupId>
+        <artifactId>plexus-build-api</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.plexus</groupId>
+        <artifactId>plexus-jetty6</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.spice</groupId>
+        <artifactId>plexus-ehcache</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.spice</groupId>
+        <artifactId>spice-utils</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aop</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-asm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-aspects</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-beans</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-context-support</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-expression</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-jdbc</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-orm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-oxm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-test</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-tx</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-web</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework</groupId>
+        <artifactId>spring-webmvc-portlet</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ldap</groupId>
+        <artifactId>spring-ldap-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ldap</groupId>
+        <artifactId>spring-ldap-core-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.binding</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.js</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>org.springframework.webflow</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-binding</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-js</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-js-resources</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.webflow</groupId>
+        <artifactId>spring-webflow</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-oxm</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-oxm-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-core-tiger</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-security</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-ws-test</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.springframework.ws</groupId>
+        <artifactId>spring-xml</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>oro</groupId>
+        <artifactId>oro</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>portlet-api</groupId>
+        <artifactId>portlet-api</artifactId>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>quartz</groupId>
+        <artifactId>quartz</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>rhino</groupId>
+        <artifactId>js</artifactId>
+        <license>Mozilla Public License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>rome</groupId>
+        <artifactId>modules</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>rome</groupId>
+        <artifactId>rome</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>slide</groupId>
+        <artifactId>jakarta-slide-webdavlib</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>stax</groupId>
+        <artifactId>stax</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>taglibs</groupId>
+        <artifactId>standard</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>tyrex</groupId>
+        <artifactId>tyrex</artifactId>
+        <license>BSD Style License</license>
+    </artifact>
+    <artifact>
+        <groupId>velocity-tools</groupId>
+        <artifactId>velocity-tools</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xalan</groupId>
+        <artifactId>serializer</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xalan</groupId>
+        <artifactId>xalan</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xerces</groupId>
+        <artifactId>xercesImpl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xerces</groupId>
+        <artifactId>xmlParserAPIs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xml-apis</groupId>
+        <artifactId>xmlParserAPIs</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xml-resolver</groupId>
+        <artifactId>xml-resolver</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xom</groupId>
+        <artifactId>xom</artifactId>
+        <license>GNU Lesser General Public License</license>
+    </artifact>
+    <artifact>
+        <groupId>xstream</groupId>
+        <artifactId>xstream</artifactId>
+        <license>BSD license</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.xml</groupId>
+        <artifactId>xmldsig</artifactId>
+        <license>JDL license</license>
+    </artifact>
+    <artifact>
+        <groupId>net.oauth.core</groupId>
+        <artifactId>oauth</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.axis</groupId>
+        <artifactId>axis</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.axis</groupId>
+        <artifactId>axis-jaxrpc</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>xpp3</groupId>
+        <artifactId>xpp3</artifactId>
+        <license>Apache License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.jdom</groupId>
+        <artifactId>jdom</artifactId>
+        <license>Apache License</license>
+    </artifact>
+    <artifact>
+        <groupId>ant</groupId>
+        <artifactId>ant</artifactId>
+        <version>1.5</version>
+        <license>Apache Software License, Version 1.1</license>
+    </artifact>
+    <artifact>
+        <groupId>cas</groupId>
+        <artifactId>cas</artifactId>
+        <version>2.0.12</version>
+        <license>Jasig License</license>
+    </artifact>
+    <artifact>
+        <groupId>cglib</groupId>
+        <artifactId>cglib-nodep</artifactId>
+        <version>2.1_3</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.google.code.guice</groupId>
+        <artifactId>guice</artifactId>
+        <version>2.0</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>commons-attributes</groupId>
+        <artifactId>commons-attributes-api</artifactId>
+        <version>2.2</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.mail</groupId>
+        <artifactId>mail</artifactId>
+        <version>1.4.1</version>
+        <license>Sun Binary Code License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.persistence</groupId>
+        <artifactId>persistence-api</artifactId>
+        <version>1.0</version>
+        <license>Sun Binary Code License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.xml.stream</groupId>
+        <artifactId>stax-api</artifactId>
+        <version>1.0-2</version>
+        <license>Sun Binary Code License</license>
+    </artifact>
+    <artifact>
+        <groupId>jgroups</groupId>
+        <artifactId>jgroups</artifactId>
+        <version>2.6.5.GA</version>
+        <license>Library (or Lesser) GNU Public License 2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>net.sf.json-lib</groupId>
+        <artifactId>json-lib</artifactId>
+        <version>2.2.3</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>1.0.1</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.gnu</groupId>
+        <artifactId>gnu-crypto</artifactId>
+        <version>2.0.1</version>
+        <license>GNU General Public License, with the "library exception"</license>
+    </artifact>
+    <artifact>
+        <groupId>org.gnu</groupId>
+        <artifactId>java-getopt</artifactId>
+        <version>1.0.13</version>
+        <license>GNU General Public License, with the "library exception"</license>
+    </artifact>
+    <artifact>
+        <groupId>org.samba.jcifs</groupId>
+        <artifactId>jcifs</artifactId>
+        <version>1.2.25</version>
+        <license>GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>org.samba.jcifs</groupId>
+        <artifactId>jcifs-ext</artifactId>
+        <version>0.9.4</version>
+        <license>GNU LESSER GENERAL PUBLIC LICENSE, Version 2.1</license>
+    </artifact>
+    <artifact>
+        <groupId>qdox</groupId>
+        <artifactId>qdox</artifactId>
+        <version>1.5</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>spy</groupId>
+        <artifactId>spymemcached</artifactId>
+        <version>2.8.1</version>
+        <license>The MIT License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.googlecode.junit-ext</groupId>
+        <artifactId>junit-ext</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.sun</groupId>
+        <artifactId>tools</artifactId>
+        <license>COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.enunciate</groupId>
+        <artifactId>enunciate-core</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.enunciate</groupId>
+        <artifactId>enunciate-core-annotations</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.enunciate</groupId>
+        <artifactId>enunciate-core-rt</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.sisu</groupId>
+        <artifactId>sisu-locks</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.sonatype.sisu.litmus</groupId>
+        <artifactId>litmus-testsupport</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet.jee</groupId>
+        <artifactId>org.restlet</artifactId>
+        <license>GPL 3.0 license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet.jee</groupId>
+        <artifactId>org.restlet.ext.servlet</artifactId>
+        <license>GPL 3.0 license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet.jee</groupId>
+        <artifactId>org.restlet.ext.slf4j</artifactId>
+        <license>GPL 3.0 license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.restlet.jee</groupId>
+        <artifactId>org.restlet.ext.spring</artifactId>
+        <license>GPL 3.0 license</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>catalina</artifactId>
+        <version>6.0.29</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.apache.tomcat</groupId>
+        <artifactId>tomcat-catalina</artifactId>
+        <version>7.0.8</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>com.atlassian.confluence</groupId>
+        <artifactId>confluence</artifactId>
+        <version>3.5</version>
+        <license>Atlassian End User License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.atlassian.jira</groupId>
+        <artifactId>jira-core</artifactId>
+        <version>4.4</version>
+        <license>Atlassian End User License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.atlassian.event</groupId>
+        <artifactId>atlassian-event</artifactId>
+        <version>2.0.6</version>
+        <license>Atlassian End User License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.atlassian.osuser</groupId>
+        <artifactId>atlassian-osuser</artifactId>
+        <version>1.1.2</version>
+        <license>Atlassian End User License</license>
+    </artifact>
+    <artifact>
+        <groupId>com.atlassian.seraph</groupId>
+        <artifactId>atlassian-seraph</artifactId>
+        <version>2.5.1</version>
+        <license>Atlassian End User License</license>
+    </artifact>
+    <artifact>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jsr173_api</artifactId>
+        <version>1.0</version>
+        <license>Commons Development and Distribution License, Version 1.0</license>
+    </artifact>
+    <artifact>
+        <groupId>org.codehaus.jettison</groupId>
+        <artifactId>jettison</artifactId>
+        <version>1.0-RC2</version>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>avalon-framework</groupId>
+        <artifactId>avalon-framework</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>logkit</groupId>
+        <artifactId>logkit</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+    <artifact>
+        <groupId>opensymphony</groupId>
+        <artifactId>ognl</artifactId>
+        <license>Apache License, Version 2.0</license>
+    </artifact>
+
+    <artifact>
+        <groupId>org.eclipse.emf</groupId>
+        <artifactId>common</artifactId>
+        <license>Eclipse Public License, Version 1.0</license>
+    </artifact>
+
+    <artifact>
+        <groupId>org.eclipse.emf</groupId>
+        <artifactId>ecore</artifactId>
+        <license>Eclipse Public License, Version 1.0</license>
+    </artifact>
+
+    <artifact>
+        <groupId>org.eclipse.xsd</groupId>
+        <artifactId>xsd</artifactId>
+        <license>Eclipse Public License, Version 1.0</license>
+    </artifact>
+
+    <artifact>
+        <groupId>picocontainer</groupId>
+        <artifactId>picocontainer</artifactId>
+        <license>BSD license</license>
+    </artifact>
+
+    <artifact>
+        <groupId>javax.media</groupId>
+        <artifactId>jai_core</artifactId>
+        <license>Java Distribution License</license>
+    </artifact>
+
+</license-lookup>

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -54,6 +54,8 @@
     <license>
       <name>Eclipse Distribution License</name>
       <url>https://www.eclipse.org/org/documents/edl-v10.html</url>
+      <distribution>repo</distribution>
+      <comments>The Eclipse Distribution License is a BSD-3 style license</comments>
     </license>
   </licenses>
   <repositories>
@@ -398,6 +400,31 @@
 
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.jasig.maven</groupId>
+          <artifactId>maven-notice-plugin</artifactId>
+          <version>1.0.4</version>
+          <configuration>
+            <noticeTemplate>NOTICE.template</noticeTemplate>
+            <licenseMapping>
+              <param>licenseMapping.xml</param>
+            </licenseMapping>
+            <includeScope>compile</includeScope>
+          </configuration>
+        </plugin>
+        <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>1.10</version>
+        <executions>
+          <execution>
+            <id>download-licenses</id>
+            <goals>
+              <goal>download-licenses</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
         <plugin>
           <!--
             generates OS specific scripts for starting java applications

--- a/src/storage/NOTICE
+++ b/src/storage/NOTICE
@@ -1,0 +1,76 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  AOP alliance under Public Domain
+  Apache Commons Logging under The Apache Software License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Gherkin under MIT License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HikariCP under The Apache Software License, Version 2.0
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  PostgreSQL Storage Backend under Eclipse Distribution License
+  Referencing services under Lesser General Public License (LGPL)
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  Spring AOP under The Apache Software License, Version 2.0
+  Spring Beans under The Apache Software License, Version 2.0
+  Spring Context under The Apache Software License, Version 2.0
+  Spring Core under The Apache Software License, Version 2.0
+  Spring Expression Language (SpEL) under The Apache Software License, Version 2.0
+  Spring Web under The Apache Software License, Version 2.0
+  Storage backends under Eclipse Distribution License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/storage/postgres/NOTICE
+++ b/src/storage/postgres/NOTICE
@@ -1,0 +1,74 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  AOP alliance under Public Domain
+  Apache Commons Logging under The Apache Software License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Gherkin under MIT License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HikariCP under The Apache Software License, Version 2.0
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Logback Core Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  PostgreSQL Storage Backend under Eclipse Distribution License
+  Referencing services under Lesser General Public License (LGPL)
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  Spring AOP under The Apache Software License, Version 2.0
+  Spring Beans under The Apache Software License, Version 2.0
+  Spring Context under The Apache Software License, Version 2.0
+  Spring Core under The Apache Software License, Version 2.0
+  Spring Expression Language (SpEL) under The Apache Software License, Version 2.0
+  Spring Web under The Apache Software License, Version 2.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/storage/rocksdb/NOTICE
+++ b/src/storage/rocksdb/NOTICE
@@ -1,0 +1,51 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  API interfaces under Lesser General Public License (LGPL)
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Mockito under The MIT License
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Referencing services under Lesser General Public License (LGPL)
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/web/NOTICE
+++ b/src/web/NOTICE
@@ -1,0 +1,108 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Guice under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoGig Web API under Eclipse Distribution License
+  GeoGig Web API Automated Functional Tests under Eclipse Distribution License
+  GeoGig WebApp under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  Gherkin under MIT License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HTTP server connector under CDDL license or GPL license
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  Jetty AJP under Apache License Version 2
+  Jetty Server under Apache License Version 2.0
+  Jetty SSLEngine under Apache License Version 2
+  Jetty Utilities under Apache License Version 2.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  org.xmlunit:xmlunit-core under The Apache Software License, Version 2.0
+  org.xmlunit:xmlunit-matchers under The Apache Software License, Version 2.0
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Servlet Specification 2.5 API under CDDL 1.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Web modules under Eclipse Distribution License
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/web/api/NOTICE
+++ b/src/web/api/NOTICE
@@ -1,0 +1,91 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoGig Web API under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  org.xmlunit:xmlunit-core under The Apache Software License, Version 2.0
+  org.xmlunit:xmlunit-matchers under The Apache Software License, Version 2.0
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/web/app/NOTICE
+++ b/src/web/app/NOTICE
@@ -1,0 +1,95 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoGig Web API under Eclipse Distribution License
+  GeoGig WebApp under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  HTTP server connector under CDDL license or GPL license
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  Jetty AJP under Apache License Version 2
+  Jetty Server under Apache License Version 2.0
+  Jetty SSLEngine under Apache License Version 2
+  Jetty Utilities under Apache License Version 2.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Servlet Specification 2.5 API under CDDL 1.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/

--- a/src/web/functional/NOTICE
+++ b/src/web/functional/NOTICE
@@ -1,0 +1,107 @@
+Copyright 2010, JA-SIG, Inc.
+This project includes software developed by Jasig.
+http://www.jasig.org/
+
+Licensed under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License. You may obtain a copy of the License at:
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on
+an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied. See the License for the
+specific language governing permissions and limitations
+under the License.
+
+This project includes:
+  Apache Commons Collections under Apache License, Version 2.0
+  API interfaces under Lesser General Public License (LGPL)
+  common under Eclipse Public License, Version 1.0
+  Commons DBCP under The Apache Software License, Version 2.0
+  Commons IO under The Apache Software License, Version 2.0
+  Commons JXPath under The Apache Software License, Version 2.0
+  Commons Lang under The Apache Software License, Version 2.0
+  Commons Pool under The Apache Software License, Version 2.0
+  Compress-LZF under Apache License 2.0
+  Cucumber-HTML under MIT License
+  Cucumber-JVM Repackaged Dependencies under BSD License or The Apache Software License, Version 2.0
+  Cucumber-JVM: Core under MIT License
+  Cucumber-JVM: Guice under MIT License
+  Cucumber-JVM: Java under MIT License
+  Cucumber-JVM: JUnit under MIT License
+  DataStore Support under Lesser General Public License (LGPL)
+  ecore under Eclipse Public License, Version 1.0
+  EJML under The Apache Software License, Version 2.0
+  EPSG Authority Service using HSQL database under Lesser General Public License (LGPL) or EPSG database distribution license or BSD License for HSQL
+  Feature Based Graphs and Networks under Lesser General Public License (LGPL)
+  FileUpload under The Apache Software License, Version 2.0
+  Filter Encoding Specification Model under Lesser General Public License (LGPL)
+  Filter Encoding Specification XML Support under Lesser General Public License (LGPL)
+  Filter XML Support under Lesser General Public License (LGPL)
+  GeoGig Command Line Interface under Eclipse Distribution License
+  GeoGig Core under Apache License, Version 2.0
+  GeoGig Core API under Eclipse Distribution License
+  GeoGig Web API under Eclipse Distribution License
+  GeoGig Web API Automated Functional Tests under Eclipse Distribution License
+  GeoGig WebApp under Eclipse Distribution License
+  GeoJSON Support under Lesser General Public License (LGPL)
+  GeoPackage Module under Lesser General Public License (LGPL)
+  GeoTools Extension under Eclipse Distribution License
+  Gherkin under MIT License
+  GML2 XML Support under Lesser General Public License (LGPL)
+  GML3 XML Support under Lesser General Public License (LGPL)
+  Google Guice - Core Library under The Apache Software License, Version 2.0
+  Google Guice - Extensions - MultiBindings under The Apache Software License, Version 2.0
+  Gson under The Apache Software License, Version 2.0
+  Guava: Google Core Libraries for Java under The Apache Software License, Version 2.0
+  Hamcrest Core under New BSD License
+  HTTP server connector under CDDL license or GPL license
+  HyperSQL Database under HSQLDB License, a BSD open source license
+  jansi under The Apache Software License, Version 2.0
+  Java implementation of GeographicLib under The MIT License(MIT)
+  javax.inject under The Apache Software License, Version 2.0
+  JCommander under The Apache Software License, Version 2.0
+  JDBC DataStore Support under Lesser General Public License (LGPL)
+  JDT Annotations for Enhanced Null Analysis under Eclipse Public License - v 1.0
+  Jetty AJP under Apache License Version 2
+  Jetty Server under Apache License Version 2.0
+  Jetty SSLEngine under Apache License Version 2
+  Jetty Utilities under Apache License Version 2.0
+  JSON.simple under The Apache Software License, Version 2.0
+  JSR 353 (JSON Processing) Default Provider under Dual license consisting of the CDDL v1.1 and GPL v2
+  jsr-275 under BSD License
+  JTS Topology Suite under Lesser General Public License (LGPL)
+  JUnit under Eclipse Public License 1.0
+  Main module under Lesser General Public License (LGPL)
+  Metadata under Lesser General Public License (LGPL)
+  Multipart form handler under CDDL license or GPL license
+  OGC CQL to Filter parser under Lesser General Public License (LGPL)
+  Open GIS Interfaces under OGC copyright or Lesser General Public License (LGPL)
+  Open Web Services Model under Lesser General Public License (LGPL)
+  Oracle DataStore under Lesser General Public License (LGPL)
+  org.xmlunit:xmlunit-core under The Apache Software License, Version 2.0
+  org.xmlunit:xmlunit-matchers under The Apache Software License, Version 2.0
+  OWS XML Support under Lesser General Public License (LGPL)
+  PicoContainer Core under BSD license
+  PostGIS DataStore under Lesser General Public License (LGPL)
+  PostgreSQL JDBC Driver under The PostgreSQL License
+  Reference Implementation under CDDL license or GPL license
+  Referencing services under Lesser General Public License (LGPL)
+  Restlet API under CDDL license or GPL license
+  RocksDB JNI under Apache License 2.0
+  RocksDB storage backend under Eclipse Distribution License
+  Servlet Specification 2.5 API under CDDL 1.0
+  servlet-api under Commons Development and Distribution License, Version 1.0
+  Shapefile module under Lesser General Public License (LGPL)
+  SLF4J API Module under MIT License
+  SLF4J Simple Binding under MIT License
+  SQLite JDBC under The Apache Software License, Version 2.0
+  Xlink Model under Lesser General Public License (LGPL)
+  XML Parsing under Lesser General Public License (LGPL)
+  xsd under Eclipse Public License, Version 1.0
+
+
+This project also includes code under copywrite of the following entities:
+  http://code.google.com/p/maven-license-plugin/


### PR DESCRIPTION
This commit added a NOTICE file and a template from which the
NOTICE file is created. Licenses which are not found online are
added to the 'licenseMapping.xml' file.

Current NOTICE file is modified (by hand) to not include any
dependencies which aren't from the 'compile' scope.
Re-executing the 'mvn notice:generate' command will replace the current
NOTICE file with a new one.

See issue: GIG-451

Signed-off-by: goudine <agoudine@boundlessgeo.com>