### PR TITLE
Update pom.xml license information based on review

### DIFF
--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -15,6 +15,21 @@
   <name>GeoGig Core</name>
   <!-- Build Instructions and Profiles Handled as a normal maven java project: mvn clean install Online tests available using:
     mvn -Ponline Corertura is configured for a test coverage report: mvn cobertura:cobertura open target/site/cobertura/index.html -->
+
+  <licenses>
+    <license>
+      <name>Eclipse Distribution License</name>
+      <url>https://www.eclipse.org/org/documents/edl-v10.html</url>
+      <distribution>repo</distribution>
+      <comments>The Eclipse Distribution License (a BSD-3 style license)</comments>
+    </license>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+      <comments>This license only applies to varint and Google diff merge patch</comments>
+    </license>
+  </licenses>
   <dependencies>
     <dependency>
       <groupId>org.locationtech.geogig</groupId>

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -54,6 +54,8 @@
     <license>
       <name>Eclipse Distribution License</name>
       <url>https://www.eclipse.org/org/documents/edl-v10.html</url>
+      <distribution>repo</distribution>
+      <comments>The Eclipse Distribution License (a BSD-3 style license)</comments>
     </license>
   </licenses>
   <repositories>


### PR DESCRIPTION
Clarified that EDL is is a BSD 3-Clause, and that the core module also includes some apache licensed code (a third-party dependency).