### PR TITLE
Serialization version 2.1

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/AbstractRevObject.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/AbstractRevObject.java
@@ -18,7 +18,7 @@ package org.locationtech.geogig.model;
  * @see RevFeatureType
  * @see RevTag
  */
-abstract class AbstractRevObject implements RevObject {
+public abstract class AbstractRevObject implements RevObject {
     private final ObjectId id;
 
     public AbstractRevObject(final ObjectId id) {

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGNode.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGNode.java
@@ -43,7 +43,7 @@ abstract class DAGNode {
 
         if (node instanceof DirectDAGNode) {
             output.writeByte(MAGIC_DIRECT);
-            FormatCommonV2.writeNode(((DirectDAGNode) node).node, output);
+            FormatCommonV2.INSTANCE.writeNode(((DirectDAGNode) node).node, output);
         } else {
             LazyDAGNode ln = (LazyDAGNode) node;
             if (ln instanceof TreeDAGNode) {
@@ -63,7 +63,7 @@ abstract class DAGNode {
         final byte magic = in.readByte();
         switch (magic) {
         case MAGIC_DIRECT: {
-            Node node = FormatCommonV2.readNode(in);
+            Node node = FormatCommonV2.INSTANCE.readNode(in);
             return DAGNode.of(node);
         }
         case MAGIC_LAZY_TREE: {

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
@@ -315,11 +315,11 @@ public class MergeStatusBuilder extends MergeScenarioConsumer {
         }
 
         private void writeNode(DataOutputStream out, Node node) throws IOException {
-            FormatCommonV2.writeNode(node, out);
+            FormatCommonV2.INSTANCE.writeNode(node, out);
         }
 
         private Node readNode(DataInputStream in) throws IOException {
-            return FormatCommonV2.readNode(in);
+            return FormatCommonV2.INSTANCE.readNode(in);
         }
 
     }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/AbstractObjectStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/AbstractObjectStore.java
@@ -29,6 +29,7 @@ import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.Closeables;
@@ -40,11 +41,24 @@ import com.google.common.io.Closeables;
  */
 public abstract class AbstractObjectStore implements ObjectStore {
 
-    protected final ObjectSerializingFactory serializer;
+    private ObjectSerializingFactory serializer;
+
+    public AbstractObjectStore() {
+        this(new SerializationFactoryProxy());
+    }
 
     public AbstractObjectStore(final ObjectSerializingFactory serializer) {
         checkNotNull(serializer);
         this.serializer = serializer;
+    }
+
+    protected void setSerializationFactory(ObjectSerializingFactory serializer) {
+        checkNotNull(serializer);
+        this.serializer = serializer;
+    }
+
+    public ObjectSerializingFactory serializer() {
+        return serializer;
     }
 
     /**
@@ -151,7 +165,7 @@ public abstract class AbstractObjectStore implements ObjectStore {
         }
         RevObject object;
         try {
-            object = serializer.read(id, raw);
+            object = serializer().read(id, raw);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         } finally {
@@ -243,7 +257,7 @@ public abstract class AbstractObjectStore implements ObjectStore {
 
     protected void writeObject(RevObject object, OutputStream target) {
         try {
-            serializer.write(object, target);
+            serializer().write(object, target);
         } catch (IOException e) {
             throw Throwables.propagate(e);
         }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_1.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.datastream;
+
+/**
+ * Serialization factory for serial version 2.1
+ * 
+ * @see FormatCommonV2_1
+ */
+public class DataStreamSerializationFactoryV2_1 extends DataStreamSerializationFactoryV2 {
+
+    public static final DataStreamSerializationFactoryV2_1 INSTANCE = new DataStreamSerializationFactoryV2_1();
+
+    public DataStreamSerializationFactoryV2_1() {
+        super(FormatCommonV2_1.INSTANCE);
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_1.java
@@ -1,0 +1,231 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.datastream;
+
+import static org.locationtech.geogig.storage.datastream.Varint.readUnsignedVarInt;
+import static org.locationtech.geogig.storage.datastream.Varint.writeUnsignedVarInt;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.locationtech.geogig.model.FieldType;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.plumbing.HashObject;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.ByteStreams;
+
+/**
+ * Format common v2.1, differs from {@link FormatCommonV2 v2} only in {@link RevFeature}
+ * serialization by adding a tail with value offsets, to allow parsing of individual attribute
+ * values.
+ * <p>
+ * Format for features:
+ * 
+ * <pre>
+ * <code>
+ * <HEADER><DATA>
+ * 
+ * <HEADER>:
+ * - unsigned varint: number of attributes
+ * - unsigned varint: size of <DATA>
+ * - unsigned varint[number of attributes]: attribute offsets (starting form zero at <DATA>, not including the header)
+ * 
+ * <DATA>:
+ * - byte[]: attribute data, as of {@link DataStreamValueSerializerV2#write(Object, DataOutput)}
+ * </code>
+ * </pre>
+ */
+public class FormatCommonV2_1 extends FormatCommonV2 {
+
+    public static final FormatCommonV2_1 INSTANCE = new FormatCommonV2_1();
+
+    private static final class InternalByteArrayOutputStream extends ByteArrayOutputStream {
+        InternalByteArrayOutputStream() {
+            super(1024);
+        }
+
+        public byte[] intenal() {
+            return super.buf;
+        }
+    }
+
+    @Override
+    public void writeFeature(RevFeature feature, DataOutput target) throws IOException {
+
+        try (InternalByteArrayOutputStream out = new InternalByteArrayOutputStream()) {
+            final DataOutput data = new DataOutputStream(out);
+            final int attrCount = feature.size();
+            final int[] dataOffsets = new int[attrCount];
+
+            int offset = 0;
+            for (int i = 0; i < attrCount; i++) {
+                Object value = feature.get(i).orNull();
+                FieldType type = FieldType.forValue(value);
+                data.writeByte(type.getTag() & 0xFF);
+                DataStreamValueSerializerV2.write(value, data);
+                dataOffsets[i] = offset;
+                offset = out.size();
+            }
+
+            // <HEADER>
+            // - unsigned varint: number of attributes
+            writeUnsignedVarInt(attrCount, target);
+
+            // - unsigned varint: size of <DATA>
+            final int dataSize = out.size();
+            writeUnsignedVarInt(dataSize, target);
+
+            // - unsigned varint[number of attributes]: attribute offsets (starting form zero at
+            // <DATA>, not including the header)
+            for (int i = 0; i < attrCount; i++) {
+                writeUnsignedVarInt(dataOffsets[i], target);
+            }
+
+            // <DATA>
+            target.write(out.intenal(), 0, dataSize);
+        }
+    }
+
+    @Override
+    public RevFeature readFeature(@Nullable ObjectId id, DataInput in) throws IOException {
+        // <HEADER>
+        // - unsigned varint: number of attributes
+        final int attrCount = readUnsignedVarInt(in);
+
+        // - unsigned varint: size of <DATA>
+        final int dataSize = readUnsignedVarInt(in);
+
+        // - unsigned varint[number of attributes]: attribute offsets (starting form zero at
+        // <DATA>, not including the header)
+        final int[] dataOffsets = new int[attrCount];
+        for (int i = 0; i < attrCount; i++) {
+            dataOffsets[i] = readUnsignedVarInt(in);
+        }
+
+        // <DATA>
+        byte[] data = new byte[dataSize];
+        in.readFully(data);
+
+        LazyRevFeature f = new LazyRevFeature(id, dataOffsets, data);
+        if (id == null) {
+            id = HashObject.hashFeature(f.values());
+            f.id = id;
+        }
+        return f;
+    }
+
+    private static final class LazyRevFeature implements RevFeature {
+
+        private final int[] offsets;
+
+        private final byte[] data;
+
+        private ObjectId id;
+
+        LazyRevFeature(ObjectId id, int[] offsets, byte[] data) {
+            this.id = id;
+            this.offsets = offsets;
+            this.data = data;
+        }
+
+        @Override
+        public ObjectId getId() {
+            return id;
+        }
+
+        @Override
+        public TYPE getType() {
+            return TYPE.FEATURE;
+        }
+
+        @Override
+        public ImmutableList<Optional<Object>> getValues() {
+            ImmutableList.Builder<Optional<Object>> b = ImmutableList.builder();
+            final int size = size();
+            for (int i = 0; i < size; i++) {
+                b.add(get(i));
+            }
+            return b.build();
+        }
+
+        List<Object> values() {
+            final int size = size();
+            List<Object> values = new ArrayList<>(size);
+            for (int i = 0; i < size; i++) {
+                values.add(parse(i));
+            }
+            return values;
+        }
+
+        @Override
+        public int size() {
+            return offsets.length;
+        }
+
+        @Override
+        public Optional<Object> get(final int index) {
+            return Optional.fromNullable(parse(index));
+        }
+
+        @Override
+        public void forEach(Consumer<Object> consumer) {
+            final int size = size();
+            for (int i = 0; i < size; i++) {
+                Object value = parse(i);
+                consumer.accept(value);
+            }
+        }
+
+        private @Nullable Object parse(int index) {
+            final int offset = offsets[index];
+            final int tagValue = data[offset] & 0xFF;
+            if (tagValue > 100) {
+                throw new IllegalStateException();
+            }
+            final FieldType type = FieldType.valueOf(tagValue);
+            DataInput in = ByteStreams.newDataInput(data);
+            @Nullable
+            Object value;
+            try {
+                in.skipBytes(offset + 1);
+                value = DataStreamValueSerializerV2.read(type, in);
+            } catch (IOException e) {
+                throw Throwables.propagate(e);
+            }
+            return value;
+        }
+
+        /**
+         * Equality is based on id
+         * 
+         * @see java.lang.Object#equals(java.lang.Object)
+         */
+        @Override
+        public boolean equals(Object o) {
+            if (!(o instanceof RevFeature)) {
+                return false;
+            }
+            return getId().equals(((RevObject) o).getId());
+        }
+
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/SerializationFactoryProxy.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/SerializationFactoryProxy.java
@@ -7,45 +7,44 @@
  * Contributors:
  * Gabriel Roldan (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.postgresql;
+package org.locationtech.geogig.storage.datastream;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.storage.ObjectSerializingFactory;
-import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
-import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 
 /**
  * An encoder for {@link RevObject} instances that delegates the the best available
  * {@link ObjectSerializingFactory} while maintaining backwards compatibility.
  * <p>
- * The purpose of this encoder is to abstract out {@link PGObjectDatabase} from the details of
- * serialization, allowing improved {@link ObjectSerializingFactory} implementations to be added
- * transparently, while maintaining backwards compatibility with objects encoded with prior versions
- * of the serialization format.
+ * The purpose of this encoder is to allow improved {@link ObjectSerializingFactory} implementations
+ * to be added transparently, while maintaining backwards compatibility with objects encoded with
+ * prior versions of the serialization format.
  * <p>
  * Serialized representations of {@code RevObject}s created by this encoder are composed of a
  * one-byte header followed by the encoded result of the concrete {@link ObjectSerializingFactory}
  * this encoder delegates to.
  * <p>
- * When deserializing a byte array from postgres, the header is used to identify which serializer
- * "version" the object was encoded with, and delegate to the proper serializer. This way, there can
- * be objects of mixed serialization formats in the same database transparently, so upgrading the
- * serialization format requires no extra maintenance.
+ * When deserializing, the header is used to identify which serializer "version" the object was
+ * encoded with, and delegate to the proper serializer. This way, there can be objects of mixed
+ * serialization formats in the same database transparently, so upgrading the serialization format
+ * requires no extra maintenance.
  */
-public class PGRevObjectEncoder {
+public class SerializationFactoryProxy implements ObjectSerializingFactory {
     /**
      * The serialized object is added a header that's one unsigned byte with the index of the
      * corresponding factory in this array
      */
     private static final ObjectSerializingFactory[] SUPPORTED_FORMATS = { //
             new LZFSerializationFactory(DataStreamSerializationFactoryV1.INSTANCE), //
-            new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE) //
+            new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE), //
+            new LZFSerializationFactory(DataStreamSerializationFactoryV2_1.INSTANCE) //
     };
 
     private static final int MAX_FORMAT_CODE = SUPPORTED_FORMATS.length - 1;
@@ -55,26 +54,36 @@ public class PGRevObjectEncoder {
      */
     private static final ObjectSerializingFactory WRITER = SUPPORTED_FORMATS[MAX_FORMAT_CODE];
 
+    @Override
+    public void write(RevObject o, OutputStream out) throws IOException {
+        final int storageVersionHeader = MAX_FORMAT_CODE;
+        out.write(storageVersionHeader);
+        WRITER.write(o, out);
+    }
+
+    @Override
+    public RevObject read(ObjectId id, InputStream in) throws IOException {
+        final int serialVersionHeader = in.read();
+        assert serialVersionHeader >= 0 && serialVersionHeader <= MAX_FORMAT_CODE;
+        final ObjectSerializingFactory serializer = SUPPORTED_FORMATS[serialVersionHeader];
+        RevObject revObject = serializer.read(id, in);
+        return revObject;
+    }
+
     /**
      * Reads object from its binary representation as stored in the database.
      */
     public RevObject decode(final ObjectId id, final byte[] bytes) {
         try (ByteArrayInputStream in = new ByteArrayInputStream(bytes)) {
-            final int serialVersionHeader = in.read();
-            assert serialVersionHeader >= 0 && serialVersionHeader <= MAX_FORMAT_CODE;
-            final ObjectSerializingFactory serializer = SUPPORTED_FORMATS[serialVersionHeader];
-            RevObject revObject = serializer.read(id, in);
-            return revObject;
+            return read(id, in);
         } catch (IOException e) {
             throw new RuntimeException("Error reading object " + id, e);
         }
     }
 
     public byte[] encode(final RevObject o) {
-        final int storageVersionHeader = MAX_FORMAT_CODE;
         try (ByteArrayOutputStream bout = new ByteArrayOutputStream()) {
-            bout.write(storageVersionHeader);
-            WRITER.write(o, bout);
+            write(o, bout);
             byte[] bytes = bout.toByteArray();
             return bytes;
         } catch (Exception e) {

--- a/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapObjectStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapObjectStore.java
@@ -196,7 +196,7 @@ public class HeapObjectStore extends AbstractObjectStore {
                     raw = objects.get(id);
                     if (raw != null) {
                         try {
-                            RevObject obj = serializer.read(id, new ByteArrayInputStream(raw));
+                            RevObject obj = serializer().read(id, new ByteArrayInputStream(raw));
                             found = type.isAssignableFrom(obj.getClass()) ? type.cast(obj) : null;
                         } catch (IOException e) {
                             throw Throwables.propagate(e);

--- a/src/core/src/test/java/org/locationtech/geogig/model/RevObjectTestSupport.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/RevObjectTestSupport.java
@@ -13,16 +13,13 @@ import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import java.util.function.Consumer;
 
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.plumbing.HashObject;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.ObjectStore;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import com.google.common.hash.HashCode;
 import com.vividsolutions.jts.geom.Envelope;
 
@@ -142,75 +139,13 @@ public class RevObjectTestSupport {
      */
     public static RevFeature featureForceId(ObjectId forceId, Object... rawValues) {
         RevFeatureBuilder builder = RevFeatureBuilder.builder().addAll(rawValues);
-        return new TestFeatureImpl(forceId, builder.build().getValues());
+        RevFeature revFeature = builder.build(forceId);
+        return revFeature;
     }
 
     public static RevFeature feature(Object... rawValues) {
         RevFeatureBuilder builder = RevFeatureBuilder.builder().addAll(rawValues);
         return builder.build();
-    }
-
-    private static class TestFeatureImpl extends AbstractRevObject implements RevFeature {
-
-        private final ImmutableList<Optional<Object>> values;
-
-        /**
-         * Constructs a new {@code RevFeature} with the provided {@link ObjectId} and set of values
-         * 
-         * @param id the {@link ObjectId} to use for this feature
-         * @param values a list of values, with {@link Optional#absent()} representing a null value
-         */
-        TestFeatureImpl(ObjectId id, ImmutableList<Optional<Object>> values) {
-            super(id);
-            this.values = values;
-        }
-
-        @Override
-        public ImmutableList<Optional<Object>> getValues() {
-            return values;
-        }
-
-        @Override
-        public TYPE getType() {
-            return TYPE.FEATURE;
-        }
-
-        @Override
-        public String toString() {
-            StringBuilder builder = new StringBuilder();
-            builder.append("Feature[");
-            builder.append(getId().toString());
-            builder.append("; ");
-            boolean first = true;
-            for (Optional<Object> value : getValues()) {
-                if (first) {
-                    first = false;
-                } else {
-                    builder.append(", ");
-                }
-
-                String valueString = String.valueOf(value.orNull());
-                builder.append(valueString.substring(0, Math.min(10, valueString.length())));
-            }
-            builder.append(']');
-            return builder.toString();
-        }
-
-        @Override
-        public int size() {
-            return values.size();
-        }
-
-        @Override
-        public Optional<Object> get(int index) {
-            // we're intentionally not enforcing a safe copy in this test-only code
-            return values.get(index);
-        }
-
-        @Override
-        public void forEach(final Consumer<Object> consumer) {
-            values.forEach((o) -> consumer.accept(o.orNull()));
-        }
     }
 
     /**

--- a/src/core/src/test/java/org/locationtech/geogig/storage/RevFeatureSerializationTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/RevFeatureSerializationTest.java
@@ -63,7 +63,7 @@ public abstract class RevFeatureSerializationTest extends Assert {
 
     protected SimpleFeatureType featureType1;
 
-    private Feature feature1_1;
+    protected Feature feature1_1;
 
     protected ObjectSerializingFactory serializer = getObjectSerializingFactory();
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureTypeV2Serialization.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureTypeV2Serialization.java
@@ -16,7 +16,7 @@ public class DataStreamFeatureTypeV2Serialization extends RevFeatureTypeSerializ
 
     @Override
     protected ObjectSerializingFactory getObjectSerializingFactory() {
-        return new DataStreamSerializationFactoryV2();
+        return DataStreamSerializationFactoryV2.INSTANCE;
     }
 
 }

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureV2SerializationTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureV2SerializationTest.java
@@ -15,6 +15,6 @@ import org.locationtech.geogig.storage.RevFeatureSerializationTest;
 public class DataStreamFeatureV2SerializationTest extends RevFeatureSerializationTest {
     @Override
     protected ObjectSerializingFactory getObjectSerializingFactory() {
-        return new DataStreamSerializationFactoryV2();
+        return DataStreamSerializationFactoryV2.INSTANCE;
     }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureV2_1SerializationTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamFeatureV2_1SerializationTest.java
@@ -10,13 +10,11 @@
 package org.locationtech.geogig.storage.datastream;
 
 import org.locationtech.geogig.storage.ObjectSerializingFactory;
-import org.locationtech.geogig.storage.RevCommitSerializationTest;
+import org.locationtech.geogig.storage.RevFeatureSerializationTest;
 
-public class DataStreamV2CommitSerializationTest extends RevCommitSerializationTest {
-
+public class DataStreamFeatureV2_1SerializationTest extends RevFeatureSerializationTest {
     @Override
     protected ObjectSerializingFactory getObjectSerializingFactory() {
-        return DataStreamSerializationFactoryV2.INSTANCE;
+        return DataStreamSerializationFactoryV2_1.INSTANCE;
     }
-
 }

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamV2RevTreeSerializationTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamV2RevTreeSerializationTest.java
@@ -15,6 +15,6 @@ import org.locationtech.geogig.storage.RevTreeSerializationTest;
 public class DataStreamV2RevTreeSerializationTest extends RevTreeSerializationTest {
     @Override
     protected ObjectSerializingFactory getObjectSerializingFactory() {
-        return new DataStreamSerializationFactoryV2();
+        return DataStreamSerializationFactoryV2.INSTANCE;
     }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/test/performance/AbstractObjectStoreStressTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/performance/AbstractObjectStoreStressTest.java
@@ -51,10 +51,13 @@ import org.locationtech.geogig.test.TestPlatform;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
+import com.google.common.base.Throwables;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
 import com.google.common.hash.BloomFilter;
 import com.google.common.hash.Funnels;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.io.WKTReader;
 
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
 public abstract class AbstractObjectStoreStressTest {
@@ -133,7 +136,7 @@ public abstract class AbstractObjectStoreStressTest {
         testPutAll(5000_000);
     }
 
-    @Ignore
+    // @Ignore
     @Test
     public void test06_PutAll_10M() throws Exception {
         testPutAll(10_000_000);
@@ -333,6 +336,8 @@ public abstract class AbstractObjectStoreStressTest {
         return fakeObject(objectId);
     }
 
+    private Geometry fakeGeom;
+
     private RevObject fakeObject(ObjectId forcedId) {
         // String oidString = objectId.toString();
         // ObjectId treeId = ObjectId.forString("tree" + oidString);
@@ -342,7 +347,16 @@ public abstract class AbstractObjectStoreStressTest {
         // String message = "message " + oidString;
         // return new RevCommitImpl(objectId, treeId, parentIds, author, committer, message);
 
-        return featureForceId(forcedId, "null", "Some string value " + forcedId);
+        if (fakeGeom == null) {
+            try {
+                fakeGeom = new WKTReader().read(
+                        "MULTIPOLYGON (((-121.3647138 38.049474, -121.3646902 38.049614, -121.3646159 38.0496058, -121.3646188 38.049587, -121.3645936 38.049586, -121.3645924 38.0496222, -121.3645056 38.0496178, -121.3645321 38.0494567, -121.3647138 38.049474)))");
+            } catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+
+        return featureForceId(forcedId, fakeGeom, "Some string value " + forcedId);
     }
 
     private ObjectId fakeId(int i) {

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGObjectDatabase.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGObjectDatabase.java
@@ -69,6 +69,7 @@ import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConflictsDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.StorageType;
+import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 import org.locationtech.geogig.storage.postgresql.Environment.ConnectionConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,7 +111,7 @@ public class PGObjectDatabase implements ObjectDatabase {
 
     private final ConfigDatabase configdb;
 
-    private static final PGRevObjectEncoder encoder = new PGRevObjectEncoder();
+    private static final SerializationFactoryProxy encoder = new SerializationFactoryProxy();
 
     private DataSource dataSource;
 

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBConfig.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBConfig.java
@@ -9,23 +9,45 @@
  */
 package org.locationtech.geogig.rocksdb;
 
-class DBOptions {
+import java.util.Map;
+
+import org.rocksdb.ColumnFamilyHandle;
+
+import com.google.common.collect.ImmutableMap;
+
+class DBConfig {
 
     private final String dbpath;
 
     private final boolean readOnly;
 
-    public DBOptions(String dbpath, boolean readOnly) {
+    private ImmutableMap<String, String> defaultMetadata;
+
+    public DBConfig(String dbpath, boolean readOnly) {
+        this(dbpath, readOnly, ImmutableMap.of());
+    }
+
+    public DBConfig(String dbpath, boolean readOnly, Map<String, String> defaultMetadata) {
         this.dbpath = dbpath;
         this.readOnly = readOnly;
+        this.defaultMetadata = ImmutableMap.copyOf(defaultMetadata);
+    }
+
+    /**
+     * If not empty, a {@link ColumnFamilyHandle} named "metadata" will be created with the provided
+     * key/value pairs, as long as {@code readOnly == false} and the db is being created for the
+     * first time.
+     */
+    public ImmutableMap<String, String> getDefaultMetadata() {
+        return defaultMetadata;
     }
 
     @Override
     public boolean equals(Object o) {
-        if (!(o instanceof DBOptions)) {
+        if (!(o instanceof DBConfig)) {
             return false;
         }
-        DBOptions other = (DBOptions) o;
+        DBConfig other = (DBConfig) o;
         return dbpath.equals(other.dbpath) && readOnly == other.readOnly;
     }
 

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbBlobStore.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbBlobStore.java
@@ -53,7 +53,7 @@ class RocksdbBlobStore implements TransactionBlobStore {
                 if (dbhandle == null) {
                     String dbpath = dbdir.getAbsolutePath();
                     boolean readOnly = this.readOnly;
-                    DBOptions address = new DBOptions(dbpath, readOnly);
+                    DBConfig address = new DBConfig(dbpath, readOnly);
                     this.dbhandle = RocksConnectionManager.INSTANCE.acquire(address);
                 }
             }

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbConflictsDatabase.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbConflictsDatabase.java
@@ -84,7 +84,7 @@ class RocksdbConflictsDatabase implements ConflictsDatabase {
         DBHandle dbHandle = dbsByTransaction.get(id);
         if (dbHandle == null) {
             String dbpath = dbPath(txId);
-            DBOptions address = new DBOptions(dbpath, false);
+            DBConfig address = new DBConfig(dbpath, false);
             dbHandle = RocksConnectionManager.INSTANCE.acquire(address);
             this.dbsByTransaction.put(id, dbHandle);
         }

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbGraphDatabase.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbGraphDatabase.java
@@ -110,7 +110,7 @@ public class RocksdbGraphDatabase implements GraphDatabase {
             return;
         }
         String dbpath = dbdir.getAbsolutePath();
-        DBOptions opts = new DBOptions(dbpath, readOnly);
+        DBConfig opts = new DBConfig(dbpath, readOnly);
         this.dbhandle = RocksConnectionManager.INSTANCE.acquire(opts);
         this.db = dbhandle.db;
         this.open = true;

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
@@ -30,8 +30,7 @@ import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.storage.AbstractObjectStore;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.ObjectStore;
-import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
-import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
+import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -62,7 +61,7 @@ public class RocksdbObjectStore extends AbstractObjectStore implements ObjectSto
 
     @Inject
     public RocksdbObjectStore(Platform platform, @Nullable Hints hints) {
-        super(new LZFSerializationFactory(DataStreamSerializationFactoryV2.INSTANCE));
+        super(new SerializationFactoryProxy());
 
         Optional<URI> repoUriOpt = new ResolveGeogigURI(platform, hints).call();
         checkArgument(repoUriOpt.isPresent(), "couldn't resolve geogig directory");

--- a/src/storage/rocksdb/src/test/java/org/locationtech/geogig/rocksdb/DBOptionsTest.java
+++ b/src/storage/rocksdb/src/test/java/org/locationtech/geogig/rocksdb/DBOptionsTest.java
@@ -10,22 +10,22 @@ public class DBOptionsTest {
 
     @Test
     public void testConstructor() {
-        DBOptions o1 = new DBOptions("path", true);
+        DBConfig o1 = new DBConfig("path", true);
         assertEquals("path", o1.getDbPath());
         assertTrue(o1.isReadOnly());
 
-        DBOptions o2 = new DBOptions("path2", false);
+        DBConfig o2 = new DBConfig("path2", false);
         assertEquals("path2", o2.getDbPath());
         assertFalse(o2.isReadOnly());
     }
 
     @Test
     public void testEquals() {
-        DBOptions o1 = new DBOptions("path1", true);
-        DBOptions o2 = new DBOptions("path1", false);
-        DBOptions o3 = new DBOptions("path2", true);
-        DBOptions o4 = new DBOptions("path2", false);
-        DBOptions o5 = new DBOptions("path2", false);
+        DBConfig o1 = new DBConfig("path1", true);
+        DBConfig o2 = new DBConfig("path1", false);
+        DBConfig o3 = new DBConfig("path2", true);
+        DBConfig o4 = new DBConfig("path2", false);
+        DBConfig o5 = new DBConfig("path2", false);
 
         assertTrue(o1.equals(o1));
         assertFalse(o1.equals(o2));
@@ -58,7 +58,7 @@ public class DBOptionsTest {
 
     @Test
     public void testToString() {
-        DBOptions o1 = new DBOptions("path", true);
+        DBConfig o1 = new DBConfig("path", true);
         assertEquals("rocksdb[path: path, readonly: true]", o1.toString());
     }
 

--- a/src/storage/rocksdb/src/test/java/org/locationtech/geogig/rocksdb/RocksdbObjectStoreConformanceTest.java
+++ b/src/storage/rocksdb/src/test/java/org/locationtech/geogig/rocksdb/RocksdbObjectStoreConformanceTest.java
@@ -22,6 +22,7 @@ import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConflictsDatabase;
 import org.locationtech.geogig.storage.ObjectStoreConformanceTest;
 import org.locationtech.geogig.storage.StorageType;
+import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 import org.locationtech.geogig.storage.fs.IniFileConfigDatabase;
 
 public class RocksdbObjectStoreConformanceTest extends ObjectStoreConformanceTest {
@@ -74,6 +75,14 @@ public class RocksdbObjectStoreConformanceTest extends ObjectStoreConformanceTes
 
         database.checkConfig();
 
+    }
+
+    @Test
+    public void testSerializer() {
+        assertTrue(database.serializer() instanceof SerializationFactoryProxy);
+        database.close();
+        database.open();
+        assertTrue(database.serializer() instanceof SerializationFactoryProxy);
     }
 
 }


### PR DESCRIPTION
Introduce serial format v2.1 for lazy parsing of feature attribute values.

`RevFeature` instances are loaded straight from its byte array and values parsed on demand, instead of eagerly parsing them when deserializing.

```
format v2:
**********
--- 10,000,000 inserted in 1.894 min
----- 1,000,000 out of 1,000,000 random objects queried with getIfPresent() in 31.87 s
----- 1,000,000 random objects queried (0 not found) with getAll() in 15.06 s
2,7G	/data2/geogig-tests/junit4011480269349402911

format v2.1:
************
--- 10,000,000 inserted in 2.162 min
----- 1,000,000 out of 1,000,000 random objects queried with getIfPresent() in 20.12 s
----- 1,000,000 random objects queried (0 not found) with getAll() in 7.220 s
2,7G	/data2/geogig-tests/junit2137252337411189338
```