### PR TITLE
stop HSQL from resetting logging

### DIFF
--- a/src/cli-app/src/main/java/org/locationtech/geogig/cli/Logging.java
+++ b/src/cli-app/src/main/java/org/locationtech/geogig/cli/Logging.java
@@ -52,6 +52,7 @@ class Logging {
     }
 
     static void tryConfigureLogging(Platform platform, @Nullable final String repoURI) {
+        System.setProperty("hsqldb.reconfig_logging", "false"); // stop hsql from reseting logging
         // instantiate and call ResolveGeogigDir directly to avoid calling getGeogig() and hence get
         // some logging events before having configured logging
         Hints hints = new Hints();


### PR DESCRIPTION
HSQLDB, when starting up (i.e. when using an EPSG code), resets logging.  This prevents this from happening.  

cf. Gory details in Geotools issue - https://osgeo-org.atlassian.net/browse/GEOT-5596