### PR TITLE
Documentation: fix navigation

### DIFF
--- a/doc/themes/geogig_docs/layout.html
+++ b/doc/themes/geogig_docs/layout.html
@@ -43,10 +43,10 @@
 
 
         <div class="btn-group-vertical" id="docs_toc">
-          <button type="button" class="btn btn-default"><a href="/docs/">User Manual</a></button>
-          <button type="button" class="btn btn-default"><a href="/technical/">Technical Manual</a></button>
-          <button type="button" class="btn btn-default"><a href="/manpages/">Man Pages</a></button>
-          <button type="button" class="btn btn-default"><a href="/workshop/">Workshop</a></button>
+          <a class="btn btn-default" href="/docs/">User Manual</a>
+          <a class="btn btn-default" href="/technical/">Technical Manual</a>
+          <a class="btn btn-default" href="/manpages/">Man Pages</a>
+          <a class="btn btn-default" href="/workshop/">Workshop</a>
       </div>
 
     {%- if display_toc %}

--- a/doc/themes/geogig_docs/static/custom.css
+++ b/doc/themes/geogig_docs/static/custom.css
@@ -342,7 +342,8 @@ Sidebar
   width: 100%;
 }
 #docs_toc .btn-default {
-  color: #333333;
+  color: #28728d;
+  text-decoration: none;
   background-color: #cccccc;
   border-color: #cccccc;
   text-transform: uppercase;
@@ -351,13 +352,10 @@ Sidebar
 }
 #docs_toc .btn-default:hover {
   background-color: #7eb5d3;
-}
-#docs_toc .btn-default:hover a {
+  text-decoration: none;
   color: #000;
 }
-#docs_toc .btn-default:hover a:hover {
-  text-decoration: none;
-}
+
 .admonition {
   border: 1px solid #ccc;
   padding: 5px 10px;

--- a/doc/themes/geogig_docs/static/custom.less
+++ b/doc/themes/geogig_docs/static/custom.less
@@ -401,7 +401,7 @@ Sidebar
 	width: 100%;
 
 	.btn-default {
-		color: #333333;
+		color: @mdblue;
 		background-color: #cccccc;
 		border-color: #cccccc;
 		text-transform: uppercase;
@@ -410,10 +410,8 @@ Sidebar
 
 		&:hover {
 			background-color: @ltblue;
-			a { color: #000; }
-			a:hover {
-				text-decoration: none;
-			}
+			color: #000;
+			text-decoration: none;
 		}
 	}
 }


### PR DESCRIPTION
as described in Issue #208, in Firefox, the documentation navigation is broken (no chance to jump from "workshop" to "manpages"), which is annoying.
This pull request should fix that issue, leaving all layout and CSS styling as before.