### PR TITLE
Add NodeId (canonical/quad) serialization for temporary storage

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/ClusteringStrategyBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/ClusteringStrategyBuilder.java
@@ -100,12 +100,6 @@ public abstract class ClusteringStrategyBuilder {
         }
 
         @Override
-        protected DAGStorageProvider createDAGStoreageProvider() {
-            // @TODO: temporary measure until we can persist mutable quadtrees to disk
-            return new HeapDAGStorageProvider(treeStore);
-        }
-
-        @Override
         protected ClusteringStrategy buildInternal(DAGStorageProvider dagStoreProvider) {
             checkState(maxBounds != null, "QuadTree max bounds was not set");
             return new QuadTreeClusteringStrategy(original, dagStoreProvider, maxBounds, maxDepth);

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/DAG.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/DAG.java
@@ -308,10 +308,10 @@ final class DAG implements Cloneable, Serializable {
         Varint.writeUnsignedVarInt(buckets.size(), out);
 
         for (NodeId nodeid : nonPromotable) {
-            out.writeUTF(((CanonicalNodeId) nodeid).name());
+            NodeIdIO.write(nodeid, out);
         }
         for (NodeId nodeid : children) {
-            out.writeUTF(((CanonicalNodeId) nodeid).name());
+            NodeIdIO.write(nodeid, out);
         }
         for (TreeId tid : buckets) {
             byte[] bucketIndicesByDepth = tid.bucketIndicesByDepth;
@@ -336,15 +336,15 @@ final class DAG implements Cloneable, Serializable {
         if (nonPromotableSize > 0) {
             nonPromotable = new HashSet<>();
             for (int i = 0; i < nonPromotableSize; i++) {
-                String name = in.readUTF();
-                nonPromotable.add(new CanonicalNodeId(name));
+                NodeId nid = NodeIdIO.read(in);
+                nonPromotable.add(nid);
             }
         }
         if (childrenSize > 0) {
             children = new HashSet<>();
             for (int i = 0; i < childrenSize; i++) {
-                String name = in.readUTF();
-                children.add(new CanonicalNodeId(name));
+                NodeId nid = NodeIdIO.read(in);
+                children.add(nid);
             }
         }
         if (bucketSize > 0) {

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/NodeIdIO.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/NodeIdIO.java
@@ -1,0 +1,136 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.model.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.locationtech.geogig.storage.datastream.Varint;
+
+/**
+ * Utility class to serialize and deserialize {@link NodeId} instances with {@link DAG#serialize}
+ * and {@link DAG#deserialize} not having to know how to encode/decode the different kinds of
+ * {@link NodeId} concrete classes.
+ *
+ */
+class NodeIdIO {
+
+    private static final byte CANONICAL = 0x01;
+
+    private static final byte QUAD = 0x02;
+
+    public static void write(NodeId id, DataOutput out) throws IOException {
+        checkNotNull(id);
+        checkNotNull(out);
+        if (id instanceof CanonicalNodeId) {
+            out.writeByte(CANONICAL);
+            writeCanonical((CanonicalNodeId) id, out);
+        } else if (id instanceof QuadTreeNodeId) {
+            out.writeByte(QUAD);
+            writeQuad((QuadTreeNodeId) id, out);
+        } else {
+            throw new IllegalArgumentException("Unknown nodeid type: " + id.getClass().getName());
+        }
+    }
+
+    public static NodeId read(DataInput in) throws IOException {
+        final int type = in.readUnsignedByte();
+        switch (type) {
+        case CANONICAL:
+            return readCanonical(in);
+        case QUAD:
+            return readQuad(in);
+        default:
+            throw new IllegalArgumentException("Uknown id type identifier: " + type);
+        }
+    }
+
+    private static void writeCanonical(CanonicalNodeId id, DataOutput out) throws IOException {
+        out.writeUTF(id.name());
+    }
+
+    private static CanonicalNodeId readCanonical(DataInput in) throws IOException {
+        String name = in.readUTF();
+        return new CanonicalNodeId(name);
+    }
+
+    private static void writeQuad(QuadTreeNodeId id, DataOutput out) throws IOException {
+        out.writeUTF(id.name());
+        Quadrant[] quadrantsByDepth = id.quadrantsByDepth();
+        writeQuadrants(quadrantsByDepth, out);
+    }
+
+    private static QuadTreeNodeId readQuad(DataInput in) throws IOException {
+        String name = in.readUTF();
+        Quadrant[] quadrantsByDepth = readQuadrants(in);
+        return new QuadTreeNodeId(name, quadrantsByDepth);
+    }
+
+    static void writeQuadrants(Quadrant[] quadrantsByDepth, DataOutput out) throws IOException {
+        final int numQuads = quadrantsByDepth.length;
+        Varint.writeUnsignedVarInt(numQuads, out);
+
+        if (numQuads == 0) {
+            return;
+        }
+
+        final int bitsPerQuad = 2;
+        final int quadsPerByte = Byte.SIZE / bitsPerQuad;
+        final int numBytes = (int) Math.ceil((double) numQuads / quadsPerByte);
+
+        byte[] data = new byte[numBytes];
+        for (int i = 0; i < numQuads; i++) {
+            final int byteN = i / quadsPerByte;
+            final int shiftBy = bitsPerQuad * (i % quadsPerByte);
+
+            final int bucketNumber = quadrantsByDepth[i].getBucketNumber();
+            final int shiftedBucketNumber = bucketNumber << shiftBy;
+            final int bucketByte = data[byteN];
+            final int sharedBucketByte = bucketByte | shiftedBucketNumber;
+            data[byteN] = (byte) sharedBucketByte;
+        }
+        out.write(data);
+    }
+
+    static Quadrant[] readQuadrants(DataInput in) throws IOException {
+        final int numQuads = Varint.readUnsignedVarInt(in);
+        if (numQuads == 0) {
+            return new Quadrant[0];
+        }
+
+        Quadrant[] quads = new Quadrant[numQuads];
+        final int bitsPerQuad = 2;
+        final int quadsPerByte = Byte.SIZE / bitsPerQuad;
+        final int numBytes = (int) Math.ceil((double) numQuads / quadsPerByte);
+
+        final byte[] data = new byte[numBytes];
+        in.readFully(data);
+
+        for (int i = 0; i < numQuads; i++) {
+            final int byteN = i / quadsPerByte;
+            final int shiftBy = bitsPerQuad * (i % quadsPerByte);
+
+            final int bucketByte = data[byteN];
+
+            final int mask = 0b00000011 << shiftBy;
+            final int unmasked = bucketByte & mask;
+            final int bucketNumber = unmasked >>> shiftBy;
+
+            Quadrant q = Quadrant.VALUES[bucketNumber];
+            quads[i] = q;
+        }
+
+        return quads;
+    }
+
+}

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy.java
@@ -113,7 +113,7 @@ class QuadTreeClusteringStrategy extends ClusteringStrategy {
         final int maxDepth = this.maxDepth;
         List<Quadrant> quadrantsByDepth = new ArrayList<>(maxDepth);
 
-        final Quadrant[] quadrants = QuadTreeNodeId.QUADRANTS;
+        final Quadrant[] quadrants = Quadrant.VALUES;
 
         Envelope parentQuadrantBounds = this.maxBounds;
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeNodeId.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeNodeId.java
@@ -15,9 +15,6 @@ import com.google.common.collect.Ordering;
 
 class QuadTreeNodeId extends NodeId {
 
-    // there's some overhead in calling Quadrant.values() repeatedly so cache it
-    static final Quadrant[] QUADRANTS = Quadrant.values();
-
     protected static final Ordering<Quadrant[]> COMPARATOR = new Ordering<Quadrant[]>() {
         @Override
         public int compare(Quadrant[] left, Quadrant[] right) {
@@ -44,7 +41,7 @@ class QuadTreeNodeId extends NodeId {
 
         Quadrant[] quadrantsByDepth = new Quadrant[maxDepth];
         for (int i = 0; i < maxDepth; i++) {
-            quadrantsByDepth[i] = QUADRANTS[quadrantIndexes[i] & 0xFF];
+            quadrantsByDepth[i] = Quadrant.VALUES[quadrantIndexes[i] & 0xFF];
         }
 
         this.quadrantsByDepth = quadrantsByDepth;

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/Quadrant.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/Quadrant.java
@@ -14,6 +14,9 @@ import com.vividsolutions.jts.geom.Envelope;
 public enum Quadrant {
     SW(0, 0), NW(0, 1), NE(1, 1), SE(1, 0);
 
+    // there's some overhead in calling Quadrant.values() repeatedly so cache it
+    static final Quadrant[] VALUES = values();
+
     private final int offsetX;
 
     private final int offsetY;
@@ -24,7 +27,7 @@ public enum Quadrant {
     }
 
     public int getBucketNumber() {
-       return this.ordinal();
+        return this.ordinal();
     }
 
     public Envelope slice(Envelope parent) {

--- a/src/core/src/test/java/org/locationtech/geogig/model/internal/NodeIdIOTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/internal/NodeIdIOTest.java
@@ -1,0 +1,100 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.model.internal;
+
+import static org.junit.Assert.assertEquals;
+import static org.locationtech.geogig.model.internal.Quadrant.NE;
+import static org.locationtech.geogig.model.internal.Quadrant.NW;
+import static org.locationtech.geogig.model.internal.Quadrant.SE;
+import static org.locationtech.geogig.model.internal.Quadrant.SW;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.ByteArrayDataInput;
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
+
+public class NodeIdIOTest {
+
+    @Test
+    public void testCanonicalNodeIds() throws Exception {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        List<NodeId> nodes = new ArrayList<>();
+        int size = 10;
+        for (int i = 0; i < size; i++) {
+            NodeId n = new CanonicalNodeId("node-" + i);
+            nodes.add(n);
+            NodeIdIO.write(n, out);
+        }
+
+        ByteArrayDataInput in = ByteStreams.newDataInput(out.toByteArray());
+
+        List<NodeId> decoded = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            NodeId n = NodeIdIO.read(in);
+            decoded.add(n);
+        }
+        assertEquals(nodes, decoded);
+    }
+
+    @Test
+    public void testEmptyQuads() throws IOException {
+        testQuadrants(new Quadrant[0]);
+    }
+
+    @Test
+    public void testQuads() throws IOException {
+        testQuadrants(new Quadrant[] { NE, SE, NW, SW });
+        testQuadrants(new Quadrant[] { NE, NE, NE, NE, NE, NE, SE, SE, SE, SE, SE, SE, SE });
+        testQuadrants(new Quadrant[] { SW, NE, SE, NE, NW, NW });
+    }
+
+    private void testQuadrants(Quadrant[] quads) throws IOException {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        NodeIdIO.writeQuadrants(quads, out);
+        byte[] encoded = out.toByteArray();
+
+        Quadrant[] decoded = NodeIdIO.readQuadrants(ByteStreams.newDataInput(encoded));
+
+        assertEquals(Lists.newArrayList(quads), Lists.newArrayList(decoded));
+    }
+
+    @Test
+    public void testQuadTreeNodeIds() throws Exception {
+        ByteArrayDataOutput out = ByteStreams.newDataOutput();
+        List<NodeId> nodes = new ArrayList<>();
+        int size = 10;
+        for (int i = 0; i < size; i++) {
+            Random rnd = new Random();
+            Quadrant[] quads = new Quadrant[2 * i];
+            for (int j = 0; j < quads.length; j++) {
+                quads[j] = Quadrant.VALUES[rnd.nextInt(4)];
+            }
+            NodeId n = new QuadTreeNodeId("node-" + i, quads);
+            nodes.add(n);
+            NodeIdIO.write(n, out);
+        }
+
+        ByteArrayDataInput in = ByteStreams.newDataInput(out.toByteArray());
+
+        List<NodeId> decoded = new ArrayList<>();
+        for (int i = 0; i < size; i++) {
+            NodeId n = NodeIdIO.read(in);
+            decoded.add(n);
+        }
+        assertEquals(nodes, decoded);
+    }
+}


### PR DESCRIPTION
NodeIdIO.read/write() take care of concrete
NodeId serialization so DAG.de/serialize() doesn't
need to know how to deal with NodeId concrete subclasses

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>