### PR TITLE
Add CRS bounds calculator

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/data/EPSGBoundsCalc.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/EPSGBoundsCalc.java
@@ -1,0 +1,125 @@
+/*
+ *  Copyright (c) 2017 Boundless and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ *  Contributors:
+ *  Morgan Thompson (Boundless) - initial implementation
+ *  Alex Goudine (Boundless)
+ */
+
+package org.locationtech.geogig.data;
+
+import com.vividsolutions.jts.geom.Envelope;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import java.util.Collection;
+import java.util.Set;
+
+import org.geotools.geometry.GeneralEnvelope;
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.referencing.CRS;
+import org.opengis.metadata.extent.Extent;
+import org.opengis.metadata.extent.GeographicBoundingBox;
+import org.opengis.metadata.extent.GeographicExtent;
+import org.opengis.referencing.crs.CRSAuthorityFactory;
+import org.opengis.referencing.operation.CoordinateOperation;
+import org.opengis.referencing.operation.CoordinateOperationFactory;
+
+/**
+ * Given a EPSG code, find the CRS bounds and return as an Envelope
+ */
+public class EPSGBoundsCalc {
+
+    /**
+     * Get the bounds of the desired CRS, uses JTS ReferencedEnvelope transform to properly
+     * handle polar projections
+     * @param crs the target CoordinateReferenceSystem
+     * @return bounds an Envelope containing the CRS bounds
+     */
+    public Envelope getExtents(CoordinateReferenceSystem crs) throws Exception {
+
+        final Extent domainOfValidity = crs.getDomainOfValidity();
+
+        if (null == domainOfValidity) {
+            throw new Exception("No domain of validity provided by CRS definition");
+        }
+
+        Collection<? extends GeographicExtent> geographicElements;
+        geographicElements = domainOfValidity.getGeographicElements();
+
+        if (null == geographicElements || geographicElements.size() != 1) {
+            throw new Exception("Number of geographic elements != 1");
+        }
+
+        GeographicExtent geographicExtent = geographicElements.iterator().next();
+        if (!(geographicExtent instanceof GeographicBoundingBox)) {
+            throw new Exception("geographic extent is not a geographic bounding box");
+        }
+
+        if (!geographicExtent.getInclusion()) {
+            throw new Exception("geographic extent is exclusive, can only deal with inclusive ones");
+        }
+
+        GeographicBoundingBox geographicBoundingBox = (GeographicBoundingBox) geographicExtent;
+
+        double minx = geographicBoundingBox.getWestBoundLongitude();
+        double miny = geographicBoundingBox.getSouthBoundLatitude();
+        double maxx = geographicBoundingBox.getEastBoundLongitude();
+        double maxy = geographicBoundingBox.getNorthBoundLatitude();
+
+        CoordinateReferenceSystem wgs84LongFirst;
+
+        try {
+
+            wgs84LongFirst = CRS.decode("EPSG:4326", true);
+            CoordinateOperationFactory coordOpFactory = CRS.getCoordinateOperationFactory(true);
+            CoordinateOperation op = coordOpFactory.createOperation(wgs84LongFirst,crs);
+
+            ReferencedEnvelope refEnvelope = new ReferencedEnvelope(minx, maxx, miny, maxy, wgs84LongFirst);
+            GeneralEnvelope genEnvelope = CRS.transform(op, refEnvelope);
+
+            double xmax = genEnvelope.getMaximum(0);
+            double ymax = genEnvelope.getMaximum(1);
+            double xmin = genEnvelope.getMinimum(0);
+            double ymin = genEnvelope.getMinimum(1);
+
+            Envelope envelope = new Envelope(xmin, xmax, ymin, ymax);
+            return envelope;
+        } catch (Exception e) {
+            throw new Exception("ERROR: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Search for the given CRS (EPSG code), return the bounds (domain of validity)
+     * @param refId the input CRS
+     * @return projectionBounds an Envelope describing the CRS bounds, or null if bounds are not found
+     */
+    public Envelope findCode(String refId) throws Exception {
+        Envelope projectionBounds = null;
+        CoordinateReferenceSystem crs = null;
+
+        CRSAuthorityFactory authorityFactory = CRS.getAuthorityFactory(true);
+        Set<String> authorityCodes = authorityFactory.getAuthorityCodes(CoordinateReferenceSystem.class);
+
+        if (refId.contains("WGS 84")) {
+            crs = authorityFactory.createCoordinateReferenceSystem("EPSG:4326");
+            projectionBounds = getExtents(crs);
+        } else {
+            for (String code : authorityCodes) {
+                if (code.startsWith("EPSG:") && code.contains(refId)) {
+                    try {
+                        crs = authorityFactory.createCoordinateReferenceSystem(code);
+                    } catch (Exception e) {
+                        System.err.printf("%s: Unable to create CRS: %s\n", code, e.getMessage());
+                    }
+                    projectionBounds = getExtents(crs);
+                    System.err.printf("%s, %s \n", code, projectionBounds);
+                }
+            }
+        }
+        return projectionBounds;
+    }
+}

--- a/src/core/src/test/java/org/locationtech/geogig/data/EPSGBoundsCalcTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/EPSGBoundsCalcTest.java
@@ -1,0 +1,105 @@
+/*
+ *  Copyright (c) 2017 Boundless and others.
+ *  All rights reserved. This program and the accompanying materials
+ *  are made available under the terms of the Eclipse Distribution License v1.0
+ *  which accompanies this distribution, and is available at
+ *  https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ *  Contributors:
+ *  Morgan Thompson (Boundless) - initial implementation
+ *  Alex Goudine (Boundless)
+ */
+
+package org.locationtech.geogig.data;
+
+import com.google.common.base.Optional;
+import com.vividsolutions.jts.geom.Envelope;
+import org.junit.Test;
+import org.locationtech.geogig.model.RevFeatureType;
+import org.locationtech.geogig.plumbing.ResolveFeatureType;
+import org.locationtech.geogig.porcelain.CommitOp;
+import org.locationtech.geogig.repository.NodeRef;
+import org.locationtech.geogig.test.integration.RepositoryTestCase;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.referencing.ReferenceIdentifier;
+
+import java.util.List;
+
+/**
+ * Created by mthompson on 2017-01-12.
+ */
+public class EPSGBoundsCalcTest extends RepositoryTestCase {
+
+    @Override
+    protected void setUpInternal() throws Exception {
+        injector.configDatabase().put("user.name", "mthompson");
+        injector.configDatabase().put("user.email", "mthompson@boundlessgeo.com");
+    }
+
+    @Test
+    public void metadataIdTest() throws Exception {
+        Envelope bounds = null;
+        ReferenceIdentifier code = null;
+
+        insertAndAdd(points1);
+        geogig.command(CommitOp.class).setMessage("Commit1").call();
+
+        Optional<RevFeatureType> featureType = geogig.command(ResolveFeatureType.class)
+            .setRefSpec("WORK_HEAD:" + NodeRef.appendChild(pointsName, idP1)).call();
+
+        List<PropertyDescriptor> descList = featureType.get().descriptors().asList();
+
+        for (PropertyDescriptor desc : descList) {
+            if (desc instanceof GeometryDescriptor) {
+                code = ((GeometryDescriptor) desc).getCoordinateReferenceSystem().getName();
+            }
+        }
+
+        try {
+            bounds = new EPSGBoundsCalc().findCode(code.toString());
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        Envelope wgs84 = new Envelope(-180.0, 180.0, -90.0, 90.0);
+        assertEquals(bounds, wgs84);
+    }
+
+    @Test
+    public void epsgTest() throws Exception {
+        Envelope bounds = null;
+        String[] testArray = {"EPSG:4326","EPSG:26910","EPSG:3857","EPSG:3412","EPSG:3411", "EPSG:3031"};
+        Envelope[] testEnvelopes = new Envelope[6];
+        testEnvelopes[0] = new Envelope(-180.0, 180.0, -90.0, 90.0);
+        testEnvelopes[1] = new Envelope(212172.22206537757, 788787.632995196, 3378624.2031936757, 9083749.435906317);
+        testEnvelopes[2] = new Envelope(-2.0037508342789244E7, 2.0037508342789244E7, -2.00489661040146E7, 2.0048966104014594E7);
+        testEnvelopes[3] = new Envelope(-3323231.542684214, 3323231.542684214, -3323231.542684214, 3323231.542684214);
+        testEnvelopes[4] = new Envelope(-2349879.5592850395, 2349879.5592850395, -2349879.5592850395, 2349879.5592850395);
+        testEnvelopes[5] = new Envelope(-3333134.027630277, 3333134.027630277, -3333134.027630277, 3333134.027630277);
+
+        for (int i = 0; i < testArray.length; i++) {
+            try {
+                bounds = new EPSGBoundsCalc().findCode(testArray[i]);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            assertEquals(bounds, testEnvelopes[i]);
+        }
+    }
+
+    @Test
+    public void nullBoundsTest() throws Exception{
+        Envelope bounds = null;
+        String[] testArray = {"EPSG:900913","random stuff!!!"};
+
+        for (int i = 0; i < testArray.length; i++) {
+            try {
+                bounds = new EPSGBoundsCalc().findCode(testArray[i]);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            assertNull(bounds);
+        }
+    }
+
+}


### PR DESCRIPTION
Added a CRS bounds calculator which returns the bounds of a valid CRS.
Returns 'null' if the bounds cannot be retrieved.
Includes test cases verifying functionality.

Signed-off-by: goudine <agoudine@boundlessgeo.com>