### PR TITLE
add backgrounding node store

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/BackgroundingNodeStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/BackgroundingNodeStore.java
@@ -1,0 +1,230 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ */
+package org.locationtech.geogig.model.internal;
+
+import com.google.common.base.Throwables;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.*;
+
+/**
+ * queues up nodes to be saved out to disk and uses a background thread to save them.
+ * <p>
+ * The optimal usage pattern is WRITE, then READ.
+ * However, it does support WRITE-READ-WRITE-READ
+ * If you do this, it will write all the outstanding items to the underlying
+ * Store before allowing the reads to occur.
+ * <p>
+ * Do not run this class with multi-threaded (untested).
+ * <p>
+ * If an error occurs, the user will be warned and the service will shutdown.
+ */
+public class BackgroundingNodeStore implements NodeStore {
+
+    public enum StateEnum {INIT, READING, WRITING}
+
+    StateEnum state = StateEnum.INIT;
+
+    NodeStore underlying;
+    BlockingQueue<SaveNodeItem> queue = null; //items that need saving
+    Consumer consumer; // thread that will do the saving
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+
+    Future<Throwable> consumerFuture;
+
+
+    //we put  this on the queue to indicate that the consumer should stop saving and shutdown
+    public static SaveNodeItem POISON_PILL = new SaveNodeItem(null, null);
+
+
+    public BackgroundingNodeStore(NodeStore underlying) {
+        this(underlying, 100_000);
+    }
+
+    public BackgroundingNodeStore(NodeStore underlying, int nItems) {
+        queue = new ArrayBlockingQueue<>(nItems);
+        this.underlying = underlying;
+
+        state = StateEnum.INIT;
+    }
+
+
+    //indicate we want to start writing.
+    // 1. if needed, it will start up a new consumer
+    // 2. if the consumer is dead (or in the process or dying), it will throw an exception
+    void startWriting() throws Exception {
+        if (state == StateEnum.WRITING) {
+            //consumer should be up, but its down (or going down)
+            if (consumerFuture.isDone() || consumer.consumerInProcessOfDying) {
+                queue.clear();
+                Throwables.propagate(consumerFuture.get());
+            }
+            return; //we're good
+        }
+
+        //start up a new consumer
+        consumer = new Consumer(underlying, queue);
+        consumerFuture = executorService.submit(consumer); //start saving
+        state = StateEnum.WRITING;
+    }
+
+
+    //indicate we want to start reading
+    // if we are in writing mode, we wait for all items to be saved
+    //  to the underlying, then shut the consumer down.
+    void startReading() {
+        if (state == StateEnum.READING) {
+            return; //we're good
+        }
+        if (state == StateEnum.INIT) {
+            state = StateEnum.READING;
+            return;
+        }
+        //stop writing, clean up then can start reading
+        Throwable consumerError = null;
+        try {
+            queue.put(POISON_PILL);
+            consumer = null;
+            consumerError = consumerFuture.get(); //wait
+            queue.clear();
+            state = StateEnum.READING;
+
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        }
+        if (consumerError != null)
+            Throwables.propagate(consumerError);
+    }
+
+
+    //try really hard not to leak threads
+    @Override
+    protected void finalize() throws Throwable {
+        if (!executorService.isShutdown())
+            executorService.shutdownNow(); // the thread could be blocked
+    }
+
+
+    @Override
+    public void close() {
+        try {
+            //most cases you're closing after reading, but make sure...
+            startReading();
+        } catch (Exception e) {
+            Throwables.propagate(e);
+        } finally {
+            try {
+                underlying.close();
+            } finally {
+                executorService.shutdownNow();
+            }
+        }
+    }
+
+    @Override
+    public DAGNode get(NodeId nodeId) {
+        startReading();
+        return underlying.get(nodeId);
+    }
+
+    @Override
+    public Map<NodeId, DAGNode> getAll(Set<NodeId> nodeIds) {
+        startReading();
+        return underlying.getAll(nodeIds);
+    }
+
+    @Override
+    public void put(NodeId nodeId, DAGNode node) {
+        try {
+            startWriting();
+            queue.put(new SaveNodeItem(nodeId, node));
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //backed by put()
+    @Override
+    public void putAll(Map<NodeId, DAGNode> nodeMappings) {
+        for (Map.Entry<NodeId, DAGNode> item : nodeMappings.entrySet()) {
+            put(item.getKey(), item.getValue());
+        }
+    }
+
+    //----------------------------------------------------------------------
+
+    /**
+     * hold info needed to save a node
+     */
+    public static class SaveNodeItem {
+        NodeId nodeId;
+        DAGNode node;
+
+        public SaveNodeItem(NodeId nodeId, DAGNode node) {
+            this.node = node;
+            this.nodeId = nodeId;
+        }
+    }
+
+    //----------------------------------------------------------------------
+
+
+    /**
+     * simple consumer that takes the queued items and writes them out
+     * to the underlying store.
+     * <p>
+     * note - returns an error if an error occurred
+     * <p>
+     * NOTE: consumerInProcessOfDying will be set while this task is dying
+     * do not add more items to the queue after this is set.
+     * This deals with a threading issue where the producer
+     * is creating new items after this has caught an error but
+     * before it terminates.  Not usually an issue, but test cases
+     * showed this can happen (only when the queue has a small max size).
+     * The problem is that the producer could fill up the queue in this
+     * very small amount of time and start blocking (making the process hang).
+     */
+    private class Consumer implements Callable<Throwable> {
+
+        NodeStore underlying;
+        BlockingQueue<SaveNodeItem> queue;
+
+        public volatile boolean consumerInProcessOfDying = false;
+
+
+        public Consumer(NodeStore underlying, BlockingQueue<SaveNodeItem> queue) {
+            this.underlying = underlying;
+            this.queue = queue;
+        }
+
+        @Override
+        public Throwable call() {
+            boolean keep_going = !Thread.interrupted();
+            try {
+                while (keep_going) {
+                    SaveNodeItem item = queue.take();
+                    if (item != POISON_PILL) {
+                        underlying.put(item.nodeId, item.node);
+                    }
+                    keep_going = !Thread.interrupted() && item != POISON_PILL;
+                }
+            } catch (InterruptedException e) {
+                //not much we can do - someone told us to stop
+                consumerInProcessOfDying = true;
+                queue.clear(); // make sure no one's blocking on us!
+                return e;
+            } catch (Throwable e) {
+                //might be something like a disk full error
+                consumerInProcessOfDying = true;
+                queue.clear(); // make sure no one's blocking on us!
+                return e;
+            }
+            return null; //normal exit
+        }
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/NodeStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/NodeStore.java
@@ -1,0 +1,28 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ */
+
+package org.locationtech.geogig.model.internal;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Interface for NodeStore implementations.
+ */
+public interface NodeStore {
+
+    void close();
+
+    DAGNode get(NodeId nodeId);
+
+    Map<NodeId, DAGNode> getAll(Set<NodeId> nodeIds);
+
+    void put(NodeId nodeId, DAGNode node);
+
+    void putAll(Map<NodeId, DAGNode> nodeMappings);
+}

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbDAGStorageProvider.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbDAGStorageProvider.java
@@ -32,7 +32,7 @@ class RocksdbDAGStorageProvider implements DAGStorageProvider {
 
     private final RocksdbHandle dagDb;
 
-    private final RocksdbNodeStore nodeStore;
+    private final NodeStore nodeStore;
 
     private final RocksdbDAGStore dagStore;
 
@@ -49,7 +49,8 @@ class RocksdbDAGStorageProvider implements DAGStorageProvider {
             dagDb = RocksdbHandle.create(dagDbDir);
 
             this.dagStore = new RocksdbDAGStore(dagDb.db);
-            this.nodeStore = new RocksdbNodeStore(dagDb.db);
+             this.nodeStore = new BackgroundingNodeStore(new RocksdbNodeStore(dagDb.db));
+           // this.nodeStore =  new RocksdbNodeStore(dagDb.db);
         } catch (Exception e) {
             RocksdbHandle.delete(dagDbDir.toFile());
             throw Throwables.propagate(e);

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbNodeStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbNodeStore.java
@@ -33,7 +33,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.io.ByteStreams;
 
-class RocksdbNodeStore {
+class RocksdbNodeStore implements NodeStore {
 
     private RocksDB db;
 

--- a/src/core/src/test/java/org/locationtech/geogig/model/internal/BackgroundingNodeStoreTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/internal/BackgroundingNodeStoreTest.java
@@ -1,0 +1,136 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ */
+package org.locationtech.geogig.model.internal;
+
+
+import com.vividsolutions.jts.geom.Envelope;
+import org.junit.Test;
+import org.locationtech.geogig.model.Node;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+public class BackgroundingNodeStoreTest {
+
+    @Test
+    public void trivialPutGetTest() {
+        HashNodeStore hns = new HashNodeStore();
+        BackgroundingNodeStore bns = new BackgroundingNodeStore(hns);
+
+        BackgroundingNodeStore.SaveNodeItem item = createItem();
+        bns.put(item.nodeId, item.node);
+
+        DAGNode node = bns.get(item.nodeId);
+
+        assertEquals(node, item.node);
+    }
+
+    @Test
+    public void testReadWriteReadWrite() {
+
+        HashNodeStore hns = new HashNodeStore();
+        BackgroundingNodeStore bns = new BackgroundingNodeStore(hns);
+
+        BackgroundingNodeStore.SaveNodeItem item = createItem();
+        bns.put(item.nodeId, item.node);
+
+        DAGNode node = bns.get(item.nodeId);
+        assertEquals(node, item.node);
+
+        item = createItem();
+        bns.put(item.nodeId, item.node);
+
+        node = bns.get(item.nodeId);
+        assertEquals(node, item.node);
+    }
+
+    @Test
+    public void testCloseWorks() {
+        HashNodeStore hns = new HashNodeStore();
+        BackgroundingNodeStore bns = new BackgroundingNodeStore(hns);
+
+        BackgroundingNodeStore.SaveNodeItem item = createItem();
+        bns.put(item.nodeId, item.node);
+        bns.close();
+
+        assertTrue(hns.closed);
+        assertTrue(bns.state != BackgroundingNodeStore.StateEnum.WRITING);
+    }
+
+    @Test(expected = RuntimeException.class)
+    public void testConsumerException() throws InterruptedException {
+        Exception except = new RuntimeException("test case error");
+        BackgroundingNodeStore.SaveNodeItem item = createItem();
+
+        NodeStore ns = mock(NodeStore.class);
+        doThrow(except).when(ns).put(eq(item.nodeId), eq(item.node));
+
+        BackgroundingNodeStore bns = new BackgroundingNodeStore(ns);
+
+        bns.put(item.nodeId, item.node);
+
+        bns.startReading();//do this so we don't have to do an actual read (waits for writes to finish)
+
+    }
+
+    //run this test to check for very sneeky low-probability issues
+    // @Test
+    public void t1() {
+        for (int t = 0; t < 100000; t++) {
+            try {
+                System.out.println(t);
+                testConsumerExceptionDoesNotCauseDeadLock();
+                assertTrue(false); //shouldnt get here
+            } catch (Exception e) {
+                assertEquals(e.getMessage(), "test case error");
+            }
+        }
+    }
+
+    @Test(timeout = 1000, expected = RuntimeException.class)
+    public void testConsumerExceptionDoesNotCauseDeadLock() {
+
+        Exception except = new RuntimeException("test case error");
+        BackgroundingNodeStore.SaveNodeItem item = createItem();
+
+        NodeStore ns = mock(NodeStore.class);
+        doThrow(except).when(ns).put(eq(item.nodeId), eq(item.node));
+
+        BackgroundingNodeStore bns = new BackgroundingNodeStore(ns, 3);
+        try {
+
+            //this will fill up the queue - it might cause a deadlock
+            //as the BlockingQueue will block waiting for the
+            // (non-existing) consumer to empty the queue...
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+            bns.put(item.nodeId, item.node);
+        } finally {
+            bns.close();
+        }
+
+        //the above should report the issue
+    }
+
+
+    int nodeNum = 0;
+
+    public BackgroundingNodeStore.SaveNodeItem createItem() {
+        Envelope bounds = new Envelope(-1, -1, 0, 0);
+        Node n = QuadTreeClusteringStrategy_computeIdTest.createNode("node: " + nodeNum++, bounds);
+        NodeId id = new NodeId(n.getName(), bounds);
+        return new BackgroundingNodeStore.SaveNodeItem(id, new DAGNode.DirectDAGNode(n));
+    }
+}

--- a/src/core/src/test/java/org/locationtech/geogig/model/internal/HashNodeStore.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/internal/HashNodeStore.java
@@ -1,0 +1,53 @@
+/* Copyright (c) 2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ */
+package org.locationtech.geogig.model.internal;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * For test cases
+ */
+public class HashNodeStore implements NodeStore {
+
+    Map<NodeId, DAGNode> saved = new HashMap<>();
+    boolean closed = false;
+
+    @Override
+    public void close() {
+        closed = true;
+        saved.clear();
+    }
+
+    @Override
+    public DAGNode get(NodeId nodeId) {
+        return saved.get(nodeId);
+    }
+
+    @Override
+    public Map<NodeId, DAGNode> getAll(Set<NodeId> nodeIds) {
+        Map<NodeId, DAGNode> result = new HashMap<>();
+        for (NodeId id : nodeIds) {
+            result.put(id, get(id));
+        }
+        return result;
+    }
+
+    @Override
+    public void put(NodeId nodeId, DAGNode node) {
+        saved.put(nodeId, node);
+    }
+
+    @Override
+    public void putAll(Map<NodeId, DAGNode> nodeMappings) {
+        for (Map.Entry<NodeId, DAGNode> item : nodeMappings.entrySet()) {
+            put(item.getKey(), item.getValue());
+        }
+
+    }
+}


### PR DESCRIPTION
This PR adds the BackgroundingNodeStore, and does a minor refactoring by adding the NodeStore interface (to enable easy composition).

The backgroundingNodeStore is a threading producer-consumer.  While writing, a consumer is running in a background thread writing saved nodes to the underlying store (usually to RocksDB).

This is a performance-based addition for index creation.  Simple testing showed it saves 15-30% time for the first part of the tree build (building the DAG before turning it into a RevTree).