### PR TITLE
Several Indexing/performance related improvements

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/model/RevFeature.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevFeature.java
@@ -15,6 +15,7 @@ import java.util.function.Consumer;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 /**
  * A {@code RevFeature} is an immutable data structure that contains the attribute value instances
@@ -67,6 +68,8 @@ public interface RevFeature extends RevObject {
      *         is thrown)
      */
     public Optional<Object> get(final int index);
+
+    public Optional<Geometry> get(final int index, final GeometryFactory gf);
 
     /**
      * Performs the given action for each attribute in the feature, in it's natural order, until all

--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -15,6 +15,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.ObjectId;
 
 import com.google.common.base.Charsets;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.hash.Hasher;
 
 public class IndexInfo {
@@ -38,7 +39,7 @@ public class IndexInfo {
         this.treeName = treeName;
         this.attributeName = attributeName;
         this.indexType = indexType;
-        this.metadata = metadata;
+        this.metadata = metadata == null ? ImmutableMap.of() : ImmutableMap.copyOf(metadata);
     }
 
     public ObjectId getId() {

--- a/src/api/src/test/java/org/locationtech/geogig/model/HashObjectFunnelsTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/HashObjectFunnelsTest.java
@@ -43,6 +43,8 @@ import com.google.common.hash.Funnel;
 import com.google.common.hash.Hasher;
 import com.google.common.hash.Hashing;
 import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 import com.vividsolutions.jts.io.ParseException;
 import com.vividsolutions.jts.io.WKTReader;
 
@@ -240,7 +242,7 @@ public class HashObjectFunnelsTest {
         assertEquals(treeHash2, id1);
 
     }
-    
+
     @Test
     public void testFeatureFunnel() throws ParseException {
         List<Optional<Object>> values = new LinkedList<Optional<Object>>();
@@ -276,6 +278,11 @@ public class HashObjectFunnelsTest {
                 for (int i = 0; i < values.size(); i++) {
                     consumer.accept(values.get(i).orNull());
                 }
+            }
+
+            @Override
+            public Optional<Geometry> get(int index, GeometryFactory gf) {
+                throw new UnsupportedOperationException();
             }
         };
 
@@ -372,7 +379,7 @@ public class HashObjectFunnelsTest {
         FieldType.valueOf(0x25);
 
     }
-    
+
     @Test
     public void testTagFunnel() {
         RevTag testTag = new RevTag() {

--- a/src/api/src/test/java/org/locationtech/geogig/repository/FeatureInfoTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/repository/FeatureInfoTest.java
@@ -20,6 +20,8 @@ import org.locationtech.geogig.model.RevObject;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 public class FeatureInfoTest {
 
@@ -55,6 +57,11 @@ public class FeatureInfoTest {
 
             @Override
             public void forEach(Consumer<Object> consumer) {
+            }
+
+            @Override
+            public Optional<Geometry> get(int index, GeometryFactory gf) {
+                throw new UnsupportedOperationException();
             }
         };
         FeatureInfo info = FeatureInfo.insert(testFeature, oid1, "Points/1");

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/CreateIndex.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/plumbing/CreateIndex.java
@@ -9,6 +9,7 @@ import org.locationtech.geogig.cli.GeogigCLI;
 import org.locationtech.geogig.cli.InvalidParameterException;
 import org.locationtech.geogig.cli.annotation.RequiresRepository;
 import org.locationtech.geogig.plumbing.index.CreateIndexInfoOp;
+import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.impl.GeoGIG;
 
 import com.beust.jcommander.Parameter;
@@ -34,11 +35,11 @@ public class CreateIndex extends AbstractCommand implements CLICommand {
 
         GeoGIG geogig = cli.getGeogig();
 
-        geogig.command(CreateIndexInfoOp.class).setTreeName(tree)
+        IndexInfo indexInfo = geogig.command(CreateIndexInfoOp.class).setTreeName(tree)
                 .setAttributeName(attribute).setIndexHistory(indexHistory)
                 .setProgressListener(cli.getProgressListener()).call();
 
+        
         cli.getConsole().println("Index created successfully.");
-
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/data/FeatureBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/FeatureBuilder.java
@@ -21,6 +21,7 @@ import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.filter.identity.FeatureId;
 
 import com.google.common.base.Preconditions;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 /**
  * Provides a method of building features from {@link RevFeature} objects that have the type
@@ -77,6 +78,20 @@ public class FeatureBuilder {
 
         GeogigSimpleFeature feature = new GeogigSimpleFeature(revFeature, featureType, fid,
                 attNameToRevTypeIndex);
+        return feature;
+    }
+
+    public Feature build(final String id, final RevFeature revFeature,
+            final GeometryFactory geometryFactory) {
+        Preconditions.checkNotNull(id);
+        Preconditions.checkNotNull(revFeature);
+
+        final FeatureId fid = new LazyVersionedFeatureId(id, revFeature.getId());
+
+        SimpleFeatureType featureType = (SimpleFeatureType) type.type();
+
+        GeogigSimpleFeature feature = new GeogigSimpleFeature(revFeature, featureType, fid,
+                attNameToRevTypeIndex, geometryFactory);
         return feature;
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureImpl.java
@@ -20,6 +20,8 @@ import org.locationtech.geogig.model.RevFeature;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.GeometryFactory;
 
 /**
  * A binary representation of the values of a Feature.
@@ -54,6 +56,16 @@ class RevFeatureImpl extends AbstractRevObject implements RevFeature {
     @Override
     public Optional<Object> get(final int index) {
         return Optional.fromNullable(safeCopy(values.get(index)));
+    }
+
+    @Override
+    public Optional<Geometry> get(int index, GeometryFactory gf) {
+        Geometry g = (Geometry) values.get(index);
+        Geometry g2 = null;
+        if (g != null) {
+            g2 = gf.createGeometry(g);
+        }
+        return Optional.fromNullable(g2);
     }
 
     @Override

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/index/BuildIndexOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/index/BuildIndexOp.java
@@ -1,16 +1,27 @@
 package org.locationtech.geogig.plumbing.index;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkState;
+
 import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevFeatureType;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.plumbing.ResolveFeatureType;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.ProgressListener;
+import org.locationtech.geogig.repository.impl.SpatialOps;
 import org.locationtech.geogig.storage.IndexDatabase;
+import org.opengis.feature.type.FeatureType;
+import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.feature.type.PropertyDescriptor;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.google.common.base.Optional;
+import com.vividsolutions.jts.geom.Envelope;
 
 /**
- * Builds an indexed tree based on a canonical tree for a given {@link Index}
+ * Builds an indexed tree based on a canonical tree for a given {@link IndexInfo}
  */
 public class BuildIndexOp extends AbstractGeoGigOp<ObjectId> {
 
@@ -53,13 +64,42 @@ public class BuildIndexOp extends AbstractGeoGigOp<ObjectId> {
     }
 
     private RevTree buildQuadTree() {
+        final Envelope maxBounds = resolveMaxBounds();
+        System.err.println("Max bounds: " + maxBounds);
         CreateQuadTree command = command(CreateQuadTree.class);
         command.setFeatureTree(canonicalTreeId);
-
+        command.setMaxBounds(maxBounds);
         ProgressListener listener = getProgressListener();
         RevTree quadTree = command.setProgressListener(listener).call();
 
         return quadTree;
     }
-}
 
+    private Envelope resolveMaxBounds() {
+        final String typeName = index.getTreeName();
+        final String geomPropertyName = index.getAttributeName();
+        Optional<RevFeatureType> revType = command(ResolveFeatureType.class).setRefSpec(typeName)
+                .call();
+        checkArgument(revType.isPresent(), "FeatureType %s not found", typeName);
+        FeatureType featureType = revType.get().type();
+        PropertyDescriptor descriptor = featureType.getDescriptor(geomPropertyName);
+        checkArgument(descriptor != null, "FeatureType %s has no geometry property %s", typeName,
+                geomPropertyName);
+        checkArgument(descriptor instanceof GeometryDescriptor,
+                "Property %s is not a geometry attribute", geomPropertyName);
+
+        CoordinateReferenceSystem crs = ((GeometryDescriptor) descriptor)
+                .getCoordinateReferenceSystem();
+
+        Envelope maxBounds;
+        try {
+            maxBounds = SpatialOps.boundsOf(crs);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                    "Error computing max bounds for the CRS of " + geomPropertyName, e);
+        }
+        checkState(maxBounds != null && !maxBounds.isNull(),
+                "Unable to compute the area of validity for the CRS of %s", geomPropertyName);
+        return maxBounds;
+    }
+}

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/index/CreateIndexInfoOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/index/CreateIndexInfoOp.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Creates an {@link Index}.
+ * Creates an {@link IndexInfo}.
  */
 public class CreateIndexInfoOp extends AbstractGeoGigOp<IndexInfo> {
 
@@ -119,8 +119,8 @@ public class CreateIndexInfoOp extends AbstractGeoGigOp<IndexInfo> {
         if (!treeId.isPresent()) {
             return;
         }
-        command(BuildIndexOp.class).setIndex(index).setCanonicalTreeId(treeId.get())
-                .setProgressListener(getProgressListener()).call();
+        ObjectId indexTreeId = command(BuildIndexOp.class).setIndex(index)
+                .setCanonicalTreeId(treeId.get()).setProgressListener(getProgressListener()).call();
+        System.err.printf("--Created index tree %s\n", indexTreeId);
     }
 }
-

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/index/CreateQuadTree.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/index/CreateQuadTree.java
@@ -49,13 +49,9 @@ import com.vividsolutions.jts.geom.Geometry;
  */
 public class CreateQuadTree extends AbstractGeoGigOp<RevTree> {
 
-    private Envelope maxBounds = wgs84Bounds();
-
     private ObjectId treeId;
 
-    private static final Envelope wgs84Bounds() {
-        return new Envelope(-180, 180, -90, 90);
-    }
+    private @Nullable Envelope maxBounds;
 
     /**
      * @param maxBounds Optional; the quad-tree max bounds, default to WGS84 bounds if not set
@@ -76,13 +72,15 @@ public class CreateQuadTree extends AbstractGeoGigOp<RevTree> {
     @Override
     protected RevTree _call() {
         Preconditions.checkArgument(treeId != null, "FeatureTree not provided");
+        Preconditions.checkArgument(maxBounds != null, "maxBounds not provided");
 
         final ObjectDatabase odb = objectDatabase();
 
         final RevTree tree = odb.getTree(treeId);
 
         boolean preserveIterationOrder = true;
-        PreOrderDiffWalk walk = new PreOrderDiffWalk(RevTree.EMPTY, tree, odb, odb, preserveIterationOrder);
+        PreOrderDiffWalk walk = new PreOrderDiffWalk(RevTree.EMPTY, tree, odb, odb,
+                preserveIterationOrder);
 
         final ProgressListener progress = getProgressListener();
 

--- a/src/core/src/main/java/org/locationtech/geogig/repository/impl/SpatialOps.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/impl/SpatialOps.java
@@ -9,9 +9,11 @@
  */
 package org.locationtech.geogig.repository.impl;
 
+import java.util.Collection;
 import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.geotools.geometry.GeneralEnvelope;
 import org.geotools.geometry.jts.JTS;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
@@ -19,8 +21,13 @@ import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevTree;
 import org.opengis.geometry.BoundingBox;
+import org.opengis.metadata.extent.Extent;
+import org.opengis.metadata.extent.GeographicBoundingBox;
+import org.opengis.metadata.extent.GeographicExtent;
 import org.opengis.referencing.FactoryException;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
+import org.opengis.referencing.operation.CoordinateOperation;
+import org.opengis.referencing.operation.CoordinateOperationFactory;
 
 import com.google.common.base.Splitter;
 import com.vividsolutions.jts.geom.Coordinate;
@@ -93,6 +100,52 @@ public class SpatialOps {
             }
         });
         return env.isNull() ? null : env;
+    }
+
+    /**
+     * Get the bounds of the desired CRS, uses JTS ReferencedEnvelope transform to properly handle
+     * polar projections
+     * 
+     * @param crs the target CoordinateReferenceSystem
+     * @return bounds an Envelope containing the CRS bounds, throws a NoSuchAuthorityCodeException
+     *         if the crs cannot be found
+     */
+    public @Nullable static Envelope boundsOf(CoordinateReferenceSystem crs) throws Exception {
+
+        final Extent domainOfValidity = crs.getDomainOfValidity();
+
+        if (null == domainOfValidity) {
+            return null;
+        }
+
+        Collection<? extends GeographicExtent> geographicElements;
+        geographicElements = domainOfValidity.getGeographicElements();
+
+        GeographicExtent geographicExtent = geographicElements.iterator().next();
+        GeographicBoundingBox geographicBoundingBox = (GeographicBoundingBox) geographicExtent;
+
+        double minx = geographicBoundingBox.getWestBoundLongitude();
+        double miny = geographicBoundingBox.getSouthBoundLatitude();
+        double maxx = geographicBoundingBox.getEastBoundLongitude();
+        double maxy = geographicBoundingBox.getNorthBoundLatitude();
+
+        CoordinateReferenceSystem wgs84LongFirst;
+
+        wgs84LongFirst = CRS.decode("EPSG:4326", true);
+        CoordinateOperationFactory coordOpFactory = CRS.getCoordinateOperationFactory(true);
+        CoordinateOperation op = coordOpFactory.createOperation(wgs84LongFirst, crs);
+
+        ReferencedEnvelope refEnvelope = new ReferencedEnvelope(minx, maxx, miny, maxy,
+                wgs84LongFirst);
+        GeneralEnvelope genEnvelope = CRS.transform(op, refEnvelope);
+
+        double xmax = genEnvelope.getMaximum(0);
+        double ymax = genEnvelope.getMaximum(1);
+        double xmin = genEnvelope.getMinimum(0);
+        double ymin = genEnvelope.getMinimum(1);
+
+        Envelope envelope = new Envelope(xmin, xmax, ymin, ymax);
+        return envelope;
     }
 
     /**

--- a/src/core/src/main/java/org/locationtech/geogig/storage/impl/IndexSerializer.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/impl/IndexSerializer.java
@@ -11,7 +11,6 @@ package org.locationtech.geogig.storage.impl;
 
 import java.io.DataInput;
 import java.io.DataOutput;
-import java.io.EOFException;
 import java.io.IOException;
 import java.util.Map;
 
@@ -20,26 +19,35 @@ import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.IndexInfo.IndexType;
 import org.locationtech.geogig.storage.datastream.DataStreamValueSerializerV2;
 
+import com.google.common.base.Throwables;
+
 public class IndexSerializer {
-    public static void serialize(IndexInfo index, DataOutput out) throws IOException {
-        DataStreamValueSerializerV2.write(index.getTreeName(), out);
-        DataStreamValueSerializerV2.write(index.getAttributeName(), out);
-        DataStreamValueSerializerV2.write(index.getIndexType().toString(), out);
-        DataStreamValueSerializerV2.write(index.getMetadata(), out);
+
+    public static void serialize(IndexInfo index, DataOutput out) {
+        try {
+            DataStreamValueSerializerV2.write(index.getTreeName(), out);
+            DataStreamValueSerializerV2.write(index.getAttributeName(), out);
+            DataStreamValueSerializerV2.write(index.getIndexType().toString(), out);
+            DataStreamValueSerializerV2.write(index.getMetadata(), out);
+        } catch (IOException e) {
+            Throwables.propagate(e);
+        }
     }
 
     @SuppressWarnings("unchecked")
-    public static IndexInfo deserialize(DataInput in) throws IOException {
-        String treeName = (String) DataStreamValueSerializerV2.read(FieldType.STRING, in);
-        String attributeName = (String) DataStreamValueSerializerV2.read(FieldType.STRING, in);
-        IndexType indexType = IndexType
-                .valueOf((String) DataStreamValueSerializerV2.read(FieldType.STRING, in));
+    public static IndexInfo deserialize(DataInput in) {
+        String treeName;
+        String attributeName;
+        IndexType indexType;
         Map<String, Object> metadata;
         try {
-            metadata = (Map<String, Object>) DataStreamValueSerializerV2
-                .read(FieldType.MAP, in);
-        } catch (EOFException e) {
-            metadata = null;
+            treeName = (String) DataStreamValueSerializerV2.read(FieldType.STRING, in);
+            attributeName = (String) DataStreamValueSerializerV2.read(FieldType.STRING, in);
+            indexType = IndexType
+                    .valueOf((String) DataStreamValueSerializerV2.read(FieldType.STRING, in));
+            metadata = (Map<String, Object>) DataStreamValueSerializerV2.read(FieldType.MAP, in);
+        } catch (IOException ioe) {
+            throw Throwables.propagate(ioe);
         }
         return new IndexInfo(treeName, attributeName, indexType, metadata);
     }

--- a/src/core/src/test/java/org/locationtech/geogig/storage/impl/IndexDatabaseConformanceTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/impl/IndexDatabaseConformanceTest.java
@@ -54,7 +54,8 @@ public abstract class IndexDatabaseConformanceTest extends ObjectStoreConformanc
         metadata.put("meta2", "someValue");
         String treeName = "tree";
         String attributeName = "attribute";
-        IndexInfo index = indexDb.createIndex(treeName, attributeName, IndexType.QUADTREE, metadata);
+        IndexInfo index = indexDb.createIndex(treeName, attributeName, IndexType.QUADTREE,
+                metadata);
 
         assertEquals(treeName, index.getTreeName());
         assertEquals(attributeName, index.getAttributeName());
@@ -113,7 +114,7 @@ public abstract class IndexDatabaseConformanceTest extends ObjectStoreConformanc
             assertEquals(treeName, index.getTreeName());
             assertEquals(attributeName2, index.getAttributeName());
             assertEquals(IndexType.QUADTREE, index.getIndexType());
-            assertNull(index.getMetadata());
+            assertTrue(index.getMetadata().isEmpty());
             assertEquals(IndexInfo.getIndexId(treeName, attributeName2), index.getId());
         } else {
             IndexInfo index = indexes.get(0);
@@ -169,7 +170,7 @@ public abstract class IndexDatabaseConformanceTest extends ObjectStoreConformanc
         assertEquals(treeName, index.getTreeName());
         assertEquals(attributeName, index.getAttributeName());
         assertEquals(IndexType.QUADTREE, index.getIndexType());
-        assertNull(index.getMetadata());
+        assertTrue(index.getMetadata().isEmpty());
         assertEquals(IndexInfo.getIndexId(treeName, attributeName), index.getId());
 
         Optional<IndexInfo> indexOpt = indexDb.getIndex(treeName, attributeName);
@@ -178,7 +179,7 @@ public abstract class IndexDatabaseConformanceTest extends ObjectStoreConformanc
         assertEquals(treeName, index.getTreeName());
         assertEquals(attributeName, index.getAttributeName());
         assertEquals(IndexType.QUADTREE, index.getIndexType());
-        assertNull(index.getMetadata());
+        assertTrue(index.getMetadata().isEmpty());
         assertEquals(IndexInfo.getIndexId(treeName, attributeName), index.getId());
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureReader.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureReader.java
@@ -150,7 +150,7 @@ class GeogigFeatureReader<T extends FeatureType, F extends Feature>
 
             Preconditions.checkArgument(oldTreeRef.isPresent() || newTreeRef.isPresent());
             typeTreeRef = newTreeRef.isPresent() ? newTreeRef.get() : oldTreeRef.get();
-            
+
             Optional<IndexInfo> index = context.indexDatabase().getIndex(typeTreePath,
                     schema.getGeometryDescriptor().getName().toString());
 
@@ -255,7 +255,8 @@ class GeogigFeatureReader<T extends FeatureType, F extends Feature>
         return treeRef.isPresent() ? treeRef.get().getObjectId() : EMPTY_TREE_ID;
     }
 
-    private Optional<ObjectId> resolveQuadTree(Optional<NodeRef> treeRef, Optional<IndexInfo> index) {
+    private Optional<ObjectId> resolveQuadTree(Optional<NodeRef> treeRef,
+            Optional<IndexInfo> index) {
         Optional<ObjectId> quadTreeId = Optional.of(EMPTY_TREE_ID);
         if (treeRef.isPresent()) {
             if (index.isPresent()) {
@@ -346,8 +347,8 @@ class GeogigFeatureReader<T extends FeatureType, F extends Feature>
             timer.stop();
             sourceIterator.close();
             sourceIterator = null;
-            // System.err.printf("######## Stats: %s, Time: %s ########\n\n",
-            // diffOp.getStats().orNull(), timer);
+            System.err.printf("######## Stats: %s, Time: %s ########\n\n",
+                    diffOp.getStats().orNull(), timer);
             LOGGER.debug(String.format("######## Stats: %s, Time: %s ########\n\n",
                     diffOp.getStats().orNull(), timer));
 

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/GeoGigFeatureSourceTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/GeoGigFeatureSourceTest.java
@@ -54,6 +54,7 @@ import org.opengis.referencing.crs.CoordinateReferenceSystem;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.vividsolutions.jts.geom.Envelope;
 import com.vividsolutions.jts.geom.Polygon;
 
 public class GeoGigFeatureSourceTest extends RepositoryTestCase {
@@ -443,6 +444,7 @@ public class GeoGigFeatureSourceTest extends RepositoryTestCase {
 
         CreateQuadTree command = geogig.command(CreateQuadTree.class);
         command.setFeatureTree(treeId);
+        command.setMaxBounds(new Envelope(-180, 180, -90, 90));
 
         RevTree quadTree = command.call();
         indexDatabase.addIndexedTree(index, treeId, quadTree.getId());

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBConfig.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBConfig.java
@@ -9,7 +9,9 @@
  */
 package org.locationtech.geogig.rocksdb;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 import org.rocksdb.ColumnFamilyHandle;
 
@@ -23,14 +25,25 @@ class DBConfig {
 
     private ImmutableMap<String, String> defaultMetadata;
 
+    private Set<String> columnFamilyNames;
+
     public DBConfig(String dbpath, boolean readOnly) {
-        this(dbpath, readOnly, ImmutableMap.of());
+        this(dbpath, readOnly, ImmutableMap.of(), Collections.emptySet());
     }
 
-    public DBConfig(String dbpath, boolean readOnly, Map<String, String> defaultMetadata) {
+    public DBConfig(String dbpath, boolean readOnly, Map<String, String> defaultMetadata,
+            Set<String> columnFamilyNames) {
         this.dbpath = dbpath;
         this.readOnly = readOnly;
+        this.columnFamilyNames = columnFamilyNames;
         this.defaultMetadata = ImmutableMap.copyOf(defaultMetadata);
+    }
+    
+    /**
+     * @return the names of extra columns to create when the database is created
+     */
+    public Set<String> getColumnFamilyNames(){
+        return columnFamilyNames;
     }
 
     /**

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBHandle.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/DBHandle.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.rocksdb;
 
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.eclipse.jdt.annotation.Nullable;
@@ -39,6 +40,8 @@ class DBHandle {
      */
     private AtomicInteger references = new AtomicInteger();
 
+    private Map<String, ColumnFamilyHandle> extraColumns;
+
     /**
      * A reference to the RocksDB instance. This needs to be closed after it's used to free up the
      * reference.
@@ -64,11 +67,12 @@ class DBHandle {
     }
 
     public DBHandle(final DBConfig config, final org.rocksdb.DBOptions options, final RocksDB db,
-            @Nullable ColumnFamilyHandle metadata) {
+            @Nullable ColumnFamilyHandle metadata, Map<String, ColumnFamilyHandle> extraColumns) {
         this.config = config;
         this.options = options;
         this.db = db;
         this.metadata = metadata;
+        this.extraColumns = extraColumns;
     }
 
     public synchronized void close() {
@@ -84,6 +88,7 @@ class DBHandle {
             }
         }
         close(metadata);
+        extraColumns.values().forEach((c) -> close(c));
         close(options);
         close(db);
     }
@@ -141,4 +146,9 @@ class DBHandle {
         }
         return Optional.fromNullable(value);
     }
+
+    public @Nullable ColumnFamilyHandle getColumnFamily(final String columnFamilyName) {
+        return extraColumns.get(columnFamilyName);
+    }
+
 }


### PR DESCRIPTION
- Allow to specify the JTS GeometryFactory used to build geometries obtained from RevFeature.
- Use a separate column instead of a key prefix for IndexInfo in RocksdbIndexDatabase
- Make CreateQuadTree/BuildIndexOp compute the quadtree max bounds.
- Make ImportOp try to find a matching EPSG code for the CRS being imported.