### PR TITLE
Support pre-filtering using Index materialized attributes.

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -19,6 +19,7 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevTree;
 
 import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -129,5 +130,11 @@ public class IndexInfo {
             return ImmutableMap.of();
         }
         return (Map<String, Object>) v;
+    }
+
+    public static @Nullable Object getMaterializedAttribute(String attName, Node n) {
+        Map<String, Object> atts = getMaterializedAttributes(n);
+        Object o = atts.get(attName);
+        return o;
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/index/IndexUtils.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/index/IndexUtils.java
@@ -66,7 +66,6 @@ public class IndexUtils {
             checkArgument(null != descriptor, "FeatureType %s does not define attribute '%s'",
                     typeName, attname);
         }
-        System.err.println("Extra attributes: " + Arrays.toString(atts));
         return atts;
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactory.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactory.java
@@ -1,0 +1,107 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.geotools.data.Query;
+import org.geotools.factory.Hints;
+import org.geotools.filter.expression.PropertyAccessor;
+import org.geotools.filter.expression.PropertyAccessorFactory;
+import org.geotools.geometry.jts.JTS;
+import org.geotools.util.Converters;
+import org.locationtech.geogig.model.Bounded;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.RevFeature;
+import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.repository.NodeRef;
+import org.locationtech.geogig.storage.ObjectDatabase;
+import org.opengis.filter.expression.PropertyName;
+
+import com.google.common.base.Optional;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+/**
+ * A GeoTools {@link PropertyAccessorFactory} that knows how to extract feature property values out
+ * of GeoGig materialized attributes in {@link Node}s coming from an index.
+ * <p>
+ * The GeoTools {@link PropertyName} expression implementation makes use of
+ * {@link PropertyAccessor}s to evaluate an attribute value out of an object.
+ * <p>
+ * When using a fully materialized index (that's it, an index that contains all the extra attributes
+ * necessary to satisfy a {@link Query}), a {@link MaterializedIndexFeatureIterator} is used to
+ * avoid fetching {@link RevFeature}s from the {@link ObjectDatabase}, and this property accessor
+ * implementation takes care of extracting attribute values from {@link Node#getExtraData() node
+ * extra data}.
+ *
+ */
+public class ExtraDataPropertyAccessorFactory implements PropertyAccessorFactory {
+
+    static final ExtraDataPropertyAccesor EXTRA_DATA = new ExtraDataPropertyAccesor();
+
+    private static final GeometryFactory BOUNDS_GEOM_FAC = new GeometryFactory();
+
+    @Override
+    public PropertyAccessor createPropertyAccessor(Class<?> type, String xpath, Class<?> target,
+            Hints hints) {
+        return EXTRA_DATA;
+    }
+
+    static class ExtraDataPropertyAccesor implements PropertyAccessor {
+
+        @Override
+        public boolean canHandle(Object object, String xpath, Class<?> target) {
+            return object instanceof Bounded;
+        }
+
+        @Override
+        public <T> T get(Object object, String xpath, @Nullable Class<T> target)
+                throws IllegalArgumentException {
+
+            Bounded b = (Bounded) object;
+            Object value = null;
+
+            if ("@bounds".equals(xpath)) {
+                Optional<Envelope> envelope = b.bounds();
+                if (envelope.isPresent()) {
+                    value = JTS.toGeometry(envelope.get(), BOUNDS_GEOM_FAC);
+                }
+            } else {
+                final Node node;
+                if (b instanceof NodeRef) {
+                    node = ((NodeRef) b).getNode();
+                } else if (b instanceof Node) {
+                    node = (Node) b;
+                } else {
+                    node = null;
+                }
+                if (node != null) {
+                    if ("@id".equals(xpath)) {
+                        value = node.getName();
+                    } else {
+                        value = IndexInfo.getMaterializedAttribute(xpath, node);
+                    }
+                }
+                if (value != null && target != null && !target.isInstance(value)) {
+                    value = Converters.convert(value, target);
+                }
+            }
+            return (T) value;
+        }
+
+        @Override
+        public <T> void set(Object object, String xpath, T value, Class<T> target)
+                throws IllegalArgumentException {
+
+            throw new UnsupportedOperationException();
+        }
+
+    }
+}

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PostFilter.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PostFilter.java
@@ -18,10 +18,10 @@ import com.google.common.base.Predicate;
  * Adapts a GeoTools {@link Filter} to a {@link Predicate} to be applied
  *
  */
-final class FilterPredicate implements Predicate<SimpleFeature> {
+final class PostFilter implements Predicate<SimpleFeature> {
     private Filter filter;
 
-    public FilterPredicate(final Filter filter) {
+    public PostFilter(final Filter filter) {
         this.filter = filter;
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilter.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilter.java
@@ -1,0 +1,65 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.geotools.filter.expression.PropertyAccessorFactory;
+import org.locationtech.geogig.model.Bounded;
+import org.locationtech.geogig.model.Bucket;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.RevObject.TYPE;
+import org.locationtech.geogig.repository.NodeRef;
+import org.opengis.filter.Filter;
+import org.opengis.filter.spatial.BinarySpatialOperator;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Predicate;
+
+/**
+ * Adapts a GeoTools {@link Filter} to a {@link Predicate} to be applied over a {@link Bounded}
+ * object (i.e. {@link Node}, {@link NodeRef}, or {@link Bucket}).
+ * <p>
+ * The evaluation returns {@code true} for buckets, so that the tree traversal continues down the
+ * path of the bucke to the leaf nodes.
+ * <p>
+ * Otherwise relies on the GeoTools {@link PropertyAccessorFactory} SPI to pick up the custom
+ * {@link ExtraDataPropertyAccessorFactory} in order to resolve attribute values out of a
+ * {@link Node} or {@link NodeRef}'s node {@link Node#getExtraData() extra data} map.
+ *
+ */
+final class PreFilter implements Predicate<Bounded> {
+
+    @VisibleForTesting
+    final Filter filter;
+
+    public PreFilter(final Filter filter) {
+        this.filter = filter;
+    }
+
+    @Override
+    public boolean apply(Bounded bounded) {
+        if (bounded == null) {
+            return false;
+        }
+        // buckets are evaluated to true for the traversal to continue to their leaf nodes, except
+        // for spatial filters, which are pre-filtered using the bounding box
+        if (bounded instanceof Bucket && !(filter instanceof BinarySpatialOperator)) {
+            return true;
+        }
+        if (bounded instanceof NodeRef && ((NodeRef) bounded).getType() == TYPE.TREE) {
+            return true;
+        }
+        return filter.evaluate(bounded);
+    }
+
+    @Override
+    public String toString() {
+        return String.format("PreFilter(%s)", filter);
+    }
+}

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
@@ -141,6 +141,10 @@ final class PreFilterBuilder implements FilterVisitor {
         List<Filter> children = filter.getChildren();
         List<Filter> pre = new ArrayList<>(children.size());
         children.forEach((f) -> pre.add((Filter) f.accept(this, extraData)));
+        if (children.contains(Filter.INCLUDE)) {
+            // if any filter isn't fully supported, we need to short-circuit to INCLUDE
+            return Filter.INCLUDE;
+        }
         return ff.or(pre);
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
@@ -14,7 +14,6 @@ import static org.opengis.filter.Filter.INCLUDE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.BiFunction;
 
 import org.geotools.factory.CommonFactoryFinder;

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilder.java
@@ -1,0 +1,415 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import static org.opengis.filter.Filter.INCLUDE;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.filter.visitor.SimplifyingFilterVisitor;
+import org.geotools.geometry.jts.JTS;
+import org.locationtech.geogig.model.Bounded;
+import org.opengis.filter.And;
+import org.opengis.filter.BinaryComparisonOperator;
+import org.opengis.filter.ExcludeFilter;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.FilterVisitor;
+import org.opengis.filter.Id;
+import org.opengis.filter.IncludeFilter;
+import org.opengis.filter.Not;
+import org.opengis.filter.Or;
+import org.opengis.filter.PropertyIsBetween;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.PropertyIsGreaterThan;
+import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
+import org.opengis.filter.PropertyIsLessThan;
+import org.opengis.filter.PropertyIsLessThanOrEqualTo;
+import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNil;
+import org.opengis.filter.PropertyIsNotEqualTo;
+import org.opengis.filter.PropertyIsNull;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.PropertyName;
+import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.Beyond;
+import org.opengis.filter.spatial.BinarySpatialOperator;
+import org.opengis.filter.spatial.Contains;
+import org.opengis.filter.spatial.Crosses;
+import org.opengis.filter.spatial.DWithin;
+import org.opengis.filter.spatial.Disjoint;
+import org.opengis.filter.spatial.Equals;
+import org.opengis.filter.spatial.Intersects;
+import org.opengis.filter.spatial.Overlaps;
+import org.opengis.filter.spatial.Touches;
+import org.opengis.filter.spatial.Within;
+import org.opengis.filter.temporal.After;
+import org.opengis.filter.temporal.AnyInteracts;
+import org.opengis.filter.temporal.Before;
+import org.opengis.filter.temporal.Begins;
+import org.opengis.filter.temporal.BegunBy;
+import org.opengis.filter.temporal.BinaryTemporalOperator;
+import org.opengis.filter.temporal.During;
+import org.opengis.filter.temporal.EndedBy;
+import org.opengis.filter.temporal.Ends;
+import org.opengis.filter.temporal.Meets;
+import org.opengis.filter.temporal.MetBy;
+import org.opengis.filter.temporal.OverlappedBy;
+import org.opengis.filter.temporal.TContains;
+import org.opengis.filter.temporal.TEquals;
+import org.opengis.filter.temporal.TOverlaps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.vividsolutions.jts.geom.Geometry;
+
+final class PreFilterBuilder implements FilterVisitor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PreFilterBuilder.class);
+
+    private static final FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+
+    private final Set<String> extraAttributes;
+
+    public PreFilterBuilder(Set<String> extraAttributes) {
+        this.extraAttributes = extraAttributes;
+    }
+
+    public Predicate<Bounded> build(Filter filter) {
+        Filter preFilter = (Filter) filter.accept(this, null);
+        preFilter = SimplifyingFilterVisitor.simplify(preFilter);
+        Predicate<Bounded> predicate;
+        if (preFilter instanceof IncludeFilter) {
+            predicate = Predicates.alwaysTrue();
+        } else if (preFilter instanceof ExcludeFilter) {
+            predicate = Predicates.alwaysFalse();
+        } else {
+            predicate = new PreFilter(preFilter);
+        }
+        // System.err.printf("Filter %s optimized as %s\n", filter, preFilter);
+        if (LOG.isTraceEnabled()) {
+            LOG.trace("Filter [{}] optimized as pre filter [{}]", filter, preFilter);
+        }
+        return predicate;
+    }
+
+    boolean isMaterialized(Expression expression) {
+        if (expression instanceof PropertyName) {
+            final String propertyName = ((PropertyName) expression).getPropertyName();
+            if (extraAttributes.contains(propertyName)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public Filter visit(ExcludeFilter filter, Object extraData) {
+        return filter;
+    }
+
+    @Override
+    public Filter visit(IncludeFilter filter, Object extraData) {
+        return filter;
+    }
+
+    @Override
+    public Filter visit(And filter, Object extraData) {
+        List<Filter> children = filter.getChildren();
+        List<Filter> pre = new ArrayList<>(children.size());
+        children.forEach((f) -> pre.add((Filter) f.accept(this, extraData)));
+        return ff.and(pre);
+    }
+
+    @Override
+    public Filter visit(Or filter, Object extraData) {
+        List<Filter> children = filter.getChildren();
+        List<Filter> pre = new ArrayList<>(children.size());
+        children.forEach((f) -> pre.add((Filter) f.accept(this, extraData)));
+        return ff.or(pre);
+    }
+
+    @Override
+    public Filter visit(Id filter, Object extraData) {
+        // Id filters are optimized already
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(Not filter, Object extraData) {
+        Filter negated = (Filter) filter.getFilter().accept(this, extraData);
+        return ff.not(negated);
+    }
+
+    @Override
+    public Filter visit(PropertyIsBetween filter, Object extraData) {
+        final Expression expression = filter.getExpression();
+        final Expression lowerBoundary = filter.getLowerBoundary();
+        final Expression upperBoundary = filter.getUpperBoundary();
+
+        if (isMaterialized(expression) && lowerBoundary instanceof Literal
+                && upperBoundary instanceof Literal) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    private Filter visitBinaryComparisonOperator(BinaryComparisonOperator filter) {
+        Expression expression1 = filter.getExpression1();
+        Expression expression2 = filter.getExpression2();
+
+        if (isMaterialized(expression1) && expression2 instanceof Literal) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(PropertyIsEqualTo filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsNotEqualTo filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsGreaterThan filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsGreaterThanOrEqualTo filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsLessThan filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsLessThanOrEqualTo filter, Object extraData) {
+        return visitBinaryComparisonOperator(filter);
+    }
+
+    @Override
+    public Filter visit(PropertyIsLike filter, Object extraData) {
+        if (isMaterialized(filter.getExpression())) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(PropertyIsNull filter, Object extraData) {
+        if (isMaterialized(filter.getExpression())) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(PropertyIsNil filter, Object extraData) {
+        if (isMaterialized(filter.getExpression())) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(BBOX filter, Object extraData) {
+        // bbox filters are optimized already
+        return INCLUDE;
+    }
+
+    private Expression toBoundsExpression(Expression expression) {
+        if (expression instanceof PropertyName) {
+            return ff.property("@bounds");
+        }
+        if (expression instanceof Literal) {
+            Geometry geometry = expression.evaluate(null, Geometry.class);
+            Geometry envelopeGeom;
+            if (geometry == null) {
+                envelopeGeom = null;
+            } else {
+                envelopeGeom = JTS.toGeometry(geometry.getEnvelopeInternal());
+            }
+            return ff.literal(envelopeGeom);
+        }
+        return expression;
+    }
+
+    private BinarySpatialOperator boundedOp(BinarySpatialOperator orig,
+            BiFunction<Expression, Expression, BinarySpatialOperator> builder) {
+
+        Expression geometry1 = toBoundsExpression(orig.getExpression1());
+        Expression geometry2 = toBoundsExpression(orig.getExpression2());
+        BinarySpatialOperator preFilter = builder.apply(geometry1, geometry2);
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Contains filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.contains(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Crosses filter, Object extraData) {
+        // simplify to a bounds intersects filter, the post-filter shall do the rest
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.intersects(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Equals filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.equal(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Intersects filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.intersects(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Overlaps filter, Object extraData) {
+        // simplify to a bounds intersects filter, the post-filter shall do the rest
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.intersects(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Touches filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.touches(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Within filter, Object extraData) {
+        // simplify to a bounds intersects filter, the post-filter shall do the rest
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.intersects(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Disjoint filter, Object extraData) {
+        // simplify to a bounds intersects filter, the post-filter shall do the rest
+        BinarySpatialOperator preFilter = boundedOp(filter, (g1, g2) -> ff.intersects(g1, g2));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(DWithin filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter,
+                (g1, g2) -> ff.dwithin(g1, g2, filter.getDistance(), filter.getDistanceUnits()));
+        return preFilter;
+    }
+
+    @Override
+    public Filter visit(Beyond filter, Object extraData) {
+        BinarySpatialOperator preFilter = boundedOp(filter,
+                (g1, g2) -> ff.beyond(g1, g2, filter.getDistance(), filter.getDistanceUnits()));
+        return preFilter;
+    }
+
+    private Filter visitBinaryTemporalOperator(BinaryTemporalOperator filter) {
+        if (isMaterialized(filter.getExpression1())) {
+            return filter;
+        }
+        return INCLUDE;
+    }
+
+    @Override
+    public Filter visit(After after, Object extraData) {
+        return visitBinaryTemporalOperator(after);
+    }
+
+    @Override
+    public Filter visit(AnyInteracts anyInteracts, Object extraData) {
+        return visitBinaryTemporalOperator(anyInteracts);
+    }
+
+    @Override
+    public Filter visit(Before before, Object extraData) {
+        return visitBinaryTemporalOperator(before);
+    }
+
+    @Override
+    public Filter visit(Begins begins, Object extraData) {
+        return visitBinaryTemporalOperator(begins);
+    }
+
+    @Override
+    public Filter visit(BegunBy begunBy, Object extraData) {
+        return visitBinaryTemporalOperator(begunBy);
+    }
+
+    @Override
+    public Filter visit(During during, Object extraData) {
+        return visitBinaryTemporalOperator(during);
+    }
+
+    @Override
+    public Filter visit(EndedBy endedBy, Object extraData) {
+        return visitBinaryTemporalOperator(endedBy);
+    }
+
+    @Override
+    public Filter visit(Ends ends, Object extraData) {
+        return visitBinaryTemporalOperator(ends);
+    }
+
+    @Override
+    public Filter visit(Meets meets, Object extraData) {
+        return visitBinaryTemporalOperator(meets);
+    }
+
+    @Override
+    public Filter visit(MetBy metBy, Object extraData) {
+        return visitBinaryTemporalOperator(metBy);
+    }
+
+    @Override
+    public Filter visit(OverlappedBy overlappedBy, Object extraData) {
+        return visitBinaryTemporalOperator(overlappedBy);
+    }
+
+    @Override
+    public Filter visit(TContains contains, Object extraData) {
+        return visitBinaryTemporalOperator(contains);
+    }
+
+    @Override
+    public Filter visit(TEquals equals, Object extraData) {
+        return visitBinaryTemporalOperator(equals);
+    }
+
+    @Override
+    public Filter visit(TOverlaps overlaps, Object extraData) {
+        return visitBinaryTemporalOperator(overlaps);
+    }
+
+    @Override
+    public Filter visitNullFilter(Object extraData) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/src/datastore/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
+++ b/src/datastore/src/main/resources/META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory
@@ -1,0 +1,1 @@
+org.locationtech.geogig.geotools.data.reader.ExtraDataPropertyAccessorFactory

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactoryTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactoryTest.java
@@ -1,0 +1,178 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.locationtech.geogig.model.impl.RevObjectTestSupport.hashString;
+
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.ServiceLoader;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.geotools.factory.FactoryRegistry;
+import org.geotools.factory.Hints;
+import org.geotools.filter.expression.PropertyAccessor;
+import org.geotools.filter.expression.PropertyAccessorFactory;
+import org.geotools.filter.expression.PropertyAccessors;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.geogig.geotools.data.reader.ExtraDataPropertyAccessorFactory.ExtraDataPropertyAccesor;
+import org.locationtech.geogig.model.Bounded;
+import org.locationtech.geogig.model.Bucket;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevObject.TYPE;
+import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.repository.NodeRef;
+
+import com.google.common.collect.ImmutableMap;
+import com.vividsolutions.jts.geom.Envelope;
+
+public class ExtraDataPropertyAccessorFactoryTest {
+
+    private Node testNode;
+
+    private NodeRef testNodeRef;
+
+    private Bucket testBucket;
+
+    @Before
+    public void before() {
+        ObjectId oid = hashString("id");
+        ObjectId metadataId = hashString("metadata");
+        Envelope bounds = new Envelope(0, 180, 0, 90);
+
+        Map<String, Object> materializedAttributes = ImmutableMap.of(//
+                "int", 1, //
+                "double", 0.5, //
+                "date", new Date(1486344231314L));
+
+        Map<String, Object> extraData = ImmutableMap.of(IndexInfo.FEATURE_ATTRIBUTES_EXTRA_DATA,
+                materializedAttributes);
+
+        testNode = Node.create("test", oid, metadataId, TYPE.FEATURE, bounds, extraData);
+
+        testNodeRef = new NodeRef(testNode, "fakeLayerName", metadataId);
+
+        ObjectId bucketId = hashString("bucketId");
+        testBucket = Bucket.create(bucketId, bounds);
+    }
+
+    @Test
+    public void testLowestLevelSPI() {
+        Iterator<PropertyAccessorFactory> iterator;
+        iterator = ServiceLoader.load(PropertyAccessorFactory.class).iterator();
+
+        boolean found = false;
+        List<String> available = new ArrayList<>();
+        while (iterator.hasNext()) {
+            PropertyAccessorFactory factory = iterator.next();
+            if (factory instanceof ExtraDataPropertyAccessorFactory) {
+                found = true;
+            }
+            available.add(factory.getClass().getName());
+        }
+
+        assertTrue("Available: " + available, found);
+    }
+
+    /**
+     * Is the factory picked up from
+     * {@code META-INF/services/org.geotools.filter.expression.PropertyAccessorFactory}
+     */
+    @Test
+    public void testLowLevelSPI() {
+        Iterator<PropertyAccessorFactory> factories;
+        factories = FactoryRegistry.lookupProviders(PropertyAccessorFactory.class);
+        while (factories.hasNext()) {
+            PropertyAccessorFactory factory = factories.next();
+            if (factory instanceof ExtraDataPropertyAccessorFactory) {
+                assertTrue(true);
+                return;
+            }
+        }
+        fail(ExtraDataPropertyAccessorFactory.class.getName() + " not found");
+    }
+
+    @Test
+    public void testSPI() {
+        findPropertyAccessor(testNode);
+        findPropertyAccessor(testNodeRef);
+        findPropertyAccessor(testBucket);
+    }
+
+    private ExtraDataPropertyAccesor findPropertyAccessor(Object object) {
+        String xpath = "int";
+        Class target = Integer.class;
+        Hints hints = null;
+
+        List<PropertyAccessor> accessors = PropertyAccessors.findPropertyAccessors(object, xpath,
+                target, hints);
+        for (PropertyAccessor pa : accessors) {
+            if (pa instanceof ExtraDataPropertyAccessorFactory.ExtraDataPropertyAccesor) {
+                return (ExtraDataPropertyAccesor) pa;
+            }
+        }
+
+        fail(ExtraDataPropertyAccessorFactory.ExtraDataPropertyAccesor.class.getName()
+                + " not found: " + accessors);
+        return null;
+    }
+
+    @Test
+    public void evaluateNode() {
+        testEvaluate(testNode, "int", 1);
+        testEvaluate(testNode, "int", 1L);
+        testEvaluate(testNode, "int", 1D);
+        testEvaluate(testNode, "double", 0.5D);
+        testEvaluate(testNode, "double", "0.5");
+    }
+
+    @Test
+    public void evaluateNodeRef() {
+        testEvaluate(testNodeRef, "int", 1);
+        testEvaluate(testNodeRef, "int", 1L);
+        testEvaluate(testNodeRef, "int", 1D);
+        testEvaluate(testNodeRef, "double", 0.5D);
+        testEvaluate(testNodeRef, "double", "0.5");
+    }
+
+    @Test
+    public void evaluateId() {
+        testEvaluate(testNodeRef, "@id", "test");
+        testEvaluate(testNode, "@id", "test");
+        testEvaluate(testBucket, "@id", null);
+    }
+
+    @Test
+    public void evaluateBucket() {
+        assertNotNull(findPropertyAccessor(testBucket));
+        assertNull(findPropertyAccessor(testBucket).get(testBucket, "int", Integer.class));
+    }
+
+    private void testEvaluate(Bounded bounded, String property, @Nullable final Object expected) {
+        ExtraDataPropertyAccesor accesor = findPropertyAccessor(bounded);
+        Class<? extends Object> target = expected == null ? null : expected.getClass();
+        Object actual = accesor.get(bounded, property, target);
+        if (expected == null) {
+            assertNull(actual);
+        } else {
+            assertEquals(expected, actual);
+        }
+    }
+}

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIteratorTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIteratorTest.java
@@ -1,0 +1,146 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.data.DataUtilities;
+import org.junit.Test;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevObject.TYPE;
+import org.locationtech.geogig.model.impl.RevFeatureBuilder;
+import org.locationtech.geogig.repository.AutoCloseableIterator;
+import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.repository.NodeRef;
+import org.locationtech.geogig.test.integration.RepositoryTestCase;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.feature.type.AttributeDescriptor;
+import org.opengis.geometry.BoundingBox;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import com.google.common.collect.Lists;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.GeometryFactory;
+
+public class MaterializedIndexFeatureIteratorTest extends RepositoryTestCase {
+
+    private GeometryFactory geometryFactory = new GeometryFactory();
+
+    @Override
+    protected void setUpInternal() throws Exception {
+        //
+    }
+
+    @Test
+    public void testAdaptEmptySchema() throws Exception {
+        CoordinateReferenceSystem crs = pointsType.getCoordinateReferenceSystem();
+
+        SimpleFeatureType emptySchema = DataUtilities.createSubType(pointsType, new String[0]);
+
+        AutoCloseableIterator<NodeRef> nodes = AutoCloseableIterator.emptyIterator();
+        MaterializedIndexFeatureIterator iterator;
+        iterator = MaterializedIndexFeatureIterator.create(emptySchema, nodes, geometryFactory,
+                crs);
+
+        NodeRef nodeRef = nodeRef((SimpleFeature) points1);
+
+        SimpleFeature feature = iterator.adapt(nodeRef);
+        assertNotNull(feature);
+        assertEquals(emptySchema, feature.getFeatureType());
+        Envelope expectedBounds = nodeRef.bounds().get();
+        BoundingBox fbounds = feature.getBounds();
+        assertEquals(expectedBounds, fbounds);
+        assertEquals(crs, fbounds.getCoordinateReferenceSystem());
+    }
+
+    @Test
+    public void testAdaptFullySupportedSchema() throws Exception {
+        CoordinateReferenceSystem crs = pointsType.getCoordinateReferenceSystem();
+
+        SimpleFeatureType subType = DataUtilities.createSubType(pointsType,
+                new String[] { "pp", "ip" });
+
+        AutoCloseableIterator<NodeRef> nodes = AutoCloseableIterator.emptyIterator();
+        MaterializedIndexFeatureIterator iterator;
+        iterator = MaterializedIndexFeatureIterator.create(subType, nodes, geometryFactory, crs);
+
+        NodeRef nodeRef = nodeRef((SimpleFeature) points1, "pp", "ip");
+
+        SimpleFeature feature = iterator.adapt(nodeRef);
+        assertNotNull(feature);
+        assertEquals(subType, feature.getFeatureType());
+
+        Envelope expectedBounds = nodeRef.bounds().get();
+        BoundingBox fbounds = feature.getBounds();
+        assertEquals(expectedBounds, fbounds);
+        assertEquals(crs, fbounds.getCoordinateReferenceSystem());
+    }
+
+    @Test
+    public void testIterate() throws Exception {
+        CoordinateReferenceSystem crs = pointsType.getCoordinateReferenceSystem();
+
+        SimpleFeatureType subType = DataUtilities.createSubType(pointsType,
+                new String[] { "pp", "ip" });
+
+        NodeRef n1 = nodeRef((SimpleFeature) points1, "pp", "ip");
+        NodeRef n2 = nodeRef((SimpleFeature) points2, "pp", "ip");
+        NodeRef n3 = nodeRef((SimpleFeature) points3, "pp", "ip");
+
+        AutoCloseableIterator<NodeRef> nodes = AutoCloseableIterator
+                .fromIterator(Lists.newArrayList(n1, n2, n3).iterator());
+
+        MaterializedIndexFeatureIterator iterator;
+        iterator = MaterializedIndexFeatureIterator.create(subType, nodes, geometryFactory, crs);
+
+        ArrayList<SimpleFeature> features = Lists.newArrayList(iterator);
+        assertEquals(3, features.size());
+        assertFeature(subType, (SimpleFeature) points1, features.get(0));
+        assertFeature(subType, (SimpleFeature) points2, features.get(1));
+        assertFeature(subType, (SimpleFeature) points3, features.get(2));
+    }
+
+    private void assertFeature(SimpleFeatureType expectedType, SimpleFeature expectedValues,
+            SimpleFeature actual) {
+        assertEquals(expectedType, actual.getFeatureType());
+        assertEquals(expectedValues.getID(), actual.getID());
+        assertEquals(expectedValues.getBounds(), actual.getBounds());
+
+        for (AttributeDescriptor att : expectedType.getAttributeDescriptors()) {
+            String name = att.getLocalName();
+            assertEquals(expectedValues.getAttribute(name), actual.getAttribute(name));
+        }
+    }
+
+    private NodeRef nodeRef(SimpleFeature f, String... extraAttributes) {
+
+        Map<String, Object> extraData = new HashMap<>();
+        Map<String, Object> extraAtts = new HashMap<>();
+        if (extraAttributes != null) {
+            for (String name : extraAttributes) {
+                extraAtts.put(name, f.getAttribute(name));
+            }
+        }
+        extraData.put(IndexInfo.FEATURE_ATTRIBUTES_EXTRA_DATA, extraAtts);
+
+        ObjectId id = RevFeatureBuilder.build(f).getId();
+        Envelope bounds = (Envelope) f.getBounds();
+        Node node = Node.create(f.getID(), id, ObjectId.NULL, TYPE.FEATURE, bounds, extraData);
+
+        String typeName = f.getType().getTypeName();
+        NodeRef nodeRef = NodeRef.create(typeName, node);
+        return nodeRef;
+    }
+
+}

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilderTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilderTest.java
@@ -1,0 +1,750 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import static org.geotools.filter.text.ecql.ECQL.toFilter;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.locationtech.geogig.model.impl.RevObjectTestSupport.hashString;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.geotools.factory.CommonFactoryFinder;
+import org.geotools.geometry.jts.JTS;
+import org.junit.Before;
+import org.junit.Test;
+import org.locationtech.geogig.model.Bounded;
+import org.locationtech.geogig.model.Bucket;
+import org.locationtech.geogig.model.Node;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.RevObject.TYPE;
+import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.repository.NodeRef;
+import org.opengis.filter.Filter;
+import org.opengis.filter.FilterFactory2;
+import org.opengis.filter.PropertyIsGreaterThan;
+import org.opengis.filter.PropertyIsGreaterThanOrEqualTo;
+import org.opengis.filter.PropertyIsLessThan;
+import org.opengis.filter.PropertyIsLessThanOrEqualTo;
+import org.opengis.filter.PropertyIsLike;
+import org.opengis.filter.PropertyIsNil;
+import org.opengis.filter.PropertyIsNotEqualTo;
+import org.opengis.filter.PropertyIsNull;
+import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.Beyond;
+import org.opengis.filter.spatial.Contains;
+import org.opengis.filter.spatial.Crosses;
+import org.opengis.filter.spatial.DWithin;
+import org.opengis.filter.spatial.Disjoint;
+import org.opengis.filter.spatial.Equals;
+import org.opengis.filter.spatial.Intersects;
+import org.opengis.filter.spatial.Overlaps;
+import org.opengis.filter.spatial.Touches;
+import org.opengis.filter.spatial.Within;
+import org.opengis.filter.temporal.After;
+import org.opengis.filter.temporal.AnyInteracts;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Polygon;
+import com.vividsolutions.jts.io.WKTReader;
+
+public class PreFilterBuilderTest {
+
+    private final Date DATE_VALUE = new Date(1486344231314L);
+
+    private final FilterFactory2 ff = CommonFactoryFinder.getFilterFactory2();
+
+    private Node testNode;
+
+    private NodeRef testNodeRef;
+
+    private Bucket testBucket;
+
+    private PreFilterBuilder builder;
+
+    @Before
+    public void before() {
+        ObjectId oid = hashString("id");
+        ObjectId metadataId = hashString("metadata");
+        Envelope bounds = new Envelope(0, 180, 0, 90);
+
+        Map<String, Object> materializedAttributes = new HashMap<>();
+        materializedAttributes.put("int", 1);
+        materializedAttributes.put("double", 0.5);
+        materializedAttributes.put("date", DATE_VALUE);
+        materializedAttributes.put("string", "geogig");
+        materializedAttributes.put("nullprop", null);
+
+        Map<String, Object> extraData = ImmutableMap.of(IndexInfo.FEATURE_ATTRIBUTES_EXTRA_DATA,
+                materializedAttributes);
+
+        testNode = Node.create("testFid", oid, metadataId, TYPE.FEATURE, bounds, extraData);
+
+        testNodeRef = new NodeRef(testNode, "fakeLayerName", metadataId);
+
+        ObjectId bucketId = hashString("bucketId");
+        testBucket = Bucket.create(bucketId, bounds);
+
+        builder = new PreFilterBuilder(materializedAttributes.keySet());
+    }
+
+    @Test
+    public void testAttributeIsMaterialized() {
+        assertTrue(builder.isMaterialized(ff.property("int")));
+        assertTrue(builder.isMaterialized(ff.property("double")));
+        assertTrue(builder.isMaterialized(ff.property("date")));
+        assertTrue(builder.isMaterialized(ff.property("string")));
+        assertFalse(builder.isMaterialized(ff.property("somethingElse")));
+    }
+
+    @Test
+    public void excludeFilter() {
+        Predicate<Bounded> predicate = builder.build(Filter.EXCLUDE);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        assertFalse(predicate.apply(testBucket));
+        assertFalse(predicate.apply(null));
+    }
+
+    @Test
+    public void includeFilter() {
+        Predicate<Bounded> predicate = builder.build(Filter.INCLUDE);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+        assertTrue(predicate.apply(null));
+    }
+
+    @Test
+    public void andFilter() throws Exception {
+        Filter filter = toFilter("int = 1 AND string = 'geogig'");
+        Predicate<Bounded> predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+        assertFalse(predicate.apply(null));
+
+        filter = toFilter("int = 2 AND string = 'geogig'");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
+        // traversal
+        assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("int = 2 AND string = 'geogig' AND nonExistent = 'something'");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void orFilter() throws Exception {
+        Filter filter = toFilter("int = 0 OR string = 'geogig'");
+        Predicate<Bounded> predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("int = 2 OR string = 'something else'");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
+        // traversal
+        assertTrue(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void idFilter() throws Exception {
+        Filter filter = toFilter("IN ('fake1', 'testFid', 'fake2')");
+        Predicate<Bounded> predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("IN ('fake1', 'fake2', 'fake3')");
+        predicate = builder.build(filter);
+        // Id filters short-circuit as TRUE because they're evaluated more efficiently by
+        // DiffTree.setPathFilter()
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
+        // traversal
+        assertTrue(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void notFilter() throws Exception {
+        Filter filter = toFilter("NOT(int = 1)");
+        Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("NOT(double < 0)");
+        predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
+        // traversal
+        assertTrue(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void propertyIsBetweenFilter() throws Exception {
+        Filter filter = toFilter("double between 0.1 and 0.6");
+        Predicate<Bounded> predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("double between 0.1 and 0.49999");
+        predicate = builder.build(filter);
+
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
+        // traversal
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = toFilter("nonMaterializedProperty between 0.1 and 0.5");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsEqualToFilter() throws Exception {
+        Predicate<Bounded> predicate = builder.build(toFilter("double = 0.5"));
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        predicate = builder.build(toFilter("int = 1.0"));
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        Filter filter = toFilter("nonMaterializedProperty = 1");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsNotEqualToFilter() throws Exception {
+        // ECQL.toFilter("double <> 0.1") returns a NOT filter instead of a PropertyIsNotEqualTo
+        PropertyIsNotEqualTo filter = ff.notEqual(ff.property("double"), ff.literal(0.1));
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.notEqual(ff.property("int"), ff.literal(1));
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = ff.notEqual(ff.property("nonMaterializedProperty"), ff.literal(0.5));
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsGreaterThanFilter() throws Exception {
+        PropertyIsGreaterThan filter = (PropertyIsGreaterThan) toFilter("double > 0.4");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (PropertyIsGreaterThan) toFilter("int > 0");
+        predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsGreaterThan) toFilter("nonMaterializedProperty > 1");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsGreaterThanOrEqualToFilter() throws Exception {
+        PropertyIsGreaterThanOrEqualTo filter = (PropertyIsGreaterThanOrEqualTo) toFilter(
+                "double >= 0.4");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (PropertyIsGreaterThanOrEqualTo) toFilter("int >= 1");
+        predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsGreaterThanOrEqualTo) toFilter("nonMaterializedProperty >= 1");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsLessThanFilter() throws Exception {
+        PropertyIsLessThan filter = (PropertyIsLessThan) toFilter("double < 5.1");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (PropertyIsLessThan) toFilter("int < 1000");
+        predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        assertFalse(builder.build(toFilter("int < 1")).apply(testNode));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsLessThan) toFilter("nonMaterializedProperty < 1");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsLessThanOrEqualToFilter() throws Exception {
+        PropertyIsLessThanOrEqualTo filter = (PropertyIsLessThanOrEqualTo) toFilter(
+                "double <= 5.1");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        assertFalse(builder.build(toFilter("int <= 0.99")).apply(testNode));
+        assertFalse(builder.build(toFilter("double <= 0.499")).apply(testNode));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsLessThanOrEqualTo) toFilter("nonMaterializedProperty <= 1");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsLikeFilter() throws Exception {
+        PropertyIsLike filter = (PropertyIsLike) toFilter("string like '%gig'");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsLike) toFilter("nonMaterializedProperty like 'something%'");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsNullFilter() throws Exception {
+        PropertyIsNull filter = (PropertyIsNull) toFilter("nullprop is null");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (PropertyIsNull) toFilter("int is null");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = (PropertyIsNull) toFilter("nonMaterializedProperty is null");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void propertyIsNilFilter() throws Exception {
+        PropertyIsNil filter = ff.isNil(ff.property("nullprop"), "notAvail");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.isNil(ff.property("string"), "notAvail");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        // if the property being tested is not materialized, pre-filter evaluates to true, in order
+        // for the post-filtering to proceed
+        filter = ff.isNil(ff.property("nonMaterializedAttribute"), "notAvail");
+        predicate = builder.build(filter);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+    }
+
+    @Test
+    public void bboxFilter() throws Exception {
+        BBOX filter = ff.bbox("the_geom", 0, 0, 180, 90, "EPSG:4326");
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.bbox("the_geom", -10, -10, -1, -1, "EPSG:4326");
+        predicate = builder.build(filter);
+        // BBOX filters are short-circuited to TRUE because they're evaluated more efficiently by
+        // DiffTree.setBoundsFilter
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertTrue(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testContainsFilter() throws Exception {
+        Contains filter;
+        filter = (Contains) toFilter("contains(the_geom, POLYGON((1 1, 1 2, 2 2, 2 1, 1 1)) )");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Contains) toFilter("contains(the_geom, POLYGON((-1 -1, 1 2, 2 2, 2 1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testCrossesFilter() throws Exception {
+        Crosses filter;
+        filter = (Crosses) toFilter("crosses(the_geom, POLYGON((1 1, 1 2, 2 2, 2 1, 1 1)) )");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue("crosses should have been simplified to intersects for pre-filtering",
+                ((PreFilter) predicate).filter instanceof Intersects);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Crosses) toFilter(
+                "crosses(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testGeometryEqualsFilter() throws Exception {
+        Equals filter;
+        Polygon bounds = JTS.toGeometry(testNode.bounds().get());
+        filter = (Equals) toFilter(String.format("equals(the_geom, %s)", bounds));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof Equals);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Equals) toFilter(
+                "equals(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testIntersectsFilter() throws Exception {
+        Intersects filter;
+        filter = (Intersects) toFilter("Intersects(the_geom, POLYGON((1 1, 1 2, 2 2, 2 1, 1 1)) )");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof Intersects);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Intersects) toFilter(
+                "Intersects(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testOverlapsFilter() throws Exception {
+        Overlaps filter;
+        filter = (Overlaps) toFilter("Overlaps(the_geom, POLYGON((1 1, 1 2, 2 2, 2 1, 1 1)) )");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue("Overlaps should have been simplified to intersects for pre-filtering",
+                ((PreFilter) predicate).filter instanceof Intersects);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Overlaps) toFilter(
+                "Overlaps(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testTouchesFilter() throws Exception {
+        Envelope bounds = testNode.bounds().get();
+        bounds.translate(-1 * bounds.getWidth(), 0);
+        Polygon touching = JTS.toGeometry(bounds);
+
+        Touches filter;
+        filter = (Touches) toFilter(String.format("Touches(the_geom, %s)", touching));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof Touches);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Touches) toFilter(
+                "Touches(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testWithinFilter() throws Exception {
+        Envelope bounds = testNode.bounds().get();
+        bounds.expandBy(1);
+        Polygon container = JTS.toGeometry(bounds);
+
+        Within filter;
+        filter = (Within) toFilter(String.format("Within(the_geom, %s)", container));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue("Within should have been simplified to intersects for pre-filtering",
+                ((PreFilter) predicate).filter instanceof Intersects);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Within) toFilter(
+                "Within(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testDisjointFilter() throws Exception {
+        Envelope bounds = testNode.bounds().get();
+        bounds.expandBy(1);
+        Polygon container = JTS.toGeometry(bounds);
+
+        Disjoint filter;
+        filter = (Disjoint) toFilter(String.format("Disjoint(the_geom, %s)", container));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue("Disjoint should have been simplified to intersects for pre-filtering",
+                ((PreFilter) predicate).filter instanceof Intersects);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = (Disjoint) toFilter(
+                "Disjoint(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testDWithinFilter() throws Exception {
+        DWithin filter;
+        filter = ff.dwithin(ff.property("the_geom"),
+                ff.literal(new WKTReader().read("POINT(0 -1)")), 1.5, "m");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof DWithin);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.dwithin(ff.property("the_geom"),
+                ff.literal(new WKTReader().read("POINT(-180 -90)")), 0.5, "m");
+
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testBeyondFilter() throws Exception {
+        Beyond filter;
+        filter = ff.beyond(ff.property("the_geom"),
+                ff.literal(new WKTReader().read("POINT(-180 0)")), 179, "m");
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof Beyond);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.beyond(ff.property("the_geom"),
+                ff.literal(new WKTReader().read("POINT(-45 0)")), 50, "m");
+
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are filtered by bbox, at the difference of other filters where they evaluate
+        // always to true in order for the diff-walk to proceed to its children
+        assertFalse(predicate.apply(testBucket));
+    }
+
+    @Test
+    public void testAfterFilter() throws Exception {
+        Date previousDate = new Date();
+        previousDate.setTime(DATE_VALUE.getTime() - 1000);
+
+        After filter = ff.after(ff.property("date"), ff.literal(previousDate));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof After);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.after(ff.property("date"), ff.literal(DATE_VALUE));
+
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are evaluated to true for the traversal to continue to its leaf nodes
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.after(ff.property("nonMaterializedProp"), ff.literal(DATE_VALUE));
+        predicate = builder.build(filter);
+        assertFalse(predicate instanceof PreFilter);// it's Predicates.alwaysTrue()
+        assertTrue(predicate.apply(null));
+    }
+
+    @Test
+    public void testAnyInteractsFilter() throws Exception {
+        Date previousDate = new Date();
+        previousDate.setTime(DATE_VALUE.getTime() - 1000);
+
+        AnyInteracts filter = ff.anyInteracts(ff.property("date"), ff.literal(DATE_VALUE));
+
+        Predicate<Bounded> predicate = builder.build(filter);
+        assertTrue(((PreFilter) predicate).filter instanceof AnyInteracts);
+
+        assertTrue(predicate.apply(testNode));
+        assertTrue(predicate.apply(testNodeRef));
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.anyInteracts(ff.property("date"), ff.literal(previousDate));
+
+        predicate = builder.build(filter);
+        assertFalse(predicate.apply(testNode));
+        assertFalse(predicate.apply(testNodeRef));
+        // buckets are evaluated to true for the traversal to continue to its leaf nodes
+        assertTrue(predicate.apply(testBucket));
+
+        filter = ff.anyInteracts(ff.property("nonMaterializedProp"), ff.literal(DATE_VALUE));
+        predicate = builder.build(filter);
+        assertFalse(predicate instanceof PreFilter);// it's Predicates.alwaysTrue()
+        assertTrue(predicate.apply(null));
+    }
+
+}

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilderTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/PreFilterBuilderTest.java
@@ -131,6 +131,9 @@ public class PreFilterBuilderTest {
         Filter filter = toFilter("int = 1 AND string = 'geogig'");
         Predicate<Bounded> predicate = builder.build(filter);
 
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -146,6 +149,9 @@ public class PreFilterBuilderTest {
 
         filter = toFilter("int = 2 AND string = 'geogig' AND nonExistent = 'something'");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
     }
@@ -155,17 +161,27 @@ public class PreFilterBuilderTest {
         Filter filter = toFilter("int = 0 OR string = 'geogig'");
         Predicate<Bounded> predicate = builder.build(filter);
 
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = toFilter("int = 2 OR string = 'something else'");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
         // traversal
         assertTrue(predicate.apply(testBucket));
+
+        filter = toFilter("int = 2 OR string = 'something else' OR nonmat ='xyz'");
+        predicate = builder.build(filter);
+        assertTrue(isAcceptEverything(predicate)); //cannot be optimized
+
     }
 
     @Test
@@ -173,12 +189,17 @@ public class PreFilterBuilderTest {
         Filter filter = toFilter("IN ('fake1', 'testFid', 'fake2')");
         Predicate<Bounded> predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));  // not optimized
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = toFilter("IN ('fake1', 'fake2', 'fake3')");
         predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate));
+
         // Id filters short-circuit as TRUE because they're evaluated more efficiently by
         // DiffTree.setPathFilter()
         assertTrue(predicate.apply(testNode));
@@ -199,6 +220,9 @@ public class PreFilterBuilderTest {
 
         filter = toFilter("NOT(double < 0)");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         // when given a bucket, it just must evaluate to true for PreorderDiffWalk to continue
@@ -210,6 +234,8 @@ public class PreFilterBuilderTest {
     public void propertyIsBetweenFilter() throws Exception {
         Filter filter = toFilter("double between 0.1 and 0.6");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
 
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
@@ -229,6 +255,9 @@ public class PreFilterBuilderTest {
         filter = toFilter("nonMaterializedProperty between 0.1 and 0.5");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -236,11 +265,17 @@ public class PreFilterBuilderTest {
     @Test
     public void propertyIsEqualToFilter() throws Exception {
         Predicate<Bounded> predicate = builder.build(toFilter("double = 0.5"));
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         predicate = builder.build(toFilter("int = 1.0"));
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -249,6 +284,9 @@ public class PreFilterBuilderTest {
         // for the post-filtering to proceed
         Filter filter = toFilter("nonMaterializedProperty = 1");
         predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate));
+
 
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
@@ -259,6 +297,9 @@ public class PreFilterBuilderTest {
         // ECQL.toFilter("double <> 0.1") returns a NOT filter instead of a PropertyIsNotEqualTo
         PropertyIsNotEqualTo filter = ff.notEqual(ff.property("double"), ff.literal(0.1));
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -274,6 +315,9 @@ public class PreFilterBuilderTest {
         filter = ff.notEqual(ff.property("nonMaterializedProperty"), ff.literal(0.5));
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -282,12 +326,18 @@ public class PreFilterBuilderTest {
     public void propertyIsGreaterThanFilter() throws Exception {
         PropertyIsGreaterThan filter = (PropertyIsGreaterThan) toFilter("double > 0.4");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = (PropertyIsGreaterThan) toFilter("int > 0");
         predicate = builder.build(filter);
+
+        assertFalse(predicate.toString().contains("always")); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -296,6 +346,9 @@ public class PreFilterBuilderTest {
         // for the post-filtering to proceed
         filter = (PropertyIsGreaterThan) toFilter("nonMaterializedProperty > 1");
         predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate)); //cannot pre-filter
+
 
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
@@ -306,12 +359,18 @@ public class PreFilterBuilderTest {
         PropertyIsGreaterThanOrEqualTo filter = (PropertyIsGreaterThanOrEqualTo) toFilter(
                 "double >= 0.4");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = (PropertyIsGreaterThanOrEqualTo) toFilter("int >= 1");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -321,6 +380,8 @@ public class PreFilterBuilderTest {
         filter = (PropertyIsGreaterThanOrEqualTo) toFilter("nonMaterializedProperty >= 1");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -329,12 +390,18 @@ public class PreFilterBuilderTest {
     public void propertyIsLessThanFilter() throws Exception {
         PropertyIsLessThan filter = (PropertyIsLessThan) toFilter("double < 5.1");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = (PropertyIsLessThan) toFilter("int < 1000");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -346,6 +413,9 @@ public class PreFilterBuilderTest {
         filter = (PropertyIsLessThan) toFilter("nonMaterializedProperty < 1");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -355,6 +425,9 @@ public class PreFilterBuilderTest {
         PropertyIsLessThanOrEqualTo filter = (PropertyIsLessThanOrEqualTo) toFilter(
                 "double <= 5.1");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -367,6 +440,9 @@ public class PreFilterBuilderTest {
         filter = (PropertyIsLessThanOrEqualTo) toFilter("nonMaterializedProperty <= 1");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -375,6 +451,10 @@ public class PreFilterBuilderTest {
     public void propertyIsLikeFilter() throws Exception {
         PropertyIsLike filter = (PropertyIsLike) toFilter("string like '%gig'");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -384,6 +464,9 @@ public class PreFilterBuilderTest {
         filter = (PropertyIsLike) toFilter("nonMaterializedProperty like 'something%'");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -392,6 +475,9 @@ public class PreFilterBuilderTest {
     public void propertyIsNullFilter() throws Exception {
         PropertyIsNull filter = (PropertyIsNull) toFilter("nullprop is null");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -407,6 +493,8 @@ public class PreFilterBuilderTest {
         filter = (PropertyIsNull) toFilter("nonMaterializedProperty is null");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -415,6 +503,9 @@ public class PreFilterBuilderTest {
     public void propertyIsNilFilter() throws Exception {
         PropertyIsNil filter = ff.isNil(ff.property("nullprop"), "notAvail");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -430,6 +521,9 @@ public class PreFilterBuilderTest {
         filter = ff.isNil(ff.property("nonMaterializedAttribute"), "notAvail");
         predicate = builder.build(filter);
 
+        assertTrue(isAcceptEverything(predicate));
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
     }
@@ -438,6 +532,9 @@ public class PreFilterBuilderTest {
     public void bboxFilter() throws Exception {
         BBOX filter = ff.bbox("the_geom", 0, 0, 180, 90, "EPSG:4326");
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate));
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -446,6 +543,9 @@ public class PreFilterBuilderTest {
         predicate = builder.build(filter);
         // BBOX filters are short-circuited to TRUE because they're evaluated more efficiently by
         // DiffTree.setBoundsFilter
+
+        assertTrue(isAcceptEverything(predicate));
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -459,12 +559,18 @@ public class PreFilterBuilderTest {
         filter = (Contains) toFilter("contains(the_geom, POLYGON((1 1, 1 2, 2 2, 2 1, 1 1)) )");
 
         Predicate<Bounded> predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
 
         filter = (Contains) toFilter("contains(the_geom, POLYGON((-1 -1, 1 2, 2 2, 2 1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -481,6 +587,9 @@ public class PreFilterBuilderTest {
         assertTrue("crosses should have been simplified to intersects for pre-filtering",
                 ((PreFilter) predicate).filter instanceof Intersects);
 
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
+
         assertTrue(predicate.apply(testNode));
         assertTrue(predicate.apply(testNodeRef));
         assertTrue(predicate.apply(testBucket));
@@ -488,6 +597,9 @@ public class PreFilterBuilderTest {
         filter = (Crosses) toFilter(
                 "crosses(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -511,6 +623,10 @@ public class PreFilterBuilderTest {
         filter = (Equals) toFilter(
                 "equals(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -533,6 +649,9 @@ public class PreFilterBuilderTest {
         filter = (Intersects) toFilter(
                 "Intersects(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -556,6 +675,9 @@ public class PreFilterBuilderTest {
         filter = (Overlaps) toFilter(
                 "Overlaps(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -582,6 +704,9 @@ public class PreFilterBuilderTest {
         filter = (Touches) toFilter(
                 "Touches(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -609,6 +734,9 @@ public class PreFilterBuilderTest {
         filter = (Within) toFilter(
                 "Within(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -636,6 +764,9 @@ public class PreFilterBuilderTest {
         filter = (Disjoint) toFilter(
                 "Disjoint(the_geom, POLYGON((-1 -1, -1 -2, -2 -2, -2 -1, -1 -1)) )");
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -660,6 +791,9 @@ public class PreFilterBuilderTest {
                 ff.literal(new WKTReader().read("POINT(-180 -90)")), 0.5, "m");
 
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -684,6 +818,9 @@ public class PreFilterBuilderTest {
                 ff.literal(new WKTReader().read("POINT(-45 0)")), 50, "m");
 
         predicate = builder.build(filter);
+
+        assertFalse(isAcceptEverything(predicate)); //verify its not just passing everything
+
         assertFalse(predicate.apply(testNode));
         assertFalse(predicate.apply(testNodeRef));
         // buckets are filtered by bbox, at the difference of other filters where they evaluate
@@ -715,6 +852,9 @@ public class PreFilterBuilderTest {
 
         filter = ff.after(ff.property("nonMaterializedProp"), ff.literal(DATE_VALUE));
         predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate));
+
         assertFalse(predicate instanceof PreFilter);// it's Predicates.alwaysTrue()
         assertTrue(predicate.apply(null));
     }
@@ -743,8 +883,15 @@ public class PreFilterBuilderTest {
 
         filter = ff.anyInteracts(ff.property("nonMaterializedProp"), ff.literal(DATE_VALUE));
         predicate = builder.build(filter);
+
+        assertTrue(isAcceptEverything(predicate));
+
         assertFalse(predicate instanceof PreFilter);// it's Predicates.alwaysTrue()
         assertTrue(predicate.apply(null));
+    }
+
+    public boolean isAcceptEverything(Predicate p) {
+        return p.toString().contains("always");
     }
 
 }


### PR DESCRIPTION
When there're materialized attributes in an Index,
FeatureReaderBuilder creates an Iterator<NodeRef>
that's pre-filtered using the available materialized
attribute values to the extent possible.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>