### PR TITLE
Strengthened semantics for Node extraData, now part of trees SHA-1

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
@@ -300,6 +300,12 @@ public class HashObjectFunnels {
             StringFunnel.funnel((CharSequence) ref.getName(), into);
             ObjectIdFunnel.funnel(ref.getObjectId(), into);
             ObjectIdFunnel.funnel(ref.getMetadataId().or(ObjectId.NULL), into);
+            Map<String, Object> extraData = ref.getExtraData();
+            // consider extraData only if it's not empty to maintain backwards compatibility with
+            // Geogig pre 1.1
+            if (!extraData.isEmpty()) {
+                PropertyValueFunnel.funnel(extraData, into);
+            }
         }
     };
 

--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -19,7 +19,6 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevTree;
 
 import com.google.common.base.Charsets;
-import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
@@ -27,7 +26,7 @@ import com.google.common.collect.Sets;
 import com.google.common.hash.Hasher;
 import com.vividsolutions.jts.geom.Envelope;
 
-public class IndexInfo {
+public final class IndexInfo {
     public static enum IndexType {
         QUADTREE
     }

--- a/src/api/src/test/java/org/locationtech/geogig/model/NodeTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/NodeTest.java
@@ -238,18 +238,6 @@ public class NodeTest {
     }
 
     @Test
-    public void testSetExtraData() {
-        Node node = Node.tree("Points",
-                ObjectId.valueOf("abc123000000000000001234567890abcdef0000"), ObjectId.NULL);
-        assertEquals(null, node.getExtraData());
-        Map<String, Object> extraData = new HashMap<String, Object>();
-        extraData.put("key", "value");
-        node.setExtraData(extraData);
-
-        assertEquals(extraData, node.getExtraData());
-    }
-
-    @Test
     public void testHashCode() {
         Node node = Node.create("Points.1",
                 ObjectId.valueOf("abc123000000000000001234567890abcdef0000"), ObjectId.NULL,

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/index/MaterializedBuilderConsumer.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/index/MaterializedBuilderConsumer.java
@@ -152,10 +152,8 @@ class MaterializedBuilderConsumer extends AbstractConsumer {
                 atts.put(attName, value.orNull());
             });
 
-            Map<String, Object> extraData = node.getExtraData();
-            if (extraData == null) {
-                extraData = new HashMap<>();
-            }
+            Map<String, Object> extraData = new HashMap<>(node.getExtraData());
+
             extraData.put(IndexInfo.FEATURE_ATTRIBUTES_EXTRA_DATA, atts);
 
             String name = node.getName();

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/index/Index.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/index/Index.java
@@ -1,11 +1,19 @@
 package org.locationtech.geogig.porcelain.index;
 
+import static com.google.common.base.Preconditions.*;
+import java.util.Objects;
+
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.storage.IndexDatabase;
 
-public class Index {
+/**
+ * A value object resulting of creating or updating an index, that provides access to the
+ * {@link IndexInfo index information} and the {@link RevTree} the index points to.
+ *
+ */
+public final class Index {
 
     private final IndexInfo indexInfo;
 
@@ -14,6 +22,8 @@ public class Index {
     private final IndexDatabase indexdb;
 
     public Index(IndexInfo indexInfo, ObjectId indexTree, IndexDatabase indexdb) {
+        checkNotNull(indexInfo);
+        checkNotNull(indexTree);
         this.indexInfo = indexInfo;
         this.indexTree = indexTree;
         this.indexdb = indexdb;
@@ -29,6 +39,20 @@ public class Index {
 
     public RevTree indexTree() {
         return indexdb.getTree(indexTree);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o instanceof Index) {
+            Index i = (Index) o;
+            return info().equals(i.info()) && indexTreeId().equals(i.indexTreeId());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(indexInfo, indexTree);
     }
 
     @Override

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
@@ -505,14 +505,12 @@ public class FormatCommonV2 {
             boundsMask = BOUNDS_BOX2D_MASK;
         }
 
-        @Nullable
         final Map<String, Object> extraData = node.getExtraData();
 
         metadataMask = node.getMetadataId().isPresent() ? METADATA_PRESENT_MASK
                 : METADATA_ABSENT_MASK;
 
-        extraDataMask = extraData == null || extraData.isEmpty() ? EXTRA_DATA_ABSENT_MASK
-                : EXTRA_DATA_PRESENT_MASK;
+        extraDataMask = extraData.isEmpty() ? EXTRA_DATA_ABSENT_MASK : EXTRA_DATA_PRESENT_MASK;
 
         // encode type and bounds mask together
         final int typeAndMasks = nodeType | boundsMask | metadataMask | extraDataMask;

--- a/src/core/src/test/java/org/locationtech/geogig/porcelain/index/UpdateIndexOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/porcelain/index/UpdateIndexOpTest.java
@@ -394,4 +394,30 @@ public class UpdateIndexOpTest extends RepositoryTestCase {
                 .setAttributeName("geom")//
                 .call();
     }
+
+    @Test
+    public void testEqualIndexesWithDifferentExtraAttributesHashDifferently() {
+        Index noExtraAtts = createAndBuildIndex();
+        Index xExtraAtts = createAndBuildIndex("x");
+        Index yExtraAtts = createAndBuildIndex("y");
+        assertNotEquals(noExtraAtts, xExtraAtts);
+        assertNotEquals(xExtraAtts, yExtraAtts);
+
+        assertNotEquals(noExtraAtts.indexTreeId(), xExtraAtts.indexTreeId());
+        assertNotEquals(xExtraAtts.indexTreeId(), yExtraAtts.indexTreeId());
+    }
+
+    private Index createAndBuildIndex(@Nullable String... extraAttributes) {
+        IndexInfo indexInfo = createIndex(extraAttributes);
+        List<String> extraAtts = null;
+        if (extraAttributes != null) {
+            extraAtts = Lists.newArrayList(extraAttributes);
+        }
+        Index index = geogig.command(UpdateIndexOp.class)//
+                .setAdd(true)//
+                .setTreeRefSpec(indexInfo.getTreeName())//
+                .setExtraAttributes(extraAtts)//
+                .call();
+        return index;
+    }
 }

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIterator.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/MaterializedIndexFeatureIterator.java
@@ -110,9 +110,6 @@ class MaterializedIndexFeatureIterator implements AutoCloseableIterator<SimpleFe
             return BoundedSimpleFeature.empty(featureType, node.getNode(), crs);
 
         } else {
-            final Map<String, Object> extraData = node.getNode().getExtraData();
-            checkNotNull(extraData);
-
             final Map<String, Object> materializedAttributes;
             materializedAttributes = IndexInfo.getMaterializedAttributes(node.getNode());
             checkNotNull(materializedAttributes);


### PR DESCRIPTION
Made Node.getExtraData() be used when computing a RevTree's SHA-1.
Doesn't affect the canonical tree ids as their nodes don't contain
extra data, but for Indexes it's necessary.

Moreover, what's stored in the nodes extra data map has semantic
value, hence it should be considered when computing the trees
SHA-1. Otherwise two equal trees with different extra attributes
in an Index would hash to the same id.

Also strengthened the semantics of Node.getExtraData() to ensure
the node's immutability.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>