### PR TITLE
improve ScreenMapPredicate for concurrency and other fixes

### DIFF
--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
@@ -84,7 +84,10 @@ class GeogigFeatureSource extends ContentFeatureSource {
     @Override
     protected void addHints(Set<Hints.Key> hints) {
         hints.add(Hints.FEATURE_DETACHED);
-        hints.add(Hints.SCREENMAP);
+        // if the user turned off the screenmap, then don't advertise it (the renderer will do its own)
+        final boolean ignorescreenmap = Boolean.getBoolean("geogig.ignorescreenmap");
+        if (!ignorescreenmap)
+            hints.add(Hints.SCREENMAP);
         hints.add(Hints.JTS_GEOMETRY_FACTORY);
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -27,6 +27,7 @@ import org.geotools.data.Query;
 import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.feature.SchemaException;
 import org.geotools.filter.spatial.ReprojectingFilterVisitor;
+import org.geotools.filter.visitor.AbstractFilterVisitor;
 import org.geotools.filter.visitor.SimplifyingFilterVisitor;
 import org.geotools.filter.visitor.SpatialFilterVisitor;
 import org.geotools.geometry.jts.ReferencedEnvelope;
@@ -54,6 +55,7 @@ import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 import org.opengis.feature.type.GeometryDescriptor;
+import org.opengis.filter.BinaryComparisonOperator;
 import org.opengis.filter.Filter;
 import org.opengis.filter.FilterFactory2;
 import org.opengis.filter.Id;
@@ -61,6 +63,7 @@ import org.opengis.filter.identity.FeatureId;
 import org.opengis.filter.identity.Identifier;
 import org.opengis.filter.sort.SortBy;
 import org.opengis.filter.spatial.BBOX;
+import org.opengis.filter.spatial.BinarySpatialOperator;
 import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -219,14 +222,14 @@ public class FeatureReaderBuilder {
         // properties, empty list means no-properties needed
         final @Nullable Set<String> requiredProperties = resolveRequiredProperties(nativeFilter);
         // properties present in the RevTree nodes' extra data
-        final Set<String> materializedProperties;
+        final Set<String> materializedIndexProperties;
         // whether the RevTree nodes contain all required properties (hence no need to fetch
         // RevFeatures from the database)
         final boolean indexContainsAllRequiredProperties;
         // whether the filter is fully supported by the NodeRef filtering (hence no need for
         // pos-processing filtering). This is the case if the filter is a simple BBOX, Id, or
         // INCLUDE, or all the required properties are present in the index Nodes
-        final boolean filterIsFullySupported;
+        final boolean filterIsFullySupportedByIndex;
 
         final ObjectId featureTypeId = typeRef.getMetadataId();
 
@@ -279,11 +282,12 @@ public class FeatureReaderBuilder {
                 newFeatureTypeTree = newCanonicalTreeId;
             }
 
-            materializedProperties = resolveMaterializedProperties(headIndex);
-            indexContainsAllRequiredProperties = materializedProperties
+            materializedIndexProperties = resolveMaterializedProperties(headIndex);
+            indexContainsAllRequiredProperties = materializedIndexProperties
                     .containsAll(requiredProperties);
-            filterIsFullySupported = filterIsFullySupported(nativeFilter,
-                    indexContainsAllRequiredProperties);
+            filterIsFullySupportedByIndex = filterIsFullySupported(nativeFilter,
+                    materializedIndexProperties, requiredProperties);
+
             treeSource = headIndex.isPresent() ? repo.indexDatabase() : repo.objectDatabase();
         }
 
@@ -296,7 +300,7 @@ public class FeatureReaderBuilder {
         diffOp.setDefaultMetadataId(featureTypeId);
         diffOp.setPreserveIterationOrder(shallPreserveIterationOrder());
         diffOp.setPathFilter(resolveFidFilter(nativeFilter));
-        diffOp.setCustomFilter(resolveNodeRefFilter(nativeFilter, materializedProperties));
+        diffOp.setCustomFilter(resolveNodeRefFilter(nativeFilter, materializedIndexProperties,filterIsFullySupportedByIndex));
         diffOp.setBoundsFilter(resolveBoundsFilter(nativeFilter, newFeatureTypeTree, treeSource));
         diffOp.setChangeTypeFilter(resolveChangeType());
         diffOp.setOldTree(oldFeatureTypeTree);
@@ -317,7 +321,7 @@ public class FeatureReaderBuilder {
         AutoCloseableIterator<NodeRef> featureRefs = toFeatureRefs(diffs, changeType);
 
         // post-processing
-        if (filterIsFullySupported) {
+        if (filterIsFullySupportedByIndex) {
             featureRefs = applyOffsetAndLimit(featureRefs);
         }
 
@@ -337,7 +341,7 @@ public class FeatureReaderBuilder {
             features = retriever.getGeoToolsFeatures(featureRefs, fullSchema, geometryFactory);
         }
 
-        if (!filterIsFullySupported) {
+        if (!filterIsFullySupportedByIndex) {
             PostFilter filterPredicate = new PostFilter(nativeFilter);
             features = AutoCloseableIterator.filter(features, filterPredicate);
             features = applyOffsetAndLimit(features);
@@ -447,15 +451,31 @@ public class FeatureReaderBuilder {
         return Optional.fromNullable(index);
     }
 
-    private boolean filterIsFullySupported(Filter nativeFilter,
-            boolean indexContainsAllRequiredProperties) {
+     static boolean filterIsFullySupported(Filter nativeFilter,
+                                    Set<String> materializedProperties,
+                                    Set<String> filterProperties) {
 
-        boolean filterSupported = Filter.INCLUDE.equals(nativeFilter) || //
-                nativeFilter instanceof BBOX || //
-                nativeFilter instanceof Id || //
-                indexContainsAllRequiredProperties;
+        if (Filter.INCLUDE.equals(nativeFilter) ||
+                nativeFilter instanceof BBOX ||
+                nativeFilter instanceof Id) {
+            return true; // simple case
+        }
 
-        return filterSupported;
+        if (materializedProperties.containsAll(filterProperties)) {
+            return true; // this is unlikely to happen, unless geom is in index
+        }
+
+         Set<String> missingAttributes = Sets.difference(filterProperties, materializedProperties);
+
+        if (missingAttributes.size() > 1) {
+            return false; // 2+ attributes missing.  We can possibly handle the geom, but not 2+
+        }
+
+        String missingAttribute = missingAttributes.iterator().next(); //there's exactly 1
+        VerifySimpleBBoxUsage visitor = new VerifySimpleBBoxUsage(missingAttribute);
+        nativeFilter.accept(visitor, null);
+
+        return  visitor.isSimple();
     }
 
     private Set<String> resolveMaterializedProperties(Optional<Index> index) {
@@ -472,7 +492,7 @@ public class FeatureReaderBuilder {
      * properties requested by {@link #propertyNames} and any other property needed to evaluate the
      * {@link #filter} in-process.
      */
-    private Set<String> resolveRequiredProperties(Filter nativeFilter) {
+     Set<String> resolveRequiredProperties(Filter nativeFilter) {
         if (outputSchemaPropertyNames == Query.ALL_NAMES) {
             return fullSchemaAttributeNames;
         }
@@ -585,12 +605,14 @@ public class FeatureReaderBuilder {
 
     @VisibleForTesting
     Predicate<Bounded> resolveNodeRefFilter(final Filter filter,
-            final Set<String> materializedProperties) {
+            final Set<String> materializedProperties, boolean indexFullySupportsQuery) {
 
         Predicate<Bounded> preFilter = new PreFilterBuilder(materializedProperties).build(filter);
 
         final boolean ignore = Boolean.getBoolean("geogig.ignorescreenmap");
-        if (screenMap != null && !ignore) {
+        //if the index is not fully supported, do not apply the screenmap filter at this stage
+        // otherwise we will remove too many features
+        if (screenMap != null && !ignore && indexFullySupportsQuery) {
             Predicate<Bounded> screenMapFilter;
             screenMapFilter = new ScreenMapPredicate(screenMap);
             preFilter = Predicates.and(preFilter, screenMapFilter);
@@ -630,5 +652,58 @@ public class FeatureReaderBuilder {
         // in-process so there's no point in forcing the iteration order here
         // preserveIterationOrder |= sortBy != null && sortBy.length > 0;
         return preserveIterationOrder;
+    }
+
+
+    public static class VerifySimpleBBoxUsage extends AbstractFilterVisitor {
+
+        public boolean isUsedInGeometryExpression = false;
+        public boolean isUsedInBBoxExpression = false;
+        public boolean isUsedInNonBBoxExpression = false;
+
+        public boolean isComplexGeomExpressions = false;
+
+        String propertyName;
+
+        public VerifySimpleBBoxUsage(String propertyName) {
+            super();
+            this.propertyName = propertyName;
+        }
+
+        public boolean isSimple() {
+            if (isComplexGeomExpressions || isUsedInNonBBoxExpression)
+                return false;
+
+            return isUsedInGeometryExpression && isUsedInBBoxExpression;
+        }
+
+        @Override
+        protected Object visit(BinarySpatialOperator filter, Object data) {
+            String[] attributes = DataUtilities.attributeNames(filter);
+
+            if (attributes.length == 0) {
+                return filter; // this should have been optimized away
+            }
+
+            if (attributes.length > 1) {
+                isComplexGeomExpressions = true; //fail -- to complex
+                return filter;
+            }
+
+            String attribute = attributes[0];
+
+            if (!attribute.equals(propertyName)) {
+                return filter; // not our attribute
+            }
+            isUsedInGeometryExpression = true;
+
+            if (filter instanceof BBOX) {
+                isUsedInBBoxExpression = true;
+                return filter;
+            }
+            //bad
+            isUsedInNonBBoxExpression = true;
+            return filter;
+        }
     }
 }


### PR DESCRIPTION
1. ScreenMapPredicate wasn't threadsafe - moved some operations around so it is
2. ScreenMap isn't threadsafe - added protection for it
3. When you turn off (-Dgeogig.ignorescreenmap=true) the geogig screenmap, it doesn't advertise in it supported hints (this allows the renderer to use its version).
4. Made ScreenMapPredicate stats collection optional (default off).
5. Made ScreenMapPredicate.Stats threadsafe