### PR TITLE
add two-stage ScreenMap to FeatureReaderBuilder

### DIFF
--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureScreenMapPredicate.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureScreenMapPredicate.java
@@ -21,7 +21,7 @@ import org.opengis.referencing.operation.TransformException;
  * This is a simple class that is very much like the ScreenMapPredicate class.
  * This works on SimpleFeatures only.
  */
-public class FeatureScreenMapPredicate implements Predicate<SimpleFeature> {
+class FeatureScreenMapPredicate implements Predicate<SimpleFeature> {
     ScreenMap screenMap;
 
     public FeatureScreenMapPredicate(ScreenMap screenMap) {

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureScreenMapPredicate.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureScreenMapPredicate.java
@@ -1,0 +1,55 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import com.google.common.base.Predicate;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import org.geotools.renderer.ScreenMap;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.referencing.operation.TransformException;
+
+
+/**
+ * This is a simple class that is very much like the ScreenMapPredicate class.
+ * This works on SimpleFeatures only.
+ */
+public class FeatureScreenMapPredicate implements Predicate<SimpleFeature> {
+    ScreenMap screenMap;
+
+    public FeatureScreenMapPredicate(ScreenMap screenMap) {
+        this.screenMap = screenMap;
+    }
+
+
+    /**
+     * Filter out small features (<pixel) where that pixel already has a small feature in it.
+     */
+    @Override
+    public boolean apply(SimpleFeature feature) {
+        Envelope e = ((Geometry) feature.getDefaultGeometry()).getEnvelopeInternal();
+        //only do work if its a small geometry
+        if (screenMap.canSimplify(e)) {
+            // screenmap isn't thread safe
+            // Both this and ScreenMapPredicate syncronize on the underlying ScreenMap object.
+            // However, i don't think its possible for both to be running at the same
+            // time (screen map filter will either occur on the index or the actual features)
+            synchronized (screenMap) {
+                try {
+                    return !screenMap.checkAndSet(e);
+                } catch (TransformException e1) {
+                    e1.printStackTrace();
+                    return true;
+                }
+            }
+        }
+        return true;
+    }
+}

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapGeometryReplacer.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapGeometryReplacer.java
@@ -1,0 +1,75 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import com.google.common.base.Function;
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.Point;
+import org.geotools.feature.simple.SimpleFeatureImpl;
+import org.geotools.renderer.ScreenMap;
+import org.opengis.feature.simple.SimpleFeature;
+
+
+/**
+ * This is a simple function that, if a geometry is "small" (fits in a pixel - as defined by
+ * the screenmap) then the geometry is replaced with one that is a full pixel's size.
+ * <p>
+ * This is the same behaviour as the StreamingRenderer and ShapefileReader.  If you don't do this
+ * the resulting image looks "funny" due to anti-aliasing.
+ * <p>
+ * NOTE: its possible for the ScreenMapGeometryReplacer to be running at the same time
+ *       as the ScreenMapPredicate or FeatureScreenMapPredicate.  However, the features
+ *       handed to this class will have already go through the filtering.
+ */
+public class ScreenMapGeometryReplacer implements Function<SimpleFeature, SimpleFeature> {
+
+    ScreenMap screenMap;
+
+    public ScreenMapGeometryReplacer(ScreenMap screenMap) {
+        this.screenMap = screenMap;
+    }
+
+    /**
+     * if the features is fully inside a pixel (screenMap.canSimplify()), then
+     * we create a new feature with a geometry that takes up the entire pixels
+     * (screenMap.getSimplifiedShape()).
+     * <p>
+     * NOTE: this makes a copy of the original feature - we could make a feature that
+     * wraps the original geometry.  However, that can get quite complex.
+     * <p>
+     * TODO: allow to specify the geometry attribute.
+     *
+     * @param feature
+     * @return
+     */
+    @Override
+    public SimpleFeature apply(SimpleFeature feature) {
+        Geometry g = (Geometry) feature.getDefaultGeometry();
+        if (g instanceof Point)
+            return feature; //cannot simplify a point
+        Envelope e = g.getEnvelopeInternal();
+        // this is safe to call multi-threaded
+        if (!screenMap.canSimplify(e)) {
+            return feature;
+        } else {
+            Geometry newGeom = screenMap.getSimplifiedShape(
+                    e.getMinX(), e.getMinY(),
+                    e.getMaxX(), e.getMaxY(),
+                    g.getFactory(), g.getClass());
+            SimpleFeatureImpl newFeat = new SimpleFeatureImpl(
+                    feature.getAttributes(),
+                    feature.getFeatureType(),
+                    feature.getIdentifier());
+            newFeat.setDefaultGeometry(newGeom);
+            return newFeat;
+        }
+    }
+}

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapGeometryReplacer.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapGeometryReplacer.java
@@ -29,7 +29,7 @@ import org.opengis.feature.simple.SimpleFeature;
  *       as the ScreenMapPredicate or FeatureScreenMapPredicate.  However, the features
  *       handed to this class will have already go through the filtering.
  */
-public class ScreenMapGeometryReplacer implements Function<SimpleFeature, SimpleFeature> {
+ class ScreenMapGeometryReplacer implements Function<SimpleFeature, SimpleFeature> {
 
     ScreenMap screenMap;
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapPredicate.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ScreenMapPredicate.java
@@ -104,7 +104,7 @@ class ScreenMapPredicate implements Predicate<Bounded> {
         //canSimplify is thread-safe
         if (screenMap.canSimplify(envelope)) {
             //these aren't thread safe
-            synchronized (this) {
+            synchronized (screenMap) {
                 try {
                     if (b instanceof NodeRef && ((NodeRef) b).getType() == TYPE.FEATURE) {
                         skip = screenMap.checkAndSet(envelope);

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilderTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilderTest.java
@@ -25,7 +25,6 @@ import org.geotools.factory.CommonFactoryFinder;
 import org.geotools.factory.Hints;
 import org.geotools.filter.text.cql2.CQLException;
 import org.geotools.filter.text.ecql.ECQL;
-import org.geotools.geometry.Envelope2D;
 import org.geotools.renderer.ScreenMap;
 import org.junit.After;
 import org.junit.Test;
@@ -54,7 +53,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.vividsolutions.jts.geom.Geometry;
 import com.vividsolutions.jts.geom.GeometryFactory;
-import org.opengis.geometry.BoundingBox;
 
 public class FeatureReaderBuilderTest extends RepositoryTestCase {
 
@@ -281,7 +279,7 @@ public class FeatureReaderBuilderTest extends RepositoryTestCase {
 
         Filter filter = ff.and(unsupported, supported);
 
-        Predicate<Bounded> preFilter = builder.resolveNodeRefFilter(filter, ImmutableSet.of("ip"), true);
+        Predicate<Bounded> preFilter = builder.createIndexPreFilter(filter, ImmutableSet.of("ip"), true);
         assertTrue(preFilter instanceof PreFilter);
         assertEquals(supported, ((PreFilter)preFilter).filter);
         

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ScreenMapTests.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ScreenMapTests.java
@@ -1,0 +1,87 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+
+package org.locationtech.geogig.geotools.data.reader;
+
+
+import com.vividsolutions.jts.geom.Envelope;
+import com.vividsolutions.jts.geom.Geometry;
+import com.vividsolutions.jts.geom.LineString;
+import org.geotools.data.DataUtilities;
+import org.geotools.feature.SchemaException;
+import org.geotools.referencing.operation.transform.IdentityTransform;
+import org.geotools.renderer.ScreenMap;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.referencing.operation.TransformException;
+
+
+import static org.junit.Assert.*;
+
+public class ScreenMapTests {
+
+    @Test
+    public void testFeatureScreenMapPredicate() throws SchemaException {
+        SimpleFeatureType lineType = DataUtilities.createType("LINE", "centerline:LineString,name:\"\",id:0");
+        SimpleFeature feature1 = DataUtilities.createFeature(lineType, "LINESTRING(0.1 0.1, 0.9 0.9)|dave|7");
+        SimpleFeature feature2 = DataUtilities.createFeature(lineType, "LINESTRING(0.1 0.1, 0.9 0.9)|dave|7");
+
+        ScreenMap sm = new ScreenMap(0, 0, 100, 100, IdentityTransform.create(2));
+        sm.setSpans(1, 1);
+
+        //both are in the same pixel
+        assertTrue(sm.canSimplify(((Geometry) feature1.getDefaultGeometry()).getEnvelopeInternal()));
+        assertTrue(sm.canSimplify(((Geometry) feature2.getDefaultGeometry()).getEnvelopeInternal()));
+
+        FeatureScreenMapPredicate smp = new FeatureScreenMapPredicate(sm);
+
+        //first one goes through
+        assertTrue(smp.apply(feature1));
+        //second one doesn't
+        assertFalse(smp.apply(feature2));
+    }
+
+    @Test
+    public void testGeometryReplacer() throws SchemaException, TransformException {
+        SimpleFeatureType lineType = DataUtilities.createType("LINE", "centerline:LineString,name:\"\",id:0");
+        SimpleFeature feature1 = DataUtilities.createFeature(lineType, "LINESTRING(0.1 0.1, 0.9 0.9)|dave|7");
+        //this feature isn't affected
+        SimpleFeature feature2 = DataUtilities.createFeature(lineType, "LINESTRING(0 0,10 10)|dave|7");
+
+
+        ScreenMap sm = new ScreenMap(0, 0, 100, 100, IdentityTransform.create(2));
+        sm.setSpans(1, 1);
+
+        //prep
+        // sm.checkAndSet( ((Geometry) feature1.getDefaultGeometry()).getEnvelopeInternal()   );
+
+        ScreenMapGeometryReplacer replacer = new ScreenMapGeometryReplacer(sm);
+
+        SimpleFeature feature1b = replacer.apply(feature1);
+        assertNotEquals(feature1, feature1b);
+        Geometry newGeom = (Geometry) feature1b.getDefaultGeometry();
+        assertTrue(newGeom instanceof LineString);
+
+        Envelope newGeomEnv = newGeom.getEnvelopeInternal();
+        assertTrue(0 == newGeomEnv.getMinX());
+        assertTrue(0 == newGeomEnv.getMinY());
+
+
+        assertTrue(1 == newGeomEnv.getMaxX());
+        assertTrue(1 == newGeomEnv.getMaxY());
+
+
+        SimpleFeature feature2b = replacer.apply(feature2);
+        assertEquals(feature2, feature2b);
+
+
+    }
+}


### PR DESCRIPTION
This adds improvements to the FeatureReaderBuilder use of the ScreenMap.

The ScreenMap filter will either run on the;
a. Index - very performant can only occur if the query Filter is can fully run on the index.  If it cannot, then it could "pass-through" a feature that will be removed by the PostFilter, resulting in holes in the result.
b. Actual Features - if the index cannot perform the filtering, then its done on the actual features.

Secondly, after Filter, a geometry replacement is done (cf StreamingRenderer and ShpFeatureReader) that replaces the "small" geometry with a pixel-sized geometry.  This tends to "fill" out the resulting map since we are only drawing one small feature/pixel. 