### PR TITLE
Reduce number of db roundtrips when using a FeatureSource/Reader

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/Context.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/Context.java
@@ -18,6 +18,8 @@ import org.locationtech.geogig.storage.ObjectDatabase;
 import org.locationtech.geogig.storage.PluginDefaults;
 import org.locationtech.geogig.storage.RefDatabase;
 
+import com.google.common.annotations.Beta;
+
 /**
  * A context object for a single repository, provides access to the different repository objects,
  * and a factory method for commands.
@@ -101,4 +103,6 @@ public interface Context {
      */
     public PluginDefaults pluginDefaults();
 
+    @Beta
+    public Context snapshot();
 }

--- a/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
@@ -77,7 +77,7 @@ public class GeogigModule extends AbstractModule {
 
         bind(ExecutorService.class).toProvider(fineGrainedExecutor).in(Scopes.SINGLETON);
 
-        bind(Context.class).to(GuiceInjector.class).in(Scopes.SINGLETON);
+        bind(Context.class).to(GuiceContext.class).in(Scopes.SINGLETON);
 
         Multibinder.newSetBinder(binder(), Decorator.class);
         bind(DecoratorProvider.class).in(Scopes.SINGLETON);

--- a/src/core/src/main/java/org/locationtech/geogig/di/GuiceContext.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/GuiceContext.java
@@ -15,6 +15,8 @@ import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.StagingArea;
 import org.locationtech.geogig.repository.WorkingTree;
+import org.locationtech.geogig.repository.impl.StagingAreaImpl;
+import org.locationtech.geogig.repository.impl.WorkingTreeImpl;
 import org.locationtech.geogig.storage.BlobStore;
 import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConflictsDatabase;
@@ -33,7 +35,7 @@ import com.google.inject.Provider;
  * @see Context
  * @see AbstractGeoGigOp
  */
-public class GuiceInjector implements Context {
+public class GuiceContext implements Context {
 
     private com.google.inject.Injector guiceInjector;
 
@@ -43,7 +45,7 @@ public class GuiceInjector implements Context {
      * @param injector the injector which has commands bound to it
      */
     @Inject
-    public GuiceInjector(com.google.inject.Injector injector) {
+    public GuiceContext(com.google.inject.Injector injector) {
         this.guiceInjector = injector;
     }
 
@@ -143,5 +145,101 @@ public class GuiceInjector implements Context {
     @Override
     public BlobStore blobStore() {
         return getDecoratedInstance(objectDatabase().getBlobStore());
+    }
+
+    @Override
+    public Context snapshot() {
+        return new SnapshotContext(this);
+    }
+
+    private static class SnapshotContext implements Context {
+
+        private Context context;
+
+        private RefDatabaseSnapshot refsSnapshot;
+
+        public SnapshotContext(Context context) {
+            this.context = context;
+            this.refsSnapshot = new RefDatabaseSnapshot(context.refDatabase());
+            this.refsSnapshot.create();
+        }
+
+        @Override
+        public <T extends AbstractGeoGigOp<?>> T command(Class<T> commandClass) {
+            T command = context.command(commandClass);
+            command.setContext(this);
+            return command;
+        }
+
+        @Override
+        public WorkingTree workingTree() {
+            return new WorkingTreeImpl(this);
+        }
+
+        @Override
+        public StagingArea index() {
+            return index();
+        }
+
+        @Override
+        public StagingArea stagingArea() {
+            return new StagingAreaImpl(this);
+        }
+
+        @Override
+        public RefDatabase refDatabase() {
+            return refsSnapshot;
+        }
+
+        @Override
+        public Context snapshot() {
+            return this;
+        }
+        //////////////// END OF DECORATED METHODS /////////////////
+
+        @Override
+        public Platform platform() {
+            return context.platform();
+        }
+
+        @Override
+        public ObjectDatabase objectDatabase() {
+            return context.objectDatabase();
+        }
+
+        @Override
+        public IndexDatabase indexDatabase() {
+            return context.indexDatabase();
+        }
+
+        @Override
+        public ConflictsDatabase conflictsDatabase() {
+            return context.conflictsDatabase();
+        }
+
+        @Override
+        public ConfigDatabase configDatabase() {
+            return context.configDatabase();
+        }
+
+        @Override
+        public GraphDatabase graphDatabase() {
+            return context.graphDatabase();
+        }
+
+        @Override
+        public Repository repository() {
+            return context.repository();
+        }
+
+        @Override
+        public BlobStore blobStore() {
+            return context.blobStore();
+        }
+
+        @Override
+        public PluginDefaults pluginDefaults() {
+            return context.pluginDefaults();
+        }
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/di/RefDatabaseSnapshot.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/RefDatabaseSnapshot.java
@@ -1,0 +1,105 @@
+package org.locationtech.geogig.di;
+
+import java.util.Map;
+import java.util.concurrent.TimeoutException;
+
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+import org.locationtech.geogig.storage.RefDatabase;
+import org.locationtech.geogig.storage.memory.HeapRefDatabase;
+
+import com.google.common.base.Preconditions;
+
+class RefDatabaseSnapshot implements RefDatabase {
+
+    private final RefDatabase actual;
+
+    private HeapRefDatabase snapshot;
+
+    public RefDatabaseSnapshot(RefDatabase actual) {
+        Preconditions.checkArgument(!(actual instanceof RefDatabaseSnapshot));
+        this.actual = actual;
+        this.snapshot = new HeapRefDatabase();
+    }
+
+    @Override
+    public void lock() throws TimeoutException {
+        actual.lock();
+    }
+
+    @Override
+    public void configure() throws RepositoryConnectionException {
+        actual.configure();
+    }
+
+    @Override
+    public boolean checkConfig() throws RepositoryConnectionException {
+        return actual.checkConfig();
+    }
+
+    @Override
+    public void unlock() {
+        actual.unlock();
+    }
+
+    @Override
+    public void create() {
+        actual.create();
+        snapshot.create();
+        snapshot.putAll(actual.getAll());
+    }
+
+    @Override
+    public void close() {
+        actual.close();
+        snapshot.close();
+    }
+
+    @Override
+    public String getRef(String name) {
+        String val = snapshot.getRef(name);
+        return val;
+    }
+
+    @Override
+    public String getSymRef(String name) {
+        String val = snapshot.getSymRef(name);
+        return val;
+    }
+
+    @Override
+    public void putRef(String refName, String refValue) {
+        actual.putRef(refName, refValue);
+        snapshot.putRef(refName, refValue);
+    }
+
+    @Override
+    public void putSymRef(String name, String val) {
+        actual.putSymRef(name, val);
+        snapshot.putSymRef(name, val);
+    }
+
+    @Override
+    public String remove(String refName) {
+        String ret = actual.remove(refName);
+        snapshot.remove(refName);
+        return ret;
+    }
+
+    @Override
+    public Map<String, String> getAll() {
+        return snapshot.getAll();
+    }
+
+    @Override
+    public Map<String, String> getAll(String prefix) {
+        return snapshot.getAll(prefix);
+    }
+
+    @Override
+    public Map<String, String> removeAll(String namespace) {
+        Map<String, String> ret = actual.removeAll(namespace);
+        snapshot.removeAll(namespace);
+        return ret;
+    }
+
+}

--- a/src/core/src/main/java/org/locationtech/geogig/repository/impl/GeogigTransaction.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/impl/GeogigTransaction.java
@@ -226,4 +226,9 @@ public class GeogigTransaction implements Context {
         return ImmutableSet.copyOf(changedRefs);
     }
 
+    @Override
+    public Context snapshot() {
+        return this;
+    }
+
 }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapRefDatabase.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/memory/HeapRefDatabase.java
@@ -191,4 +191,8 @@ public class HeapRefDatabase extends AbstractRefDatabase {
     public boolean checkConfig() {
         return true;
     }
+
+    public void putAll(Map<String, String> all) {
+        this.refs.putAll(all);
+    }
 }

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
@@ -9,6 +9,8 @@
  */
 package org.locationtech.geogig.geotools.data;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.io.IOException;
 import java.util.Set;
 
@@ -63,18 +65,8 @@ class GeogigFeatureSource extends ContentFeatureSource {
      * @param entry
      */
     public GeogigFeatureSource(ContentEntry entry) {
-        this(entry, (Query) null);
-    }
-
-    /**
-     * <b>Precondition</b>: {@code entry.getDataStore() instanceof GeoGigDataStore}
-     * 
-     * @param entry
-     * @param query optional "definition query" making this feature source a "view"
-     */
-    public GeogigFeatureSource(ContentEntry entry, @Nullable Query query) {
-        super(entry, query);
-        Preconditions.checkArgument(entry.getDataStore() instanceof GeoGigDataStore);
+        super(entry, Query.ALL);
+        checkArgument(entry.getDataStore() instanceof GeoGigDataStore);
     }
 
     /**
@@ -84,7 +76,8 @@ class GeogigFeatureSource extends ContentFeatureSource {
     @Override
     protected void addHints(Set<Hints.Key> hints) {
         hints.add(Hints.FEATURE_DETACHED);
-        // if the user turned off the screenmap, then don't advertise it (the renderer will do its own)
+        // if the user turned off the screenmap, then don't advertise it (the renderer will do its
+        // own)
         final boolean ignorescreenmap = Boolean.getBoolean("geogig.ignorescreenmap");
         if (!ignorescreenmap)
             hints.add(Hints.SCREENMAP);

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureStore.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureStore.java
@@ -72,11 +72,10 @@ class GeogigFeatureStore extends ContentFeatureStore {
 
     /**
      * @param entry
-     * @param query
      */
     public GeogigFeatureStore(ContentEntry entry) {
         super(entry, (Query) null);
-        delegate = new GeogigFeatureSource(entry, query) {
+        delegate = new GeogigFeatureSource(entry) {
             @Override
             public void setTransaction(Transaction transaction) {
                 super.setTransaction(transaction);

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/stresstest/DataStoreConcurrencyTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/stresstest/DataStoreConcurrencyTest.java
@@ -56,6 +56,8 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 public class DataStoreConcurrencyTest {
 
+    private Context context;
+
     private GeoGigDataStore store;
 
     private static final SimpleFeatureType pointType;
@@ -88,7 +90,7 @@ public class DataStoreConcurrencyTest {
         platform.setUserHome(userHomeDirectory);
 
         GlobalContextBuilder.builder(new TestContextBuilder(platform));
-        Context context = GlobalContextBuilder.builder().build(new Hints().platform(platform));
+        context = GlobalContextBuilder.builder().build(new Hints().platform(platform));
 
         GeoGIG repo = new GeoGIG(context);
         repo.command(InitOp.class).call();
@@ -106,7 +108,7 @@ public class DataStoreConcurrencyTest {
 
         readThreads = Executors.newFixedThreadPool(readThreadCount,
                 new ThreadFactoryBuilder().setNameFormat("read-thread-%d").build());
-        initialCommitCount = copyOf(store.getGeogig().command(LogOp.class).call()).size();
+        initialCommitCount = copyOf(context.command(LogOp.class).call()).size();
     }
 
     @After
@@ -130,7 +132,7 @@ public class DataStoreConcurrencyTest {
             assertEquals(insertsPerTask, f.get().intValue());
         }
 
-        List<RevCommit> commits = copyOf(store.getGeogig().command(LogOp.class).call());
+        List<RevCommit> commits = copyOf(context.command(LogOp.class).call());
         final int expectedCommitCount = initialCommitCount + insertsPerTask * writeThreadCount;
         assertEquals(expectedCommitCount, commits.size());
     }
@@ -169,7 +171,7 @@ public class DataStoreConcurrencyTest {
             assertEquals(readsPerTask, f.get().intValue());
         }
 
-        List<RevCommit> commits = copyOf(store.getGeogig().command(LogOp.class).call());
+        List<RevCommit> commits = copyOf(context.command(LogOp.class).call());
         final int expectedCommitCount = insertsPerTask + initialCommitCount
                 + insertsPerTask * writeThreadCount;
         assertEquals(expectedCommitCount, commits.size());

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/DataSourceManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/DataSourceManager.java
@@ -36,7 +36,8 @@ class DataSourceManager extends ConnectionManager<Environment, DataSource> {
     protected DataSource connect(Environment config) {
         HikariConfig hc = new HikariConfig();
         hc.setConnectionInitSql("SELECT NOW()");
-        hc.setConnectionTestQuery("SELECT NOW()");
+        // no need to set a validation query, connections auto validate
+        // hc.setConnectionTestQuery("SELECT NOW()");
         hc.setDriverClassName("org.postgresql.Driver");
 
         final String jdbcUrl = getUrl(config.connectionConfig);


### PR DESCRIPTION
Adds experimental Context.snapshot():Context method to use
a view of the repository at that point in time, by cacheing
all the values in the RefDatabase.

This reduces the number of roundtrips to the RefsDatabase
for a single GeoServer GetMap request from 21 to just 1, which
is especially cumbersome for the postgres backend on slow-ish
networks.