### PR TITLE
allow FeatureReaderBuilder to return property-reduced features 

### DIFF
--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -14,12 +14,10 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.base.Predicates.notNull;
 
-import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ReTypingFeatureReader.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/ReTypingFeatureReader.java
@@ -1,0 +1,75 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.geotools.data.FeatureReader;
+import org.geotools.feature.simple.SimpleFeatureImpl;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+import org.opengis.filter.identity.FeatureId;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+/**
+ * provides functionality for xforming features from one feature type to another.
+ * The new feature type is a sub-set of the attributes in the original feature type.
+ */
+public class ReTypingFeatureReader
+        implements FeatureReader<SimpleFeatureType, SimpleFeature> {
+
+    FeatureReader<SimpleFeatureType, SimpleFeature> underlying;
+    SimpleFeatureType underlyingSchema;
+    SimpleFeatureType newSchema;
+    int[] indexesIntoUnderlyingAttributes;
+
+    public ReTypingFeatureReader(FeatureReader<SimpleFeatureType, SimpleFeature> underlying, SimpleFeatureType underlyingSchema, SimpleFeatureType newSchema) {
+        this.underlying = underlying;
+        this.underlyingSchema = underlyingSchema;
+        this.newSchema = newSchema;
+
+        indexesIntoUnderlyingAttributes = new int[newSchema.getAttributeCount()];
+        for (int t = 0; t < indexesIntoUnderlyingAttributes.length; t++) {
+            indexesIntoUnderlyingAttributes[t] = underlyingSchema.indexOf(newSchema.getDescriptor(t).getName());
+        }
+    }
+
+    @Override
+    public SimpleFeatureType getFeatureType() {
+        return newSchema;
+    }
+
+    @Override
+    public SimpleFeature next() throws IOException, IllegalArgumentException, NoSuchElementException {
+        SimpleFeature underlyingFeature = underlying.next();
+        FeatureId id = underlyingFeature.getIdentifier();
+        List<Object> atts = new ArrayList<>(indexesIntoUnderlyingAttributes.length);
+        for (int t = 0; t < indexesIntoUnderlyingAttributes.length; t++) {
+            atts.add(underlyingFeature.getAttribute(indexesIntoUnderlyingAttributes[t]));
+        }
+        SimpleFeature result = new SimpleFeatureImpl(atts, newSchema, id);
+
+        //TODO: Userdata
+
+        return result;
+    }
+
+    @Override
+    public boolean hasNext() throws IOException {
+        return underlying.hasNext();
+    }
+
+    @Override
+    public void close() throws IOException {
+        underlying.close();
+    }
+}

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ReTypingFeatureReaderTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ReTypingFeatureReaderTest.java
@@ -1,0 +1,58 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.geotools.data.reader;
+
+
+import com.vividsolutions.jts.geom.Coordinate;
+import com.vividsolutions.jts.geom.GeometryFactory;
+import org.geotools.data.DataUtilities;
+import org.geotools.data.FeatureReader;
+import org.junit.Test;
+import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.simple.SimpleFeatureType;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+public class ReTypingFeatureReaderTest {
+
+    @Test
+    public void testRetyping() throws Exception {
+        String typeSchema1 = "geom:Point,tag:String,featureNumber:Integer";
+        String typeSchema2 = "geom:Point,featureNumber:Integer";
+
+        SimpleFeatureType featureType1 = DataUtilities.createType("typeSchema1", typeSchema1);
+        SimpleFeatureType featureType2 = DataUtilities.createType("typeSchema2", typeSchema2);
+        GeometryFactory gf = new GeometryFactory();
+
+
+        SimpleFeature f = DataUtilities.template(featureType1, "id.1");
+        f.setAttribute("geom", gf.createPoint(new Coordinate(1, 2)));
+        f.setAttribute("tag", "mytag");
+        f.setAttribute("featureNumber", 123);
+
+        FeatureReader<SimpleFeatureType, SimpleFeature> underlying = DataUtilities.reader(new SimpleFeature[]{f});
+
+        ReTypingFeatureReader retyping = new ReTypingFeatureReader(underlying, featureType1, featureType2);
+
+        assertTrue(retyping.hasNext());
+        SimpleFeature f2 = retyping.next();
+
+        assertEquals(f2.getID(), f.getID());
+        assertEquals(f2.getAttribute("geom"), f.getAttribute("geom"));
+        assertEquals(f2.getAttribute("featureNumber"), f.getAttribute("featureNumber"));
+
+        assertNull(f2.getAttribute("tag"));
+
+        assertFalse(retyping.hasNext());
+    }
+}


### PR DESCRIPTION
The geogig FeatureReaderBuilder currently always returns all the properties in the feature - even if the underlying Query only asks for a few of the properties.  This change just retypes the resulting features so they only have the requested properties.

If you don't do this, the WFS doesn't correctly return features when a request comes in for a property-reduced Query/GetFeatures.

@groldan -- not sure if this is the correct way to do this given the laziness of the features.  It might be possible to do retyping at an earlier stage (i.e. instead of creating the full features in the first place).