### PR TITLE
Fix a bug that made updates to spatial index trees contain the old and new nodes

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGTreeBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGTreeBuilder.java
@@ -137,8 +137,8 @@ public class DAGTreeBuilder {
 
         SharedState state = new SharedState(targetStore, clusteringStrategy, listener);
 
-        DAG root = clusteringStrategy.buildRoot();
-        TreeId rootId = clusteringStrategy.getRootId();
+        final DAG root = clusteringStrategy.buildRoot();
+        final TreeId rootId = root.getId();
         final int baseDepth = rootId.depthLength();
         TreeBuildTask task = new TreeBuildTask(state, root, baseDepth);
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/TreeId.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/TreeId.java
@@ -76,4 +76,15 @@ final class TreeId implements Comparable<TreeId>, Serializable {
     public String toString() {
         return Arrays.toString(bucketIndicesByDepth);
     }
+
+    /**
+     * Factory method to create a child tree id of this one at with the given bucket id
+     */
+    public TreeId newChild(int bucketId) {
+        int depthLength = depthLength();
+        byte[] childIndices = new byte[depthLength + 1];
+        System.arraycopy(this.bucketIndicesByDepth, 0, childIndices, 0, depthLength);
+        childIndices[depthLength] = (byte) bucketId;
+        return new TreeId(childIndices);
+    }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/model/impl/QuadTreeBuilderTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/impl/QuadTreeBuilderTest.java
@@ -231,8 +231,7 @@ public class QuadTreeBuilderTest extends RevTreeBuilderTest {
 
         final RevTree tree = createQuadTree(maxBounds, nodes).build();
 
-        QuadTreeBuilder builder = QuadTreeBuilder.create(objectStore, objectStore, tree,
-                maxBounds);
+        QuadTreeBuilder builder = QuadTreeBuilder.create(objectStore, objectStore, tree, maxBounds);
         // collect some keys to remove
         final Set<Node> removedNodes = new HashSet<>();
         {
@@ -268,8 +267,7 @@ public class QuadTreeBuilderTest extends RevTreeBuilderTest {
 
         final RevTree tree = createQuadTree(maxBounds, origNodes).build();
 
-        QuadTreeBuilder builder = QuadTreeBuilder.create(objectStore, objectStore, tree,
-                maxBounds);
+        QuadTreeBuilder builder = QuadTreeBuilder.create(objectStore, objectStore, tree, maxBounds);
 
         final Set<Node> removedNodes = new HashSet<>();
         final Set<Node> addedNodes = new HashSet<>();
@@ -416,5 +414,4 @@ public class QuadTreeBuilderTest extends RevTreeBuilderTest {
         }
         return qtree;
     }
-
 }

--- a/src/core/src/test/java/org/locationtech/geogig/model/impl/RevTreeBuilderTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/impl/RevTreeBuilderTest.java
@@ -322,9 +322,13 @@ public abstract class RevTreeBuilderTest {
      *         {@code bounds = [i, i+1, i, i+1]}
      */
     protected static Node node(int i) {
+        Envelope bounds = new Envelope(i, i + 1, i, i + 1);
+        return node(i, bounds);
+    }
+
+    protected static Node node(int i, Envelope bounds) {
         String key = "a" + String.valueOf(i);
         ObjectId oid = RevObjectTestSupport.hashString(key);
-        Envelope bounds = new Envelope(i, i + 1, i, i + 1);
         Node node = Node.create(key, oid, ObjectId.NULL, TYPE.FEATURE, bounds);
         return node;
     }


### PR DESCRIPTION
QuadTreeClusteringStrategy.buildRoot() collapses top level DAG's
that are composed of one single bucket to the shallowest child DAG
that's either a leaf tree or has more than one bucket.

This is so many nodes that fall on the same quadrant do not produce
unnecessary deep trees.

When such a RevTree representing a spatial index is updated (that is,
a new one is created based on a previous one), the original structure
needs to be recreated (the top level one-bucket DAGs) so that node updates
can subsequently find their path to the tree structure and be correctly
updated.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>