### PR TITLE
Create FeatureSources that respect the provided namespace and definit…

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/data/retrieve/BulkFeatureRetriever.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/retrieve/BulkFeatureRetriever.java
@@ -11,6 +11,7 @@ package org.locationtech.geogig.data.retrieve;
 
 import java.util.Iterator;
 
+import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.data.FeatureBuilder;
 import org.locationtech.geogig.model.NodeRef;
 import org.locationtech.geogig.model.RevFeature;
@@ -20,6 +21,7 @@ import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.ObjectInfo;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.opengis.feature.simple.SimpleFeature;
+import org.opengis.feature.type.Name;
 
 import com.google.common.base.Function;
 import com.vividsolutions.jts.geom.GeometryFactory;
@@ -82,15 +84,17 @@ public class BulkFeatureRetriever {
      *
      * @param refs list of node refs to fetch {@link RevFeature}s for
      * @param nativeType the feature type the features adhere to
+     * @param typeNameOverride in case the resulting feature type needs to be renamed (e.g. to
+     *        change the namespace URI, and/or the local name)
      * @param geometryFactory the geometry factory to create geometry attributes with
      * @return
      */
     public AutoCloseableIterator<SimpleFeature> getGeoToolsFeatures(
             AutoCloseableIterator<NodeRef> refs, RevFeatureType nativeType,
-            GeometryFactory geometryFactory) {
+            @Nullable Name typeNameOverride, GeometryFactory geometryFactory) {
 
         // builder for this particular schema
-        FeatureBuilder featureBuilder = new FeatureBuilder(nativeType);
+        FeatureBuilder featureBuilder = new FeatureBuilder(nativeType, typeNameOverride);
 
         // function that converts the FeatureInfo a feature of the given schema
         Function<ObjectInfo<RevFeature>, SimpleFeature> funcBuildFeature = (input -> MultiFeatureTypeBuilder

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/GeogigFeatureSource.java
@@ -313,6 +313,7 @@ class GeogigFeatureSource extends ContentFeatureSource {
         final @Nullable ScreenMap screenMap = (ScreenMap) hints.get(Hints.SCREENMAP);
         final @Nullable String[] propertyNames = query.getPropertyNames();
         final @Nullable SortBy[] sortBy = query.getSortBy();
+        final Name assignedName = getEntry().getName();
 
         final Filter filter = query.getFilter();
 
@@ -322,6 +323,7 @@ class GeogigFeatureSource extends ContentFeatureSource {
         FeatureReaderBuilder builder = FeatureReaderBuilder.builder(context, nativeType, typeRef);
 
         FeatureReader<SimpleFeatureType, SimpleFeature> featureReader = builder//
+                .targetSchema(getSchema())//
                 .filter(filter)//
                 .headRef(getRootRef())//
                 .oldHeadRef(oldRoot())//


### PR DESCRIPTION
…ion query

Commit db4da25 introduced a deffect by which the namespce URI
assigned to a DataStore would not be propagated to the SimpleFeatures
(although it would be propagated to the FeatureSource's FeatureType),
due to FeatureBuilder receiving the RevFeatureType instead of a
SimpleFetureType to avoid the misleading perception that it could
build a Feature in any FeatureType given instead of being forced
to match an actual geogig RevFeatureType.

This patch fixes the returned feature's target name/namespace
and also makes it so GeoGigFeatureSource supports the "definition
query" properties that might be given to its ContentFeatureSource
superclass.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>