### PR TITLE
Use Progress Listener for Update Index

### DIFF
--- a/src/cli/src/test/resources/features/porcelain/Commit.feature
+++ b/src/cli/src/test/resources/features/porcelain/Commit.feature
@@ -6,19 +6,19 @@ Feature: "commit" command
     
   Scenario: Try to commit with timestamp
     Given I have a repository
-     And I have staged "points1"     
-     And I run the command "commit -t 2010-04-22T19:53:23Z -m msg"
-    When I run the command "log --utc"
-    Then the response should contain "2010-04-22"
-     And the response should contain variable "{@ObjectId|localrepo|HEAD}"
+      And I have staged "points1"
+      And I run the command "commit -t 2010-04-22T19:53:23Z -m msg"
+     When I run the command "log --utc"
+     Then the response should contain "2010-04-22"
+      And the response should contain variable "{@ObjectId|localrepo|HEAD}"
     
   Scenario: Try to commit with timestamp in millisecs
     Given I have a repository
-     And I have staged "points1"     
-     And I run the command "commit -t 1000000000 -m msg"
-    When I run the command "log"
-    Then the response should contain "1970-01"
-     And the response should contain variable "{@ObjectId|localrepo|HEAD}"
+      And I have staged "points1"
+      And I run the command "commit -t 1000000000 -m msg"
+     When I run the command "log"
+     Then the response should contain "1970-01"
+      And the response should contain variable "{@ObjectId|localrepo|HEAD}"
 
   Scenario: Try to commit current staged features
     Given I have a repository
@@ -114,14 +114,21 @@ Feature: "commit" command
      
   Scenario: Try to commit only points
     Given I have a repository
-     And I have unstaged "points1"
-     And I have unstaged "points2"
-     And I have unstaged "lines1"
-     And I have staged "lines2"
-    When I run the command "commit -m Test Points"
-    Then the response should contain "2 features added"
-     And the response should contain variable "{@ObjectId|localrepo|HEAD}"
+      And I have unstaged "points1"
+      And I have unstaged "points2"
+      And I have unstaged "lines1"
+      And I have staged "lines2"
+     When I run the command "commit -m Test Points"
+     Then the response should contain "2 features added"
+      And the response should contain variable "{@ObjectId|localrepo|HEAD}"
 
-    
-
-         
+  Scenario: Committing a modified indexed feature updates the indexes
+    Given I have a repository
+      And I have staged "points1"
+     When I run the command "commit -m noIndex"
+      And the response should contain "1 features added"
+     When I run the command "index create --tree Points"
+     Then the response should contain "Index created successfully"
+      And I have staged "points1_modified"
+     When I run the command "commit -m withIndex"
+      And the response should contain "Updated index"

--- a/src/core/src/main/java/org/locationtech/geogig/hooks/builtin/UpdateIndexesHook.java
+++ b/src/core/src/main/java/org/locationtech/geogig/hooks/builtin/UpdateIndexesHook.java
@@ -56,7 +56,6 @@ public class UpdateIndexesHook implements CommandHook {
                             .setProgressListener(listener)//
                             .call();
                     if (!updates.isEmpty()) {
-                        System.err.println("***" + updates);
                         listener.setDescription(String.format("updated indexes: %s\n", updates));
                     }
                 } catch (Exception e) {

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/UpdateRef.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/UpdateRef.java
@@ -107,7 +107,7 @@ public class UpdateRef extends AbstractGeoGigOp<Optional<Ref>> {
             try {
                 storedValue = refDatabase.getRef(name);
             } catch (IllegalArgumentException e) {
-                // may be updating what used to be a symred to be a direct ref
+                // may be updating what used to be a symref to be a direct ref
                 storedValue = refDatabase.getSymRef(name);
             }
             checkState(oldValue.equals(storedValue), "Old value (" + storedValue
@@ -123,7 +123,7 @@ public class UpdateRef extends AbstractGeoGigOp<Optional<Ref>> {
         }
 
         checkState(newValue.isNull() || objectDatabase().exists(newValue),
-                "Tried to update Ref %s to an obect that doesn't exist: %s", name, newValue);
+                "Tried to update Ref %s to an object that doesn't exist: %s", name, newValue);
 
         refDatabase.putRef(name, newValue.toString());
         Optional<Ref> newRef = command(RefParse.class).setName(name).call();

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/BranchCreateOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/BranchCreateOp.java
@@ -103,14 +103,14 @@ public class BranchCreateOp extends AbstractGeoGigOp<Ref> {
         Optional<Ref> branchRef;
         if (orphan) {
             branchRef = command(UpdateRef.class).setName(branchRefPath).setNewValue(ObjectId.NULL)
-                    .call();
+                    .setProgressListener(getProgressListener()).call();
         } else {
             final String branchOrigin = Optional.fromNullable(commit_ish).or(Ref.HEAD);
 
             final ObjectId branchOriginCommitId = resolveOriginCommitId(branchOrigin);
 
             branchRef = command(UpdateRef.class).setName(branchRefPath)
-                    .setNewValue(branchOriginCommitId).call();
+                    .setNewValue(branchOriginCommitId).setProgressListener(getProgressListener()).call();
             checkState(branchRef.isPresent());
         }
 

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CommitOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CommitOp.java
@@ -261,14 +261,14 @@ public class CommitOp extends AbstractGeoGigOp<RevCommit> {
         String commitMessage = message;
 
         getProgressListener().started();
-        float writeTreeProgress = 99f;
+        float writeTreeProgress = 98f;
         if (all) {
             writeTreeProgress = 50f;
             AddOp op = command(AddOp.class);
             for (String st : pathFilters) {
                 op.addPattern(st);
             }
-            op.setUpdateOnly(true).setProgressListener(subProgress(49f)).call();
+            op.setUpdateOnly(true).setProgressListener(subProgress(48f)).call();
         }
         if (getProgressListener().isCanceled()) {
             return null;
@@ -376,9 +376,10 @@ public class CommitOp extends AbstractGeoGigOp<RevCommit> {
         }
         final ObjectStore objectDb = objectDatabase();
         objectDb.put(commit);
-        // set the HEAD pointing to the new commit
         final Optional<Ref> branchHead = command(UpdateRef.class).setName(currentBranch)
-                .setNewValue(commit.getId()).call();
+            .setNewValue(commit.getId()).setProgressListener(subProgress(1f)).call();
+
+
         checkState(commit.getId().equals(branchHead.get().getObjectId()));
 
         final Optional<Ref> newHead = command(UpdateSymRef.class).setName(Ref.HEAD)

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/index/UpdateIndexesOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/index/UpdateIndexesOp.java
@@ -63,7 +63,6 @@ public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
     protected List<Index> _call() {
         checkNotNull(rootRefSpec, "rootRefSpec not provided");
 
-        getProgressListener().setDescription("Updating indexes at " + rootRefSpec);
         final Ref branchRef = this.rootRefSpec;
 
         final List<NodeRef> featureTypeTreeRefs;


### PR DESCRIPTION
[GIG-590] - Use Progress Listener instead of
System.err for logging.

Signed-off-by: goudine <agoudine@boundlessgeo.com>