### PR TITLE
Simplify Node and bounds handling

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/model/Bucket.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/Bucket.java
@@ -9,17 +9,19 @@
  */
 package org.locationtech.geogig.model;
 
-import com.vividsolutions.jts.geom.Coordinate;
+import static com.google.common.base.Optional.fromNullable;
+
 import org.eclipse.jdt.annotation.Nullable;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.vividsolutions.jts.geom.Envelope;
 
 /**
  * A Bucket is merely a bounded pointer to another tree in a {@link RevTree} data structure.
  * <p>
- * {@link Node}s are pointers to named objects such as feature trees or features, while a Bucket is a
- * pointer to the {@link RevTree}s it's parent tree is split into when the builder's imposed split
+ * {@link Node}s are pointers to named objects such as feature trees or features, while a Bucket is
+ * a pointer to the {@link RevTree}s it's parent tree is split into when the builder's imposed split
  * threshold is surpassed.
  * 
  * @see RevTree#buckets()
@@ -27,29 +29,17 @@ import com.vividsolutions.jts.geom.Envelope;
  */
 public abstract class Bucket implements Bounded {
 
-    private final ObjectId bucketTree;
-    Float32Bounds bounds;
-
-
-    private Bucket(ObjectId id) {
-        this.bucketTree = id;
+    public static Bucket create(final ObjectId bucketTree, final @Nullable Envelope bounds) {
+        Preconditions.checkNotNull(bucketTree);
+        Float32Bounds b32 = Float32Bounds.valueOf(bounds);
+        return new BucketImpl(bucketTree, b32);
     }
 
     /**
      * @return the {@link ObjectId} of the tree this bucket points to
      */
     @Override
-    public ObjectId getObjectId() {
-        return bucketTree;
-    }
-
-    @Override
-    public String toString() {
-        Envelope bounds = new Envelope();
-        expand(bounds);
-        return getClass().getSimpleName() + "[" + getObjectId() + "] "
-                + (bounds.isNull() ? "" : bounds.toString());
-    }
+    public abstract ObjectId getObjectId();
 
     /**
      * Equality check based purely on {@link #getObjectId() ObjectId}
@@ -62,69 +52,41 @@ public abstract class Bucket implements Bounded {
         return getObjectId().equals(((Bucket) o).getObjectId());
     }
 
-    @Override
-    public boolean intersects(Envelope env) {
-        if (bounds == null)
-            return false;
-        return bounds.intersects(env);
-    }
+    private static class BucketImpl extends Bucket {
+        private final ObjectId bucketTree;
 
-    @Override
-    public void expand(Envelope env) {
-        if (bounds != null)
+        private final Float32Bounds bounds;
+
+        private BucketImpl(ObjectId id, Float32Bounds bounds) {
+            this.bucketTree = id;
+            this.bounds = bounds;
+        }
+
+        @Override
+        public ObjectId getObjectId() {
+            return bucketTree;
+        }
+
+        @Override
+        public String toString() {
+            return getClass().getSimpleName() + "[" + getObjectId() + "] "
+                    + (bounds.isNull() ? "" : bounds.toString());
+        }
+
+        @Override
+        public boolean intersects(Envelope env) {
+            return bounds.intersects(env);
+        }
+
+        @Override
+        public void expand(Envelope env) {
             bounds.expand(env);
-    }
-
-    @Override
-    public Optional<Envelope> bounds() {
-        if  ( (bounds == null) || (bounds.isNull()) )
-            return Optional.absent();
-
-        return Optional.of(bounds.asEnvelope());
-    }
-
-    void setBounds(Envelope env) {
-        bounds = new Float32Bounds(env);
-    }
-
-    private static class PointBucket extends Bucket {
-
-
-        public PointBucket(ObjectId id, double x, double y) {
-            super(id);
-            setBounds(new Envelope(new Coordinate(x,y)));
         }
 
-    }
-
-    private static class RectangleBucket extends Bucket {
-
-        public RectangleBucket(ObjectId id, Envelope env) {
-            super(id);
-            setBounds(env);
+        @Override
+        public Optional<Envelope> bounds() {
+            return fromNullable(bounds.isNull() ? null : bounds.asEnvelope());
         }
 
-    }
-
-    private static class NonSpatialBucket extends Bucket {
-
-        public NonSpatialBucket(ObjectId id) {
-            super(id);
-        }
-
-    }
-
-    public static Bucket create(final ObjectId bucketTree, final @Nullable Envelope bounds) {
-        if (bounds == null || bounds.isNull()) {
-            return new NonSpatialBucket(bucketTree);
-        }
-
-        Float32Bounds b32 = new Float32Bounds(bounds);
-        Envelope bounds2 = b32.asEnvelope();
-
-        if (bounds2.getWidth() == 0D && bounds2.getHeight() == 0D) {
-            return new PointBucket(bucketTree, bounds2.getMinX(), bounds2.getMinY());
-        }
-        return new RectangleBucket(bucketTree, bounds2);
     }
 }

--- a/src/api/src/test/java/org/locationtech/geogig/model/BucketTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/BucketTest.java
@@ -33,7 +33,6 @@ public class BucketTest {
         assertTrue(pointBucket.intersects(env));
         assertFalse(pointBucket.intersects(new Envelope(0, 5, 0, 0)));
 
-        assertTrue(pointBucket.toString().contains("PointBucket"));
         assertTrue(pointBucket.toString().contains(oId.toString()));
     }
 
@@ -54,13 +53,10 @@ public class BucketTest {
         assertTrue(rectangleBucket.intersects(env));
         assertFalse(rectangleBucket.intersects(new Envelope(5, 5, 7, 7)));
 
-        assertTrue(rectangleBucket.toString().contains("RectangleBucket"));
         assertTrue(rectangleBucket.toString().contains(oId.toString()));
 
-        assertTrue(noWidthBucket.toString().contains("RectangleBucket"));
         assertTrue(noWidthBucket.toString().contains(oId.toString()));
 
-        assertTrue(noHeightBucket.toString().contains("RectangleBucket"));
         assertTrue(noHeightBucket.toString().contains(oId.toString()));
     }
 
@@ -83,7 +79,6 @@ public class BucketTest {
 
         assertFalse(nonspatialBucket.intersects(env));
         assertFalse(nonspatialBucket.intersects(new Envelope(0, 0, 100, 100)));
-        assertTrue(nonspatialBucket.toString().contains("NonSpatialBucket"));
         assertTrue(nonspatialBucket.toString().contains(oId.toString()));
     }
 

--- a/src/api/src/test/java/org/locationtech/geogig/model/Float32BoundsTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/Float32BoundsTest.java
@@ -22,7 +22,7 @@ public class Float32BoundsTest {
     public void testSimple() {
         // 1,1 is the same in float4 and float8
         Coordinate coord = new Coordinate(1, 1);
-        Float32Bounds bounds = new Float32Bounds(new Envelope(coord));
+        Float32Bounds bounds = Float32Bounds.valueOf(new Envelope(coord));
         assertTrue(bounds.asEnvelope().contains(coord));
         assertTrue(bounds.intersects(new Envelope(coord)));
 
@@ -32,7 +32,7 @@ public class Float32BoundsTest {
 
 
         coord = new Coordinate(Math.PI, Math.E);
-        bounds = new Float32Bounds(new Envelope(coord));
+        bounds = Float32Bounds.valueOf(new Envelope(coord));
         assertTrue(bounds.asEnvelope().contains(coord));
         assertTrue(bounds.intersects(new Envelope(coord)));
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_2.java
@@ -1,3 +1,12 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
 package org.locationtech.geogig.storage.datastream;
 
 


### PR DESCRIPTION
Node had an inner class hiearchy that's overkill,
simplified it to be just FeatureNode and TreeNode.

Bucket's inner class hierarchy replaced by a single
BucketImpl, still leaving the door open for extension
by serial formats.

Float32Bounds is now a non nullable member variable
and a null object, Float32Bounds.EMPTY, is used for
non spatial Nodes/Buckets, which is returned by the new
factory method Float32bounds.valueOf(@Nullable Envelope)

Float32Bounds.isNull boolean member variable was removed
in favor of a simple runtime evaluation by isNull() to
slightly reduce it's memory footprint, since lots of instances
of this class will be created. It's intersects(Envelope)
method was also changed for direct evaluation instead of
creating an intermediate Envelope.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>