### PR TITLE
Removing mention of BSD 3-clause license from the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ License
 GeoGig is proudly open source:
 
 * Source code is distributed under an [Eclipse Distribution License (EDL)](LICENSE.txt>) unless otherwise stated.
-  This is a BSD 3 Clause License.
 * For details on third-party dependencies review [NOTICE](NOTICE.txt>)
 
 Download


### PR DESCRIPTION
I don't think this is actually true. Probably best to remove it for now.