### PR TITLE
Prevent geogig from closing if the process will not exit on finish.

### DIFF
--- a/src/cli-app/src/main/java/org/locationtech/geogig/cli/app/CLI.java
+++ b/src/cli-app/src/main/java/org/locationtech/geogig/cli/app/CLI.java
@@ -79,9 +79,8 @@ public class CLI {
         addShutdownHook(cli);
         int exitCode = cli.execute(args);
 
-        cli.close();
-
         if (exitCode != 0 || cli.isExitOnFinish()) {
+            cli.close();
             System.exit(exitCode);
         }
     }

--- a/src/cli/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
+++ b/src/cli/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
@@ -405,7 +405,9 @@ public class GeogigCLI {
         } finally {
             // close after executing a command for the next one to reopen with its own hints and not
             // to keep the db's open for write meanwhile
-            close();
+            if (isExitOnFinish()) {
+                close();
+            }
         }
         if (printError) {
             try {


### PR DESCRIPTION
`geogig serve` was not serving single repositories due to the repository being closed after the command was executed.