### PR TITLE
Fix empty string bug in custom geotools converter factories

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/data/MapToStringConverterFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/data/MapToStringConverterFactory.java
@@ -101,11 +101,11 @@ public class MapToStringConverterFactory implements ConverterFactory {
 
         @Override
         public <T> T convert(Object source, Class<T> target) throws Exception {
-            if (source == null) {
+            Preconditions.checkArgument(source == null || source.getClass().equals(String.class));
+            Preconditions.checkArgument(Map.class.isAssignableFrom(target));
+            if (source == null || ((String) source).trim().isEmpty()) {
                 return null;
             }
-            Preconditions.checkArgument(source.getClass().equals(String.class));
-            Preconditions.checkArgument(Map.class.isAssignableFrom(target));
 
             Map<String, String> entries = EntrySplitter.split((String) source);
 

--- a/src/core/src/test/java/org/locationtech/geogig/data/MapToStringConverterFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/MapToStringConverterFactoryTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016 Boundless and others.
+/* Copyright (c) 2015-2017 Boundless and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -12,24 +12,41 @@ package org.locationtech.geogig.data;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
+import java.util.HashMap;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Objects;
 
 import org.geotools.util.Converters;
 import org.junit.Test;
 
 import com.google.common.collect.ImmutableMap;
 
+/**
+ * Test suite for {@link MapToStringConverterFactory}
+ *
+ */
 public class MapToStringConverterFactoryTest {
+    
+    @Test
+    public void nullTest(){
+        assertNull(Converters.convert(null, Map.class));
+        assertNull(Converters.convert("", Map.class));
+        assertNull(Converters.convert(" ", Map.class));
+    }
 
     @Test
     public void roundtripTest() {
 
-        Map<String, ? extends Object> map = ImmutableMap.of(//
-                "key1", "value1", //
-                "key:2", "value|2", //
-                "key3", Integer.valueOf(12345), //
-                "submap", ImmutableMap.of("submap1", "subvalue1", "submap2", new Long(789)));
+        Map<String, Object> map = new HashMap<>();
+        map.put("key1", "value1");
+        map.put("key:2", "value|2");
+        map.put("key3", Integer.valueOf(12345));
+        map.put("nullval", null);
+        map.put("arrayval", new double[] { Math.PI, Double.MIN_VALUE, Double.MAX_VALUE });
+        map.put("submap", ImmutableMap.of("submap1", "subvalue1", "submap2", new Long(789)));
 
         assertNull(Converters.convert(map, Integer.class));
 
@@ -40,7 +57,12 @@ public class MapToStringConverterFactoryTest {
         Map<String, Object> roundTripped = Converters.convert(converted, Map.class);
         assertNotNull(roundTripped);
 
-        assertEquals(map, roundTripped);
+        assertEquals(map.size(), roundTripped.size());
+        assertEquals(map.keySet(), roundTripped.keySet());
+
+        for (Entry<String, Object> e : map.entrySet()) {
+            assertTrue(Objects.deepEquals(e.getValue(), roundTripped.get(e.getKey())));
+        }
     }
 
 }

--- a/src/core/src/test/java/org/locationtech/geogig/data/PrimitiveArrayToStringConverterFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/PrimitiveArrayToStringConverterFactoryTest.java
@@ -1,4 +1,4 @@
-/* Copyright (c) 2015-2016 Boundless and others.
+/* Copyright (c) 2015-2017 Boundless and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Distribution License v1.0
  * which accompanies this distribution, and is available at
@@ -11,14 +11,42 @@ package org.locationtech.geogig.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Array;
+import java.util.List;
 
 import org.geotools.util.Converters;
 import org.junit.Test;
 
+import com.google.common.base.Splitter;
+
+/**
+ * Test suite for {@link PrimitiveArrayToStringConverterFactory}
+ */
 public class PrimitiveArrayToStringConverterFactoryTest {
+
+    @Test
+    public void testNull() {
+        assertNull(Converters.convert(null, String.class));
+        assertNull(Converters.convert(null, int[].class));
+        assertNull(Converters.convert("", boolean[].class));
+        assertNull(Converters.convert("", byte[].class));
+        assertNull(Converters.convert("", short[].class));
+        assertNull(Converters.convert("", int[].class));
+        assertNull(Converters.convert("", long[].class));
+        assertNull(Converters.convert("", float[].class));
+        assertNull(Converters.convert("", double[].class));
+
+        assertNull(Converters.convert(" ", boolean[].class));
+        assertNull(Converters.convert(" ", byte[].class));
+        assertNull(Converters.convert(" ", short[].class));
+        assertNull(Converters.convert(" ", int[].class));
+        assertNull(Converters.convert(" ", long[].class));
+        assertNull(Converters.convert(" ", float[].class));
+        assertNull(Converters.convert(" ", double[].class));
+    }
 
     @Test
     public void testBoolean() {
@@ -63,14 +91,25 @@ public class PrimitiveArrayToStringConverterFactoryTest {
     public void testDouble() {
         roundtripTest(new double[0]);
         roundtripTest(new double[] { Double.NaN, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY,
-                Double.MIN_VALUE, -1.1, 0, 1.1, 2.2, 3.3, Double.MAX_VALUE });
+                Double.MIN_VALUE, -1.1, 0, 1.1, 2.2, 3.3, Double.MAX_VALUE, Math.PI, Math.E });
     }
 
     private void roundtripTest(Object value) {
 
         String converted = Converters.convert(value, String.class);
         assertNotNull(converted);
-
+        int length = Array.getLength(value);
+        if (0 == length) {
+            assertEquals("[]", converted);
+        } else {
+            assertTrue(converted.startsWith("["));
+            assertTrue(converted.endsWith("]"));
+            String plain = converted.substring(1);
+            plain = plain.substring(0, plain.length() - 1);
+            List<String> elems = Splitter.on(',').omitEmptyStrings().trimResults()
+                    .splitToList(plain);
+            assertEquals(length, elems.size());
+        }
         Object roundTripped = Converters.convert(converted, value.getClass());
 
         assertNotNull(roundTripped);


### PR DESCRIPTION
Fix a bug in PrimitiveArrayToStringConverterFactory that
returned an empty array when converting an empty string to
a primitive array instead of null.

It had the side effect of breaking the geoserver config UI
for ImageMosaic layers as it uses the Converters framework
to parse the "Bands" argument to an int[] that comes as an
empty string.

This patch makes the same fix to our MapToStringConverterFactory
although no bug report was issued for it, for the sake of
consistency.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>