### PR TITLE
[backport 1.1.x] Prevent initializing/importing repos with a name that is already in use

### DIFF
--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/repository/InitCommandResource.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/repository/InitCommandResource.java
@@ -15,6 +15,7 @@ import static org.locationtech.geogig.porcelain.ConfigOp.ConfigScope.LOCAL;
 import java.util.Map;
 
 import org.locationtech.geogig.porcelain.ConfigOp;
+import org.locationtech.geogig.web.api.ParameterSet;
 import org.restlet.data.MediaType;
 import org.restlet.data.Request;
 import org.restlet.data.Status;
@@ -22,10 +23,11 @@ import org.restlet.resource.Representation;
 import org.restlet.resource.Variant;
 
 /**
- * CommandResource extension to handle repository initialization requests specifically. The main reason for this
- * extension is to support setting the 2 required configuration elements ("user.name" and "user.email") with a single
- * "init" command, as opposed to requiring clients to make 3 Web API requests, 1 to initialize the repository and 1
- * each to set "user.name" and "user.email".
+ * CommandResource extension to handle repository initialization requests specifically. The main
+ * reason for this extension is to support setting the 2 required configuration elements
+ * ("user.name" and "user.email") with a single "init" command, as opposed to requiring clients to
+ * make 3 Web API requests, 1 to initialize the repository and 1 each to set "user.name" and
+ * "user.email".
  */
 public class InitCommandResource extends CommandResource {
 
@@ -43,6 +45,14 @@ public class InitCommandResource extends CommandResource {
     @Override
     protected String getCommandName() {
         return INIT_CMD;
+    }
+
+    @Override
+    protected ParameterSet handleRequestEntity(Request request) {
+        // For Init Requests, we do NOT want to consume the request entity at this point. The Entity
+        // may contain information that is needed to build the correct GeoGig repository context in
+        // which the Init command needs to be run.
+        return null;
     }
 
     @Override

--- a/src/web/functional/src/test/java/org/geogig/web/functional/DefaultFunctionalTestContext.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/DefaultFunctionalTestContext.java
@@ -38,6 +38,7 @@ import org.restlet.data.Protocol;
 import org.restlet.data.Reference;
 import org.restlet.data.Request;
 import org.restlet.data.Response;
+import org.restlet.resource.InputRepresentation;
 import org.restlet.resource.Representation;
 import org.restlet.resource.StringRepresentation;
 import org.w3c.dom.Document;
@@ -217,12 +218,20 @@ public class DefaultFunctionalTestContext extends FunctionalTestContext {
         setLastResponse(app.handle(request));
     }
 
+    private InputRepresentation createEntity(final String content, final String contentType) {
+        // create an InputRepresentation of the content
+        final MediaType mediaType = MediaType.valueOf(contentType);
+        final ByteArrayInputStream bais = new ByteArrayInputStream(content.getBytes());
+        return new InputRepresentation(bais, mediaType);
+    }
+
     @Override
     protected void callInternal(final Method method, String resourceUri, String content, String contentType) {
         Request request = new Request(method, resourceUri);
         request.setRootRef(new Reference(""));
         if (content != null && !content.isEmpty() && contentType != null) {
-            request.setEntity(content, MediaType.valueOf(contentType));
+            // create an InputRepresentation of the content
+            request.setEntity(createEntity(content, contentType));
         }
         setLastResponse(app.handle(request));
     }

--- a/src/web/functional/src/test/java/org/geogig/web/functional/DefaultFunctionalTestContext.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/DefaultFunctionalTestContext.java
@@ -82,6 +82,7 @@ public class DefaultFunctionalTestContext extends FunctionalTestContext {
 
             this.app = new Main(repoProvider, true);
             this.app.start();
+            setVariable("@systemTempPath", rootFolder.getCanonicalPath().replace("\\", "/"));
         }
     }
 

--- a/src/web/functional/src/test/java/org/geogig/web/functional/FunctionalTestContext.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/FunctionalTestContext.java
@@ -271,6 +271,16 @@ public abstract class FunctionalTestContext extends ExternalResource {
     protected abstract TestData createRepo(final String name) throws Exception;
 
     /**
+     * Create a repository that isn't managed with the given name for testing.
+     *
+     * @param name the repository name
+     * @return a newly created {@link TestData} for the repository.
+     * @throws Exception
+     */
+    protected TestData createUnmanagedRepo(final String name) throws Exception {
+        return createRepo(name);
+    }
+    /**
      * Issue a request with the given {@link Method} to the provided resource URI.
      * 
      * @param method the http method to use

--- a/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/WebAPICucumberHooks.java
@@ -170,6 +170,15 @@ public class WebAPICucumberHooks {
         openedRepos.addAll(context.setUpDefaultMultiRepoServer());
     }
 
+    @Given("I have \"([^\"]*)\" that is not managed$")
+    public void setupExtraUnMangedRepo(String repoName) throws Exception {
+        context.createUnmanagedRepo(repoName)
+                .init("geogigUser", "repo1_Owner@geogig.org")
+                .loadDefaultData()
+                .getRepo().close();
+        openedRepos.add(repoName);
+    }
+
     @Given("^There is a default multirepo server with remotes$")
     public void setUpDefaultMultiRepoWithRemotes() throws Exception {
         setUpEmptyMultiRepo();
@@ -1100,9 +1109,21 @@ public class WebAPICucumberHooks {
         context.postFile(targetURI, formFieldName, file);
     }
 
-    @When("^I post content-type \"([^\"]*)\" to \"([^\"]*)\" with$")
-    public void post_content(String contentType, String targetURI, String postContent) {
-        context.postContent(contentType, targetURI, postContent);
+    @When("^I \"([^\"]*)\" content-type \"([^\"]*)\" to \"([^\"]*)\" with$")
+    public void requestWithContent(String method, String contentType, String targetURI,
+            String content) {
+        final String resourceUri = context.replaceVariables(targetURI);
+        final String requestContent = context.replaceVariables(content);
+        switch (method) {
+            case "PUT":
+                context.callInternal(Method.PUT, resourceUri, requestContent, contentType);
+                break;
+            case "POST":
+                context.callInternal(Method.POST, resourceUri, requestContent, contentType);
+                break;
+            default:
+                fail("Unsupported request method: " + method);
+        }
     }
 
     /**

--- a/src/web/functional/src/test/resources/features/commands/Config.feature
+++ b/src/web/functional/src/test/resources/features/commands/Config.feature
@@ -39,7 +39,7 @@ Feature: Config
       
   Scenario: Config POST with a name and value as json sets the config entry and GET retrieves the set value
     Given There is an empty repository named repo1
-     When I post content-type "application/json" to "/repos/repo1/config" with
+     When I "POST" content-type "application/json" to "/repos/repo1/config" with
        """
        {
          "name":"user.name",
@@ -54,7 +54,7 @@ Feature: Config
       
   Scenario: Config POST with a name and value as xml sets the config entry and GET retrieves the set value
     Given There is an empty repository named repo1
-     When I post content-type "application/xml" to "/repos/repo1/config" with
+     When I "POST" content-type "application/xml" to "/repos/repo1/config" with
        """
        <params>
          <name>user.name</name>

--- a/src/web/functional/src/test/resources/features/commands/CreateRepository.feature
+++ b/src/web/functional/src/test/resources/features/commands/CreateRepository.feature
@@ -13,7 +13,13 @@ Feature: Create Repository
 
   Scenario: Verify trying to create an existing repo issues 409 "Conflict"
     Given There is a default multirepo server
-    When I call "PUT /repos/repo1/init"
+    And I have "extraRepo" that is not managed
+    When I "PUT" content-type "application/json" to "/repos/extraRepo/init" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
     Then the response status should be '409'
     And the response ContentType should be "application/xml"
     And the xpath "/response/success/text()" equals "false"
@@ -36,7 +42,13 @@ Feature: Create Repository
 
   Scenario: Verify trying to create an existing repo issues 409 "Conflict", JSON requested response
     Given There is a default multirepo server
-    When I call "PUT /repos/repo1/init.json"
+    And I have "extraRepo" that is not managed
+    When I "PUT" content-type "application/json" to "/repos/extraRepo/init.json" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
     Then the response status should be '409'
     And the response ContentType should be "application/json"
     And the json object "response.success" equals "false"

--- a/src/web/functional/src/test/resources/features/commands/CreateRepository.feature
+++ b/src/web/functional/src/test/resources/features/commands/CreateRepository.feature
@@ -91,14 +91,6 @@ Feature: Create Repository
     And the xpath "/response/repo/atom:link/@href" contains "/repos/repo1.xml"
     And the parent directory of repository "repo1" equals System Temp directory
 
-  Scenario: Verify JSON fomratted response of Init with already existing repository
-    Given There is a default multirepo server
-    When I call "PUT /repos/repo1/init.json" with the System Temp Directory as the parentDirectory
-    Then the response status should be '409'
-    And the response ContentType should be "application/json"
-    And the json object "response.success" equals "false"
-    And the json object "response.error" equals "Cannot run init on an already initialized repository."
-
   Scenario: Verify JSON fomratted response of Init with JSON formatted request parameters and Author
     Given There is an empty multirepo server
     When I call "PUT /repos/repo1/init.json" with Author and the System Temp Directory as the parentDirectory

--- a/src/web/functional/src/test/resources/features/repo/MergeFeature.feature
+++ b/src/web/functional/src/test/resources/features/repo/MergeFeature.feature
@@ -24,7 +24,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature with an invalid json payload issues a 400 status code
     Given There is an empty repository named repo1
-     When I post content-type "text/plain" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "text/plain" to "/repos/repo1/repo/mergefeature" with
       """
       "unexpected format"
       """
@@ -33,7 +33,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature without a feature issues a 400 status code
     Given There is an empty repository named repo1
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {}
       """
@@ -42,7 +42,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature without an "ours" id issues a 400 status code
     Given There is an empty repository named repo1
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1"
@@ -53,7 +53,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature without a "theirs" id issues a 400 status code
     Given There is a default multirepo server
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1",
@@ -65,7 +65,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature without any merges issues a 400 status code
     Given There is a default multirepo server
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1",
@@ -78,7 +78,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature builds a new feature from provided merges using ours and theirs (both features are the same)
     Given There is a default multirepo server
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1",
@@ -96,7 +96,7 @@ Feature: MergeFeature
       
   Scenario: MergeFeature builds a new feature from provided merges with custom values (both features are the same)
     Given There is a default multirepo server
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1",
@@ -125,7 +125,7 @@ Feature: MergeFeature
   Scenario: MergeFeature builds a new feature from provided merges (different versions of the same feature)
     Given There is a default multirepo server
       And I have committed "Point.1_modified" on the "repo1" repo in the "" transaction
-     When I post content-type "application/json" to "/repos/repo1/repo/mergefeature" with
+     When I "POST" content-type "application/json" to "/repos/repo1/repo/mergefeature" with
       """
       {
         "path"="Points/Point.1",


### PR DESCRIPTION
* Fix Init handling so that the JSON entity contents are processed at the correct point in the command execution.
* Refactor Init tests to allow for repository initialization without automatically adding a repo to the list of managed repos (for the GeoServer plugin)