### PR TITLE
Decouple RocksDB module from Command Line Interface

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/RepositoryResolver.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/RepositoryResolver.java
@@ -14,15 +14,37 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ServiceLoader;
 
 import org.locationtech.geogig.storage.ConfigDatabase;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 
 public abstract class RepositoryResolver {
+
+    /**
+     * System property key for specifying disabled resolvers.
+     */
+    private static final String DISABLE_RESOLVER_KEY = "disableResolvers";
+
+    /**
+     * List of disabled resolver class names.
+     */
+    private static final List<String> DISABLED_RESOLVERS = new ArrayList<>();
+
+    static {
+        // look for a System property of disabled resolvers
+        String disabledResolvers = System.getProperty(DISABLE_RESOLVER_KEY);
+        if (disabledResolvers != null) {
+            String[] disabledResolverArray = disabledResolvers.split(",");
+            DISABLED_RESOLVERS.addAll(Arrays.asList(disabledResolverArray));
+        }
+    }
 
     /**
      * Finds a {@code RepositoryResolver} that {@link #canHandle(URI) can handle} the given URI, or
@@ -32,6 +54,8 @@ public abstract class RepositoryResolver {
      * all the {@code META-INF/services/org.locationtech.geogig.repository.RepositoryResolver} files
      * in the classpath will be scanned for fully qualified names of implementing classes.
      * 
+     * @param repoURI Repository location URI
+     * @return A RepositoryResolver that can handle the supplied URI.
      * @throws IllegalArgumentException if no repository resolver is found capable of handling the
      *         given URI
      */
@@ -44,7 +68,8 @@ public abstract class RepositoryResolver {
 
         while (initializers.hasNext()) {
             RepositoryResolver initializer = initializers.next();
-            if (initializer.canHandle(repoURI)) {
+            final String resolverClassName = initializer.getClass().getName();
+            if (!DISABLED_RESOLVERS.contains(resolverClassName) && initializer.canHandle(repoURI)) {
                 return initializer;
             }
         }
@@ -70,7 +95,9 @@ public abstract class RepositoryResolver {
 
         while (initializers.hasNext()) {
             RepositoryResolver initializer = initializers.next();
-            if (initializer.canHandleURIScheme(scheme)) {
+            final String resolverClassName = initializer.getClass().getName();
+            if (!DISABLED_RESOLVERS.contains(resolverClassName)
+                    && initializer.canHandleURIScheme(scheme)) {
                 return true;
             }
         }
@@ -187,6 +214,7 @@ public abstract class RepositoryResolver {
      * Deletes the repository addressed by the given URI.
      * <p>
      * 
+     * @param repositoryLocation Repository URI location
      * @return {@code true} if the repository was deleted, {@code false} is the repository didn't
      *         exist.
      * @throws IllegalArgumentException if this implementation can't handle the given URI
@@ -195,4 +223,30 @@ public abstract class RepositoryResolver {
      */
     public abstract boolean delete(URI repositoryLocation) throws Exception;
 
+    /**
+     * Sets or overrides the list of disabled resolvers.
+     *
+     * @param disabledResolvers List of class names of RepositoryResolver implementations that
+     *        should be disabled.
+     * <p>
+     *        Example: "org.locationtech.geogig.repository.impl.FileRepositoryResolver" to disable
+     *        the File/Directory resolver for URI scheme "file".
+     */
+    @VisibleForTesting
+    static void setDisabledResolvers(List<String> disabledResolvers) {
+        // clear any existing disabled resolvers
+        clearDisabledResolvers();
+        if (disabledResolvers != null) {
+            DISABLED_RESOLVERS.addAll(disabledResolvers);
+        }
+    }
+
+    /**
+     * Clears the list of disabled RepositoryResolvers.
+     */
+    @VisibleForTesting
+    static void clearDisabledResolvers() {
+        // clear any existing disabled resolvers
+        DISABLED_RESOLVERS.clear();
+    }
 }

--- a/src/api/src/test/java/org/locationtech/geogig/repository/RepositoryResolverTestUtil.java
+++ b/src/api/src/test/java/org/locationtech/geogig/repository/RepositoryResolverTestUtil.java
@@ -1,0 +1,35 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Erik Merkle (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.repository;
+
+import java.util.List;
+
+/**
+ * Test Utility to disable RepositoryResolvers.
+ */
+public class RepositoryResolverTestUtil {
+
+    /**
+     * Sets a list of disabled RepositoryResolvers.
+     * @param disabledResolvers List of class names of RepositoryResolver implementations that
+     * should be disabled. Example: "org.locationtech.geogig.repository.impl.FileRepositoryResolver"
+     * to disable the File/Directory resolver for URI scheme "file".
+     */
+    public static void setDisabledResolvers(List<String> disabledResolvers) {
+        RepositoryResolver.setDisabledResolvers(disabledResolvers);
+    }
+
+    /**
+     * Clears the list of disabled RepositoryResolvers.
+     */
+    public static void clearDisabledResolverList() {
+        RepositoryResolver.clearDisabledResolvers();
+    }
+}

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -20,12 +20,6 @@
       <artifactId>geogig-core</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <!-- As the default storage provider (see CLIContextBuilder.defaults) -->
-      <groupId>org.locationtech.geogig</groupId>
-      <artifactId>geogig-rocksdb</artifactId>
-      <version>${project.version}</version>
-    </dependency>
 
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -85,6 +79,13 @@
     <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <!-- As the default storage provider (see CLIContextBuilder.defaults) -->
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-rocksdb</artifactId>
+      <version>${project.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -165,6 +165,13 @@
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-api</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/core/src/main/java/org/locationtech/geogig/storage/impl/RocksdbMap.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/impl/RocksdbMap.java
@@ -7,7 +7,7 @@
  * Contributors:
  * Johnathan Garrett (Prominent Edge) - initial implementation
  */
-package org.locationtech.geogig.rocksdb;
+package org.locationtech.geogig.storage.impl;
 
 import static com.google.common.base.Throwables.propagate;
 

--- a/src/core/src/test/java/org/locationtech/geogig/repository/impl/RepositoryResolverTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/repository/impl/RepositoryResolverTest.java
@@ -11,16 +11,22 @@ package org.locationtech.geogig.repository.impl;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Arrays;
 import java.util.List;
 
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.repository.RepositoryResolver;
+import org.locationtech.geogig.repository.RepositoryResolverTestUtil;
 import org.locationtech.geogig.storage.ConfigDatabase;
 
 public class RepositoryResolverTest {
@@ -81,6 +87,13 @@ public class RepositoryResolverTest {
 
     }
 
+    @Before
+    @After
+    public void resetDisabledResolvers() {
+        // clear any disabled resolvers, so tests have expected resolvers available
+        RepositoryResolverTestUtil.clearDisabledResolverList();
+    }
+
     @Test
     public void testLookup() throws URISyntaxException {
         URI uri = new URI("test://somerepo");
@@ -97,4 +110,90 @@ public class RepositoryResolverTest {
         assertFalse(canHandleScheme);
     }
 
+    private void verifyTestResolver(final boolean isAvailable, final URI uri) {
+        if (isAvailable) {
+            // assert Resolver is available for "test" scheme
+            assertTrue("TestResolver should be available",
+                    RepositoryResolver.resolverAvailableForURIScheme("test"));
+            // assert Resolver can be looked up for URI
+            assertNotNull("TestResolver should be available", RepositoryResolver.lookup(uri));
+        } else {
+            // assert Resolver is not available for "test" scheme
+            assertFalse("TestResolver should not be available",
+                    RepositoryResolver.resolverAvailableForURIScheme("test"));
+            // assert Resolver can not be looked up for URI
+            try {
+                RepositoryResolver.lookup(uri);
+                fail("TestResolver should not be available");
+            } catch (IllegalArgumentException iae) {
+                // expected
+            } catch (Throwable t) {
+                // unexpected
+                fail("Unexpected error: " + t.getMessage());
+            }
+        }
+    }
+
+    private void verifyFileRepositoryResolver(final boolean isAvailable, final URI uri) {
+        if (isAvailable) {
+            // assert Resolver is available for "test" scheme
+            assertTrue("FileRepositoryResolver should be available",
+                    RepositoryResolver.resolverAvailableForURIScheme("file"));
+            // assert Resolver can be looked up for URI
+            assertNotNull("FileRepositoryResolver should be available",
+                    RepositoryResolver.lookup(uri));
+        } else {
+            // assert Resolver is not available for "test" scheme
+            assertFalse("FileRepositoryResolver should not be available",
+                    RepositoryResolver.resolverAvailableForURIScheme("file"));
+            // assert Resolver can not be looked up for URI
+            try {
+                RepositoryResolver.lookup(uri);
+                fail("FileRepositoryResolver should not be available");
+            } catch (IllegalArgumentException iae) {
+                // expected
+            } catch (Throwable t) {
+                // unexpected
+                fail("Unexpected error: " + t.getMessage());
+            }
+        }
+    }
+
+    @Test
+    public void testCanHandleAndLookupWithDisabledResolvers() throws URISyntaxException {
+        // test URIs for lookup
+        final URI testUri = new URI("test://someRepo");
+        final URI fileUri = new URI("file:/someFileRepo");
+
+        // by default, both the TestResolver and the FileRepositoryResolver should be available
+        // during tests.
+        verifyTestResolver(true, testUri);
+        verifyFileRepositoryResolver(true, fileUri);
+
+        // disable the TestResolver
+        RepositoryResolverTestUtil.setDisabledResolvers(Arrays.asList(
+                "org.locationtech.geogig.repository.impl.RepositoryResolverTest$TestResolver"));
+
+        // verify TestResolver is not available and can't be looked up
+        verifyTestResolver(false, testUri);
+        verifyFileRepositoryResolver(true, fileUri);
+
+        // now disable the FileRepositoryResolver
+        RepositoryResolverTestUtil.setDisabledResolvers(Arrays.asList(
+                "org.locationtech.geogig.repository.impl.FileRepositoryResolver"));
+
+        // Verify the TestResolver is available again
+        verifyTestResolver(true, testUri);
+        verifyFileRepositoryResolver(false, fileUri);
+
+        // now disable both TestResolver and FileRepositoryResolver
+        RepositoryResolverTestUtil.setDisabledResolvers(Arrays.asList(
+                "org.locationtech.geogig.repository.impl.RepositoryResolverTest$TestResolver",
+                "org.locationtech.geogig.repository.impl.FileRepositoryResolver"));
+
+        // Verify neither the TestResolver nor the FileRepositoryResolver are available
+        verifyTestResolver(false, testUri);
+        verifyFileRepositoryResolver(false, fileUri);
+
+    }
 }

--- a/src/geotools/pom.xml
+++ b/src/geotools/pom.xml
@@ -138,6 +138,12 @@
       <groupId>org.locationtech.geogig</groupId>
       <artifactId>geogig-rocksdb</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-rocksdb</artifactId>
+      <version>${project.version}</version>
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/AuditReport.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/AuditReport.java
@@ -11,7 +11,7 @@ package org.locationtech.geogig.geotools.geopkg;
 
 import java.util.concurrent.atomic.AtomicLong;
 
-import org.locationtech.geogig.rocksdb.RocksdbMap;
+import org.locationtech.geogig.storage.impl.RocksdbMap;
 
 public class AuditReport {
 

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgGeogigMetadata.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgGeogigMetadata.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ConcurrentMap;
 
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.repository.DiffEntry.ChangeType;
-import org.locationtech.geogig.rocksdb.RocksdbMap;
+import org.locationtech.geogig.storage.impl.RocksdbMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgImportResult.java
+++ b/src/geotools/src/main/java/org/locationtech/geogig/geotools/geopkg/GeopkgImportResult.java
@@ -13,7 +13,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.locationtech.geogig.model.RevCommit;
-import org.locationtech.geogig.rocksdb.RocksdbMap;
+import org.locationtech.geogig.storage.impl.RocksdbMap;
 
 /**
  * Contains the results of a geopackage import.

--- a/src/storage/postgres/pom.xml
+++ b/src/storage/postgres/pom.xml
@@ -74,6 +74,12 @@
     </dependency>
     <dependency>
       <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-rocksdb</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
       <artifactId>geogig-cli</artifactId>
       <version>${project.version}</version>
       <classifier>tests</classifier>

--- a/src/web/api/pom.xml
+++ b/src/web/api/pom.xml
@@ -75,6 +75,12 @@
         <scope>test</scope>
     </dependency>
     <dependency>
+        <groupId>org.locationtech.geogig</groupId>
+        <artifactId>geogig-rocksdb</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/src/web/api/src/main/java/org/locationtech/geogig/rest/geopkg/GeoPkgImportContext.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/rest/geopkg/GeoPkgImportContext.java
@@ -36,7 +36,7 @@ import org.locationtech.geogig.rest.AsyncContext.AsyncCommand;
 import org.locationtech.geogig.rest.CommandRepresentationFactory;
 import org.locationtech.geogig.rest.geotools.DataStoreImportContextService;
 import org.locationtech.geogig.rest.repository.UploadCommandResource;
-import org.locationtech.geogig.rocksdb.RocksdbMap;
+import org.locationtech.geogig.storage.impl.RocksdbMap;
 import org.locationtech.geogig.storage.AutoCloseableIterator;
 import org.locationtech.geogig.web.api.CommandSpecException;
 import org.locationtech.geogig.web.api.PagedMergeScenarioConsumer;

--- a/src/web/functional/pom.xml
+++ b/src/web/functional/pom.xml
@@ -84,6 +84,19 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-api</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+        <groupId>org.locationtech.geogig</groupId>
+        <artifactId>geogig-rocksdb</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/src/web/functional/src/test/java/org/geogig/web/functional/MissingResolversTest.java
+++ b/src/web/functional/src/test/java/org/geogig/web/functional/MissingResolversTest.java
@@ -1,0 +1,26 @@
+/* Copyright (c) 2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ * 
+ * Contributors:
+ * Erik Merkle (Boundless) - initial implementation
+ */
+package org.geogig.web.functional;
+
+import org.junit.runner.RunWith;
+
+import cucumber.api.CucumberOptions;
+import cucumber.api.junit.Cucumber;
+
+/**
+ *
+ */
+@RunWith(Cucumber.class)
+@CucumberOptions(strict = true, plugin = { "pretty", "html:cucumber-report",
+        "json:cucumber-report/cucumber.json" }, glue = { "org.geogig.web.functional" }, features = {
+                "src/test/resources/features/resolvers" })
+public class MissingResolversTest {
+
+}

--- a/src/web/functional/src/test/resources/features/resolvers/MissingResolvers.feature
+++ b/src/web/functional/src/test/resources/features/resolvers/MissingResolvers.feature
@@ -1,0 +1,158 @@
+# Copyright (c) 2017 Boundless and others.
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Distribution License v1.0
+# which accompanies this distribution, and is available at
+# https://www.eclipse.org/org/documents/edl-v10.html
+#
+# Contributors:
+# Erik Merkle (Boundless) - initial implementation
+
+@CreateRepository @MissingBackend
+Feature: Tests Init request behavior when certain repository backends backend are not available
+
+  Scenario: Init request for RocksDB repo with RocksDB backend missing
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/xml"
+    And the xpath "/response/success/text()" equals "false"
+    And the xpath "/response/error/text()" contains "No repository initializer found capable of handling this kind of URI: file:/"
+
+  Scenario: Init request for RocksDB repo with RocksDB backend missing, JSON response
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init.json" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/json"
+    And the json object "response.success" equals "false"
+    And the json response "response.error" should contain "No repository initializer found capable of handling this kind of URI: file:/"
+
+  Scenario: Init request for PostgreSQL repo with PostgreSQL backend missing
+    Given There is an empty multirepo server
+    And I have disabled backends: "PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init" with
+      """
+      {
+        "dbName":"database",
+        "dbPassword":"password"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/xml"
+    And the xpath "/response/success/text()" equals "false"
+    And the xpath "/response/error/text()" contains "No repository initializer found capable of handling this kind of URI: postgresql:/"
+
+  Scenario: Init request for PostgreSQL repo with PostgreSQL backend missing, JSON response
+    Given There is an empty multirepo server
+    And I have disabled backends: "PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init.json" with
+      """
+      {
+        "dbName":"database",
+        "dbPassword":"password"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/json"
+    And the json object "response.success" equals "false"
+    And the json response "response.error" should contain "No repository initializer found capable of handling this kind of URI: postgresql:/"
+
+  Scenario: Init request for RocksDB repo with PostgreSQL backend missing
+    Given There is an empty multirepo server
+    And I have disabled backends: "PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '201'
+    And the response ContentType should be "application/xml"
+    And the xpath "/response/success/text()" equals "true"
+    And the xpath "/response/repo/name/text()" equals "repo1"
+    And the xpath "/response/repo/atom:link/@href" contains "/repos/repo1.xml"
+
+  Scenario: Init request for RocksDB repo with PostgreSQL backend missing, JSON response
+    Given There is an empty multirepo server
+    And I have disabled backends: "PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init.json" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '201'
+    And the response ContentType should be "application/json"
+    And the json object "response.success" equals "true"
+    And the json object "response.repo.name" equals "repo1"
+    And the json object "response.repo.href" ends with "/repos/repo1.json"
+
+  Scenario: Init request for RocksDB repo with RocksDB and PostgreSQL backends missing
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory, PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/xml"
+    And the xpath "/response/success/text()" equals "false"
+    And the xpath "/response/error/text()" contains "No repository initializer found capable of handling this kind of URI: file:/"
+
+  Scenario: Init request for RocksDB repo with RocksDB and PostgreSQL backends missing, JSON response
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory, PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init.json" with
+      """
+      {
+        "parentDirectory":"{@systemTempPath}"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/json"
+    And the json object "response.success" equals "false"
+    And the json response "response.error" should contain "No repository initializer found capable of handling this kind of URI: file:/"
+
+  Scenario: Init request for PostgreSQL repo with RocksDB and PostgreSQL backends missing
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory, PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init" with
+      """
+      {
+        "dbName":"database",
+        "dbPassword":"password"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/xml"
+    And the xpath "/response/success/text()" equals "false"
+    And the xpath "/response/error/text()" contains "No repository initializer found capable of handling this kind of URI: postgresql:/"
+
+  Scenario: Init request for PostgreSQL repo with RocksDB and PostgreSQL backends missing, JSON response
+    Given There is an empty multirepo server
+    And I have disabled backends: "Directory, PostgreSQL"
+    When I "PUT" content-type "application/json" to "/repos/repo1/init.json" with
+      """
+      {
+        "dbName":"database",
+        "dbPassword":"password"
+      }
+      """
+    Then the response status should be '400'
+    And the response ContentType should be "application/json"
+    And the json object "response.success" equals "false"
+    And the json response "response.error" should contain "No repository initializer found capable of handling this kind of URI: postgresql:/"
+   


### PR DESCRIPTION
* Move RocksdbMap from geogig-rocksdb to geogig-core
* Replace compile time dependencies on geogig-rocksdb to be test-scope dependencies

Signed-off-by: Erik Merkle <emerkle@boundlessgeo.com>