### PR TITLE
Disable RocksDB memory mapped files on Windows

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbHandle.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbHandle.java
@@ -74,12 +74,15 @@ class RocksdbHandle {
     public static RocksdbHandle create(Path targetDir) {
         RocksDB.loadLibrary();
 
+        final String os = System.getProperty("os.name");
+        final boolean isWindows = os.toLowerCase().contains("windows");
+        final boolean safeToUseMMappedFiles = !isWindows;
+
         Options options = new Options();
         options.setCreateIfMissing(true)//
                 .setAdviseRandomOnOpen(true)//
-                .setAllowMmapReads(true)//
-                .setAllowMmapWrites(true)//
-                .setAllowOsBuffer(true)//
+                .setAllowMmapReads(safeToUseMMappedFiles)//
+                .setAllowMmapWrites(safeToUseMMappedFiles)//
                 .setWriteBufferSize(16 * 1024 * 1024)//
                 .setMaxWriteBufferNumber(8)//
                 .setMaxBackgroundCompactions(2)//

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksConnectionManager.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksConnectionManager.java
@@ -56,12 +56,15 @@ class RocksConnectionManager extends ConnectionManager<DBConfig, DBHandle> {
 
         RocksDB.loadLibrary();
 
+        final String os = System.getProperty("os.name");
+        final boolean isWindows = os.toLowerCase().contains("windows");
+        final boolean safeToUseMMappedFiles = !isWindows;
+
         org.rocksdb.DBOptions dbOptions = new org.rocksdb.DBOptions();
         dbOptions.setCreateIfMissing(true)//
                 .setAdviseRandomOnOpen(true)//
-                .setAllowMmapReads(true)//
-                .setAllowMmapWrites(true)//
-                .setAllowOsBuffer(true)//
+                .setAllowMmapReads(safeToUseMMappedFiles)//
+                .setAllowMmapWrites(safeToUseMMappedFiles)//
                 .setBytesPerSync(64 * 1024 * 1024);
 
         RocksDB db;


### PR DESCRIPTION
Allowing MMapped files on Windows for rocksdb produces the
following error when inserting a large (>1M) objects through putAll():
```   
org.rocksdb.RocksDBException: IO error: Failed to FlushViewOfFile: .../000015.sst:
    The process cannot access the file because another process has locked a portion of the file.
    at org.rocksdb.RocksDB.write0(Native Method) ~[rocksdbjni-4.11.2.jar:na]
    at org.rocksdb.RocksDB.write(RocksDB.java:555) ~[rocksdbjni-4.11.2.jar:na]
    at org.locationtech.geogig.rocksdb.RocksdbObjectStore.putAll(RocksdbObjectStore.java:371)
```

Fixes #302
 