### PR TITLE
Move CLI bundled jarfiles to "libexec"

### DIFF
--- a/src/cli-app/cli-assembly-dir.xml
+++ b/src/cli-app/cli-assembly-dir.xml
@@ -32,7 +32,7 @@
         </file-->
         <file>
             <source>target/geogig-build/dependency-tree.txt</source>
-            <outputDirectory>lib</outputDirectory>
+            <outputDirectory>misc</outputDirectory>
         </file>
         <file>
             <source>../../LICENSE.txt</source>
@@ -40,14 +40,18 @@
         <file>
             <source>../../NOTICE.txt</source>
         </file>
+        <file>
+            <source>target/geogig-build/libexec/maven-metadata-appassembler.xml</source>
+            <outputDirectory>misc</outputDirectory>
+        </file>
     </files>
     
     <fileSets>
         <fileSet>
-            <directory>target/geogig-build/lib</directory>
-            <outputDirectory>/lib</outputDirectory>
+            <directory>target/geogig-build/libexec</directory>
+            <outputDirectory>/libexec</outputDirectory>
             <includes>
-                <include>*</include>
+                <include>*.jar</include>
             </includes>
         </fileSet>
         <fileSet>

--- a/src/cli-app/cli-assembly-zip.xml
+++ b/src/cli-app/cli-assembly-zip.xml
@@ -26,7 +26,8 @@
             <outputDirectory>geogig</outputDirectory>
             <includes>
                 <include>bin/**</include>
-                <include>lib/**</include>
+                <include>libexec/**</include>
+                <include>misc/**</include>
             </includes>
             <fileMode>0755</fileMode>
             <directoryMode>0755</directoryMode>

--- a/src/cli-app/pom.xml
+++ b/src/cli-app/pom.xml
@@ -104,7 +104,7 @@
           <!-- set alternative assemble directory -->
           <assembleDirectory>${project.build.directory}/geogig-build</assembleDirectory>
           <repositoryLayout>flat</repositoryLayout>
-          <repositoryName>lib</repositoryName>
+          <repositoryName>libexec</repositoryName>
           <useWildcardClassPath>true</useWildcardClassPath>
           <useAsterikClassPath>true</useAsterikClassPath>
           <platforms>


### PR DESCRIPTION
This should make building Kegs for OSX/macOS brew a little easier.

Signed-off-by: Erik Merkle <emerkle@boundlessgeo.com>