### PR TITLE
Remove dead-code binding to ExecutorService held by RepositoryImpl

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
@@ -65,17 +65,6 @@ public class GeogigModule extends AbstractModule {
      */
     @Override
     protected void configure() {
-
-        Provider<ExecutorService> fineGrainedExecutor = new Provider<ExecutorService>() {
-            @Override
-            public ExecutorService get() {
-                int availableProcessors = Runtime.getRuntime().availableProcessors();
-                return Executors.newFixedThreadPool(availableProcessors);
-            }
-        };
-
-        bind(ExecutorService.class).toProvider(fineGrainedExecutor).in(Scopes.SINGLETON);
-
         bind(Context.class).to(GuiceContext.class).in(Scopes.SINGLETON);
 
         Multibinder.newSetBinder(binder(), Decorator.class);

--- a/src/core/src/main/java/org/locationtech/geogig/repository/impl/RepositoryImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/impl/RepositoryImpl.java
@@ -13,7 +13,6 @@ import java.io.Closeable;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
 
 import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.NodeRef;
@@ -74,14 +73,11 @@ public class RepositoryImpl implements Repository {
 
     private URI repositoryLocation;
 
-    private ExecutorService executor;
-
     private volatile boolean open;
 
     @Inject
-    public RepositoryImpl(Context context, ExecutorService executor) {
+    public RepositoryImpl(Context context) {
         this.context = context;
-        this.executor = executor;
     }
 
     @Override
@@ -143,7 +139,6 @@ public class RepositoryImpl implements Repository {
         close(context.objectDatabase());
         close(context.indexDatabase());
         close(context.graphDatabase());
-        executor.shutdownNow();
         close(context.configDatabase());
         for (RepositoryListener l : listeners) {
             try {// don't let a broken listener mess us up


### PR DESCRIPTION
RepositoryImpl held a per-repository ExecutorService,
provided by the default guice module GeogigModule, that's
never used.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>