### PR TITLE
Fix a bug by which re-hashing a commit would result in a different SHA-1

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
@@ -9,6 +9,8 @@
  */
 package org.locationtech.geogig.model;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.lang.reflect.Array;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -23,6 +25,7 @@ import java.util.UUID;
 import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.referencing.CRS;
 import org.locationtech.geogig.model.RevObject.TYPE;
+import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.GeometryDescriptor;
 import org.opengis.feature.type.Name;
 import org.opengis.feature.type.PropertyDescriptor;
@@ -79,26 +82,30 @@ public class HashObjectFunnels {
     /**
      * Convenience method to hash a {@link RevFeature} out of its property values
      * 
-     * @param hasher expected to be {@link ObjectId#HASH_FUNCTION} in order to compute the SHA-1
-     *        hash
+     * @param into expected to be {@link ObjectId#HASH_FUNCTION} in order to compute the SHA-1 hash
      * @param values the {@link RevFeature} actual values, not {@code Optional}s
      */
-    public static void feature(PrimitiveSink hasher, List<Object> values) {
-        FeatureFunnel.INSTANCE.funnelValues(values, hasher);
+    public static void feature(PrimitiveSink into, List<Object> values) {
+        checkNotNull(into);
+        checkNotNull(values);
+        FeatureFunnel.INSTANCE.funnelValues(values, into);
     }
 
     /**
      * Convenience method to hash a {@link RevTree} out of its values
      * 
-     * @param hasher expected to be {@link ObjectId#HASH_FUNCTION} in order to compute the SHA-1
-     *        hash
+     * @param into expected to be {@link ObjectId#HASH_FUNCTION} in order to compute the SHA-1 hash
      * @param trees the tree's {@link RevTree#trees() contained tree nodes}
      * @param features the tree's {@link RevTree#trees() contained feature nodes}
      * @param buckets the tree's {@link RevTree#trees() contained bucket pointers}
      */
-    public static void tree(PrimitiveSink hasher, List<Node> trees, List<Node> features,
+    public static void tree(PrimitiveSink into, List<Node> trees, List<Node> features,
             SortedMap<Integer, Bucket> buckets) {
-        TreeFunnel.INSTANCE.funnel(hasher, trees, features, buckets);
+        checkNotNull(into);
+        checkNotNull(trees);
+        checkNotNull(features);
+        checkNotNull(buckets);
+        TreeFunnel.INSTANCE.funnel(into, trees, features, buckets);
     }
 
     public static ObjectId hashTree(@Nullable List<Node> trees, @Nullable List<Node> features,
@@ -263,17 +270,20 @@ public class HashObjectFunnels {
 
         @Override
         public void funnel(RevFeatureType from, PrimitiveSink into) {
+            funnel(into, from.type());
+        }
+
+        public void funnel(PrimitiveSink into, FeatureType type) {
             RevObjectTypeFunnel.funnel(TYPE.FEATURETYPE, into);
 
-            Collection<PropertyDescriptor> featureTypeProperties = from.type().getDescriptors();
+            Collection<PropertyDescriptor> featureTypeProperties = type.getDescriptors();
 
-            NameFunnel.funnel(from.getName(), into);
+            NameFunnel.funnel(type.getName(), into);
 
             for (PropertyDescriptor descriptor : featureTypeProperties) {
                 PropertyDescriptorFunnel.funnel(descriptor, into);
             }
         }
-
     };
 
     private static final class TagFunnel implements Funnel<RevTag> {
@@ -283,11 +293,16 @@ public class HashObjectFunnels {
 
         @Override
         public void funnel(RevTag from, PrimitiveSink into) {
+            funnel(into, from.getName(), from.getCommitId(), from.getMessage(), from.getTagger());
+        }
+
+        public void funnel(PrimitiveSink into, String name, ObjectId commitId, String message,
+                RevPerson tagger) {
             RevObjectTypeFunnel.funnel(TYPE.TAG, into);
-            ObjectIdFunnel.funnel(from.getCommitId(), into);
-            StringFunnel.funnel((CharSequence) from.getName(), into);
-            StringFunnel.funnel((CharSequence) from.getMessage(), into);
-            PersonFunnel.funnel(from.getTagger(), into);
+            ObjectIdFunnel.funnel(commitId, into);
+            StringFunnel.funnel(name, into);
+            StringFunnel.funnel(message, into);
+            PersonFunnel.funnel(tagger, into);
         }
     };
 
@@ -528,5 +543,34 @@ public class HashObjectFunnels {
             }
         }
     };
+
+    public static void tag(PrimitiveSink into, String name, ObjectId commitId, String message,
+            RevPerson tagger) {
+        checkNotNull(into);
+        checkNotNull(name);
+        checkNotNull(commitId);
+        checkNotNull(message);
+        checkNotNull(tagger);
+        TagFunnel.INSTANCE.funnel(into, name, commitId, message, tagger);
+    }
+
+    public static void featureType(PrimitiveSink into, FeatureType featureType) {
+        checkNotNull(into);
+        checkNotNull(featureType);
+        FeatureTypeFunnel.INSTANCE.funnel(into, featureType);
+    }
+
+    public static void commit(PrimitiveSink into, ObjectId treeId,
+            ImmutableList<ObjectId> parentIds, RevPerson author, RevPerson committer,
+            String commitMessage) {
+        checkNotNull(into);
+        checkNotNull(treeId);
+        checkNotNull(parentIds);
+        checkNotNull(author);
+        checkNotNull(committer);
+        checkNotNull(commitMessage);
+
+        CommitFunnel.INSTANCE.funnel(into, treeId, parentIds, commitMessage, author, committer);
+    }
 
 }

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/AbstractRevObject.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/AbstractRevObject.java
@@ -17,6 +17,8 @@ import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
 
+import com.google.common.base.Preconditions;
+
 /**
  * Base object type accessed during revision walking.
  * 
@@ -30,6 +32,7 @@ public abstract class AbstractRevObject implements RevObject {
     private final ObjectId id;
 
     public AbstractRevObject(final ObjectId id) {
+        Preconditions.checkNotNull(id);
         this.id = id;
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/CommitBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/CommitBuilder.java
@@ -9,6 +9,8 @@
  */
 package org.locationtech.geogig.model.impl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import java.util.List;
 
 import org.locationtech.geogig.model.ObjectId;
@@ -261,15 +263,20 @@ public final class CommitBuilder {
 
         final String commitMessage = this.message == null ? "" : this.message;
 
-        RevCommit unnnamedCommit = new RevCommitImpl(ObjectId.NULL, treeId, parentIds, author,
-                committer, commitMessage);
-        ObjectId commitId = new HashObject().setObject(unnnamedCommit).call();
+        final ObjectId commitId = HashObject.hashCommit(treeId, parentIds, author, committer,
+                commitMessage);
 
         return new RevCommitImpl(commitId, treeId, parentIds, author, committer, commitMessage);
     }
 
-    public static RevCommit build(ObjectId id, ObjectId treeId, List<ObjectId> parents,
+    public static RevCommit create(ObjectId id, ObjectId treeId, List<ObjectId> parents,
             RevPerson author, RevPerson committer, String message) {
+        checkNotNull(id);
+        checkNotNull(treeId);
+        checkNotNull(parents);
+        checkNotNull(author);
+        checkNotNull(committer);
+        checkNotNull(message);
         return new RevCommitImpl(id, treeId, ImmutableList.copyOf(parents), author, committer,
                 message);
     }

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevCommitImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevCommitImpl.java
@@ -10,7 +10,6 @@
 package org.locationtech.geogig.model.impl;
 
 import static com.google.common.base.Objects.equal;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevCommit;
@@ -36,15 +35,6 @@ class RevCommitImpl extends AbstractRevObject implements RevCommit {
 
     private String message;
 
-    /**
-     * Constructs a new {@code RevCommit} with the given {@link ObjectId}.
-     * 
-     * @param id the object id to use
-     */
-    public RevCommitImpl(final ObjectId id) {
-        super(id);
-    }
-
     @Override
     public TYPE getType() {
         return TYPE.COMMIT;
@@ -60,14 +50,9 @@ class RevCommitImpl extends AbstractRevObject implements RevCommit {
      * @param committer the committer of this commit
      * @param message the message for this commit
      */
-    public RevCommitImpl(final ObjectId id, ObjectId treeId, ImmutableList<ObjectId> parentIds,
+    RevCommitImpl(final ObjectId id, ObjectId treeId, ImmutableList<ObjectId> parentIds,
             RevPerson author, RevPerson committer, String message) {
-        this(id);
-        checkNotNull(treeId);
-        checkNotNull(parentIds);
-        checkNotNull(author);
-        checkNotNull(committer);
-        checkNotNull(message);
+        super(id);
         this.treeId = treeId;
         this.parentIds = parentIds;
         this.author = author;

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureTypeBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureTypeBuilder.java
@@ -9,25 +9,67 @@
  */
 package org.locationtech.geogig.model.impl;
 
-import org.eclipse.jdt.annotation.Nullable;
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
+
+import org.geotools.data.DataUtilities;
+import org.geotools.referencing.CRS;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevFeatureType;
 import org.locationtech.geogig.plumbing.HashObject;
+import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
+import org.opengis.referencing.crs.CoordinateReferenceSystem;
+
+import com.google.common.base.Throwables;
 
 public class RevFeatureTypeBuilder {
 
+    /**
+     * Builds a {@link RevFeatureType} for the given feature type, computing its id throuh
+     * {@link HashObject}
+     */
     public static RevFeatureType build(FeatureType featureType) {
-        return RevFeatureTypeBuilder.build(null, featureType);
+        checkNotNull(featureType);
+        featureType = adapt(featureType);
+        ObjectId id = HashObject.hashFeatureType(featureType);
+        return RevFeatureTypeBuilder.create(id, featureType);
     }
 
-    public static RevFeatureType build(@Nullable ObjectId id, FeatureType ftype) {
-        if (id == null) {
-            RevFeatureTypeImpl unnamed = new RevFeatureTypeImpl(ftype);
-            id = new HashObject().setObject(unnamed).call();
-        }
+    /**
+     * Creates and returns a new {@link RevFeatureType} for the given FeatureType with the given
+     * {@link ObjectId id} without verifying the SHA-1 matches the contents of the
+     * {@link RevFeatureType}
+     */
+    public static RevFeatureType create(ObjectId id, FeatureType ftype) {
+        checkNotNull(id);
+        checkNotNull(ftype);
 
         return new RevFeatureTypeImpl(id, ftype);
     }
 
+    // GeoTools treats DefaultGeographic.WGS84 as a special case when calling the
+    // CRS.toSRS() method, and that causes the parsed RevFeatureType to hash differently.
+    // To compensate that, we replace any instance of it with a CRS built using the
+    // EPSG:4326 code, which works consistently when storing it and later recovering it from
+    // the database.
+    private static FeatureType adapt(FeatureType featureType) {
+        CoordinateReferenceSystem defaultCrs = featureType.getCoordinateReferenceSystem();
+        final boolean compareMetadata = false;
+        if (null != defaultCrs && WGS84.equals(
+                (org.geotools.referencing.AbstractIdentifiedObject) defaultCrs, compareMetadata)) {
+            checkArgument(featureType instanceof SimpleFeatureType);
+            try {
+                final boolean longitudeFirst = true;
+                CoordinateReferenceSystem epsg4326 = CRS.decode("EPSG:4326", longitudeFirst);
+                String[] includeAllAttributes = null;
+                featureType = DataUtilities.createSubType((SimpleFeatureType) featureType,
+                        includeAllAttributes, epsg4326);
+            } catch (Exception e) {
+                throw Throwables.propagate(e);
+            }
+        }
+        return featureType;
+    }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureTypeImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevFeatureTypeImpl.java
@@ -9,21 +9,14 @@
  */
 package org.locationtech.geogig.model.impl;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
-import static org.geotools.referencing.crs.DefaultGeographicCRS.WGS84;
 
-import org.geotools.data.DataUtilities;
-import org.geotools.referencing.CRS;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevFeatureType;
-import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
 import org.opengis.feature.type.Name;
 import org.opengis.feature.type.PropertyDescriptor;
-import org.opengis.referencing.crs.CoordinateReferenceSystem;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
 /**
@@ -36,44 +29,17 @@ class RevFeatureTypeImpl extends AbstractRevObject implements RevFeatureType {
     private ImmutableList<PropertyDescriptor> sortedDescriptors;
 
     /**
-     * Constructs a new {@code RevFeatureType} from the given {@link FeatureType}.
-     * 
-     * @param featureType the feature type to use
-     */
-    RevFeatureTypeImpl(FeatureType featureType) {
-        this(ObjectId.NULL, featureType);
-    }
-
-    /**
      * Constructs a new {@code RevFeatureType} from the given {@link ObjectId} and
      * {@link FeatureType}.
      * 
      * @param id the object id to use for this feature type
      * @param featureType the feature type to use
      */
-    public RevFeatureTypeImpl(ObjectId id, FeatureType featureType) {
+    RevFeatureTypeImpl(ObjectId id, FeatureType featureType) {
         super(id);
         checkNotNull(featureType);
-        CoordinateReferenceSystem defaultCrs = featureType.getCoordinateReferenceSystem();
-        if (WGS84.equals((org.geotools.referencing.AbstractIdentifiedObject) defaultCrs, false)) {
-            // GeoTools treats DefaultGeographic.WGS84 as a special case when calling the
-            // CRS.toSRS() method, and that causes the parsed RevFeatureType to hash differently.
-            // To compensate that, we replace any instance of it with a CRS built using the
-            // EPSG:4326 code, which works consistently when storing it and later recovering it from
-            // the database.
-            checkArgument(featureType instanceof SimpleFeatureType);
-            try {
-                final boolean longitudeFirst = true;
-                CoordinateReferenceSystem epsg4326 = CRS.decode("EPSG:4326", longitudeFirst);
-                String[] includeAllAttributes = null;
-                featureType = DataUtilities.createSubType((SimpleFeatureType) featureType,
-                        includeAllAttributes, epsg4326);
-            } catch (Exception e) {
-                throw Throwables.propagate(e);
-            }
-        }
         this.featureType = featureType;
-        sortedDescriptors = ImmutableList.copyOf(featureType.getDescriptors());
+        this.sortedDescriptors = ImmutableList.copyOf(featureType.getDescriptors());
     }
 
     @Override

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevPersonImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevPersonImpl.java
@@ -39,7 +39,7 @@ class RevPersonImpl implements RevPerson {
      * @param timestamp milliseconds since January 1, 1970, 00:00:00 GMT
      * @param timeZoneOffset milliseconds to add to the GMT timestamp
      */
-    public RevPersonImpl(@Nullable String name, @Nullable String email, long timeStamp,
+    RevPersonImpl(@Nullable String name, @Nullable String email, long timeStamp,
             int timeZoneOffset) {
         this.name = name;
         this.email = email;

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTagBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTagBuilder.java
@@ -9,15 +9,27 @@
  */
 package org.locationtech.geogig.model.impl;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevPerson;
 import org.locationtech.geogig.model.RevTag;
+import org.locationtech.geogig.plumbing.HashObject;
 
 public class RevTagBuilder {
 
-    public static RevTag build(ObjectId id, String name, ObjectId commitId, String message,
+    public static RevTag create(ObjectId id, String name, ObjectId commitId, String message,
             RevPerson tagger) {
+        checkNotNull(id);
+        checkNotNull(name);
+        checkNotNull(commitId);
+        checkNotNull(message);
+        checkNotNull(tagger);
         return new RevTagImpl(id, name, commitId, message, tagger);
     }
 
+    public static RevTag build(String name, ObjectId commitId, String message, RevPerson tagger) {
+        ObjectId id = HashObject.hashTag(name, commitId, message, tagger);
+        return create(id, name, commitId, message, tagger);
+    }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTagImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTagImpl.java
@@ -10,7 +10,6 @@
 package org.locationtech.geogig.model.impl;
 
 import static com.google.common.base.Objects.equal;
-import static com.google.common.base.Preconditions.checkNotNull;
 
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevPerson;
@@ -41,10 +40,6 @@ class RevTagImpl extends AbstractRevObject implements RevTag {
     RevTagImpl(final ObjectId id, final String name, final ObjectId commitId, final String message,
             RevPerson tagger) {
         super(id);
-        checkNotNull(name);
-        checkNotNull(commitId);
-        checkNotNull(message);
-        checkNotNull(tagger);
         this.name = name;
         this.commit = commitId;
         this.message = message;

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/TagCreateOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/TagCreateOp.java
@@ -19,7 +19,6 @@ import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.impl.RevPersonBuilder;
 import org.locationtech.geogig.model.impl.RevTagBuilder;
 import org.locationtech.geogig.plumbing.CheckRefFormat;
-import org.locationtech.geogig.plumbing.HashObject;
 import org.locationtech.geogig.plumbing.RefParse;
 import org.locationtech.geogig.plumbing.UpdateRef;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
@@ -62,9 +61,9 @@ public class TagCreateOp extends AbstractGeoGigOp<RevTag> {
         }
         RevPerson tagger = resolveTagger();
         message = message == null ? "" : message;
-        RevTag tag = RevTagBuilder.build(ObjectId.NULL, name, commitId, message, tagger);
-        ObjectId id = command(HashObject.class).setObject(tag).call();
-        tag = RevTagBuilder.build(id, name, commitId, message, tagger);
+
+        RevTag tag = RevTagBuilder.build(name, commitId, message, tagger);
+
         objectDatabase().put(tag);
         Optional<Ref> branchRef = command(UpdateRef.class).setName(tagRefPath)
                 .setNewValue(tag.getId()).call();

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
@@ -125,7 +125,7 @@ public class FormatCommonV1 {
         final String message = in.readUTF();
         final RevPerson tagger = readRevPerson(in);
 
-        return RevTagBuilder.build(id, name, commitId, message, tagger);
+        return RevTagBuilder.create(id, name, commitId, message, tagger);
     }
 
     public static void writeTag(RevTag tag, DataOutput out) throws IOException {
@@ -174,7 +174,7 @@ public class FormatCommonV1 {
 
         final String message = in.readUTF();
 
-        return CommitBuilder.build(id, treeId, parentListBuilder.build(), author, committer,
+        return CommitBuilder.create(id, treeId, parentListBuilder.build(), author, committer,
                 message);
     }
 
@@ -320,7 +320,7 @@ public class FormatCommonV1 {
         }
         SimpleFeatureType ftype = typeFactory.createSimpleFeatureType(name, attributes, null, false,
                 Collections.<Filter> emptyList(), BasicFeatureTypes.FEATURE, null);
-        return RevFeatureTypeBuilder.build(id, ftype);
+        return RevFeatureTypeBuilder.create(id, ftype);
     }
 
     private static Name readName(DataInput in) throws IOException {

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
@@ -140,10 +140,10 @@ public class FormatCommonV2 {
 
         RevTag tag;
         if (id == null) {
-            tag = RevTagBuilder.build(ObjectId.NULL, name, commitId, message, tagger);
+            tag = RevTagBuilder.create(ObjectId.NULL, name, commitId, message, tagger);
             id = new HashObject().setObject(tag).call();
         }
-        tag = RevTagBuilder.build(id, name, commitId, message, tagger);
+        tag = RevTagBuilder.create(id, name, commitId, message, tagger);
         return tag;
     }
 
@@ -184,11 +184,11 @@ public class FormatCommonV2 {
         if (id == null) {
             commitId = ObjectId.NULL;
         }
-        RevCommit commit = CommitBuilder.build(commitId, treeId, parentListBuilder.build(), author,
+        RevCommit commit = CommitBuilder.create(commitId, treeId, parentListBuilder.build(), author,
                 committer, message);
         if (id == null) {
             commitId = new HashObject().setObject(commit).call();
-            commit = CommitBuilder.build(commitId, treeId, parentListBuilder.build(), author,
+            commit = CommitBuilder.create(commitId, treeId, parentListBuilder.build(), author,
                     committer, message);
         }
         return commit;
@@ -625,7 +625,7 @@ public class FormatCommonV2 {
         SimpleFeatureType ftype = typeFactory.createSimpleFeatureType(name, attributes, null, false,
                 Collections.<Filter> emptyList(), BasicFeatureTypes.FEATURE, null);
         RevFeatureType revtype;
-        revtype = RevFeatureTypeBuilder.build(id, ftype);
+        revtype = RevFeatureTypeBuilder.create(id, ftype);
 
         return revtype;
     }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/text/TextSerializationFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/text/TextSerializationFactory.java
@@ -853,7 +853,7 @@ public class TextSerializationFactory implements ObjectSerializingFactory {
             String message = parseLine(requireLine(reader), "message");
             String commitId = parseLine(requireLine(reader), "commitid");
             RevPerson tagger = parsePerson(requireLine(reader));
-            RevTag tag = RevTagBuilder.build(id, name, ObjectId.valueOf(commitId), message, tagger);
+            RevTag tag = RevTagBuilder.create(id, name, ObjectId.valueOf(commitId), message, tagger);
             return tag;
         }
 

--- a/src/core/src/test/java/org/locationtech/geogig/data/retrieve/BulkFeatureRetrieverTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/retrieve/BulkFeatureRetrieverTest.java
@@ -45,10 +45,9 @@ public class BulkFeatureRetrieverTest {
     public void testGet() throws Exception {
         ObjectId meta1 = getOID(1);
 
-        RevFeatureTypeBuilder ftbuilder = new RevFeatureTypeBuilder();
         SimpleFeatureType fType1 = DataUtilities.createType("location",
                 "the_geom:Point:srid=4326,name:String,name2:String");
-        RevFeatureType revft1 = ftbuilder.build(meta1, fType1);
+        RevFeatureType revft1 = RevFeatureTypeBuilder.create(meta1, fType1);
 
         WKTReader2 wkt = new WKTReader2();
         RevFeature f1 = RevObjectTestSupport.featureForceId(getOID(2), wkt.read("POINT(0 0)"),
@@ -73,7 +72,7 @@ public class BulkFeatureRetrieverTest {
 
         AutoCloseableIterator<ObjectInfo<RevObject>> objects = AutoCloseableIterator
                 .fromIterator(objs.iterator());
-        
+
         when(odb.getObjects(anyObject(), anyObject(), anyObject())).thenReturn(objects);
 
         Iterator<NodeRef> input = Arrays.asList(nr1, nr2).iterator();

--- a/src/core/src/test/java/org/locationtech/geogig/data/retrieve/MultiFeatureTypeBuilderTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/retrieve/MultiFeatureTypeBuilderTest.java
@@ -39,14 +39,13 @@ public class MultiFeatureTypeBuilderTest {
         ObjectId meta1 = getOID(1);
         ObjectId meta2 = getOID(2);
 
-        RevFeatureTypeBuilder ftbuilder = new RevFeatureTypeBuilder();
         SimpleFeatureType fType1 = DataUtilities.createType("location",
                 "the_geom:Point:srid=4326,name:String,name2:String");
-        RevFeatureType revft1 = ftbuilder.build(getOID(1), fType1);
+        RevFeatureType revft1 = RevFeatureTypeBuilder.create(getOID(1), fType1);
 
         SimpleFeatureType fType2 = DataUtilities.createType("location",
                 "the_geom:Point:srid=4326,name3:String,name4:String");
-        RevFeatureType revft2 = ftbuilder.build(getOID(1), fType2);
+        RevFeatureType revft2 = RevFeatureTypeBuilder.create(getOID(1), fType2);
 
         ObjectDatabase odb = mock(ObjectDatabase.class);
         when(odb.getFeatureType(meta1)).thenReturn(revft1);
@@ -68,10 +67,9 @@ public class MultiFeatureTypeBuilderTest {
 
         ObjectId meta1 = getOID(1);
 
-        RevFeatureTypeBuilder ftbuilder = new RevFeatureTypeBuilder();
         SimpleFeatureType fType1 = DataUtilities.createType("location",
                 "the_geom:Point:srid=4326,name:String,name2:String");
-        RevFeatureType revft1 = ftbuilder.build(getOID(1), fType1);
+        RevFeatureType revft1 = RevFeatureTypeBuilder.create(getOID(1), fType1);
 
         ObjectDatabase odb = mock(ObjectDatabase.class);
         when(odb.getFeatureType(meta1)).thenReturn(revft1);

--- a/src/core/src/test/java/org/locationtech/geogig/model/impl/RevCommitImplTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/impl/RevCommitImplTest.java
@@ -38,7 +38,7 @@ public class RevCommitImplTest {
         String message = "This is a test commit";
         ImmutableList<ObjectId> parentIds = ImmutableList
                 .of(RevObjectTestSupport.hashString("Parent 1"));
-        RevCommit commit = CommitBuilder.build(id, treeId, parentIds, author, committer, message);
+        RevCommit commit = CommitBuilder.create(id, treeId, parentIds, author, committer, message);
 
         assertEquals(committer, commit.getCommitter());
         assertEquals(author, commit.getAuthor());
@@ -50,7 +50,7 @@ public class RevCommitImplTest {
         assertEquals(parentIds.get(0), commit.parentN(0).get());
 
         parentIds = ImmutableList.of();
-        commit = CommitBuilder.build(id, treeId, parentIds, author, committer, message);
+        commit = CommitBuilder.create(id, treeId, parentIds, author, committer, message);
         assertEquals(Collections.EMPTY_LIST, commit.getParentIds());
         assertEquals(Optional.absent(), commit.parentN(0));
     }
@@ -66,35 +66,35 @@ public class RevCommitImplTest {
         ImmutableList<ObjectId> parentId = ImmutableList
                 .of(RevObjectTestSupport.hashString("Parent 1"));
         ImmutableList<ObjectId> emptyParentIds = ImmutableList.of();
-        RevCommit commit = CommitBuilder.build(id, treeId, parentId, author, committer, message);
+        RevCommit commit = CommitBuilder.create(id, treeId, parentId, author, committer, message);
 
         String commitString = commit.toString();
 
         assertEquals("Commit[" + id.toString() + ", '" + message + "']", commitString);
 
-        RevCommit commit2 = CommitBuilder.build(RevObjectTestSupport.hashString("second commit"),
+        RevCommit commit2 = CommitBuilder.create(RevObjectTestSupport.hashString("second commit"),
                 treeId, parentId, author, committer, message);
 
         assertTrue(commit.equals(commit2));
 
-        commit2 = CommitBuilder.build(id, RevObjectTestSupport.hashString("new test tree"),
+        commit2 = CommitBuilder.create(id, RevObjectTestSupport.hashString("new test tree"),
                 parentId, author, committer, message);
 
         assertFalse(commit.equals(commit2));
 
-        commit2 = CommitBuilder.build(id, treeId, emptyParentIds, author, committer, message);
+        commit2 = CommitBuilder.create(id, treeId, emptyParentIds, author, committer, message);
 
         assertFalse(commit.equals(commit2));
 
-        commit2 = CommitBuilder.build(id, treeId, parentId, committer, committer, message);
+        commit2 = CommitBuilder.create(id, treeId, parentId, committer, committer, message);
 
         assertFalse(commit.equals(commit2));
 
-        commit2 = CommitBuilder.build(id, treeId, parentId, author, author, message);
+        commit2 = CommitBuilder.create(id, treeId, parentId, author, author, message);
 
         assertFalse(commit.equals(commit2));
 
-        commit2 = CommitBuilder.build(id, treeId, parentId, author, committer, "new message");
+        commit2 = CommitBuilder.create(id, treeId, parentId, author, committer, "new message");
 
         assertFalse(commit.equals(commit2));
 

--- a/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
@@ -36,6 +36,7 @@ import org.locationtech.geogig.model.impl.RevFeatureTypeBuilder;
 import org.locationtech.geogig.model.impl.RevObjectTestSupport;
 import org.locationtech.geogig.model.impl.RevPersonBuilder;
 import org.locationtech.geogig.model.impl.RevTagBuilder;
+import org.locationtech.geogig.model.impl.RevTreeBuilder;
 import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.test.integration.RepositoryTestCase;
 import org.opengis.feature.Feature;
@@ -69,6 +70,10 @@ public class HashObjectTest extends RepositoryTestCase {
     private RevFeature coverageRevFeature;
 
     private RevFeatureType coverageRevFeatureType;
+
+    private RevTag tag1;
+
+    private RevTag tag2;
 
     @Override
     protected void setUpInternal() throws Exception {
@@ -147,6 +152,15 @@ public class HashObjectTest extends RepositoryTestCase {
         hashCommand.setContext(mockCommandLocator);
         when(mockCommandLocator.command(eq(DescribeFeatureType.class)))
                 .thenReturn(new DescribeFeatureType());
+
+        RevPerson tagger = RevPersonBuilder.build("volaya", "volaya@boundlessgeo.com", -1000, -1);
+        RevPerson tagger2 = RevPersonBuilder.build("groldan", "groldan@boundlessgeo.com", 10000, 0);
+        tag1 = RevTagBuilder.build("tag1", RevObjectTestSupport.hashString("fake commit id"),
+                "message", tagger);
+        tag2 = RevTagBuilder.build("tag2",
+                RevObjectTestSupport.hashString("another fake commit id"), "another message",
+                tagger2);
+
     }
 
     @Test
@@ -278,24 +292,18 @@ public class HashObjectTest extends RepositoryTestCase {
 
     @Test
     public void testHashTags() throws Exception {
-
-        RevPerson tagger = RevPersonBuilder.build("volaya", "volaya@boundlessgeo.com", -1000, -1);
-        RevPerson tagger2 = RevPersonBuilder.build("groldan", "groldan@boundlessgeo.com", 10000, 0);
-        RevTag tag = RevTagBuilder.build(null, "tag1",
-                RevObjectTestSupport.hashString("fake commit id"), "message", tagger);
-        RevTag tag2 = RevTagBuilder.build(null, "tag2",
-                RevObjectTestSupport.hashString("another fake commit id"), "another message",
-                tagger2);
-        ObjectId tagId = hashCommand.setObject(tag).call();
+        ObjectId tagId = hashCommand.setObject(tag1).call();
         ObjectId tagId2 = hashCommand.setObject(tag2).call();
         assertNotNull(tagId);
         assertNotNull(tagId2);
         assertNotSame(tagId, tagId2);
-
     }
 
     @Test
     public void testHashCommitsConsistency() throws Exception {
+        testHashCommitsConsistency(pointFeature1);
+        testHashCommitsConsistency(featureType1);
+        testHashCommitsConsistency(tag1);
         testHashCommitsConsistency(commit1);
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/plumbing/HashObjectTest.java
@@ -22,12 +22,12 @@ import java.util.TreeMap;
 import java.util.UUID;
 
 import org.geotools.data.DataUtilities;
-import org.geotools.geometry.jts.WKTReader2;
 import org.junit.Test;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevFeatureType;
+import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevPerson;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.impl.CommitBuilder;
@@ -43,8 +43,6 @@ import org.opengis.feature.simple.SimpleFeatureType;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.vividsolutions.jts.geom.Geometry;
-import com.vividsolutions.jts.io.ParseException;
 
 public class HashObjectTest extends RepositoryTestCase {
 
@@ -283,15 +281,28 @@ public class HashObjectTest extends RepositoryTestCase {
 
         RevPerson tagger = RevPersonBuilder.build("volaya", "volaya@boundlessgeo.com", -1000, -1);
         RevPerson tagger2 = RevPersonBuilder.build("groldan", "groldan@boundlessgeo.com", 10000, 0);
-        RevTag tag = RevTagBuilder.build(null, "tag1", RevObjectTestSupport.hashString("fake commit id"),
-                "message", tagger);
+        RevTag tag = RevTagBuilder.build(null, "tag1",
+                RevObjectTestSupport.hashString("fake commit id"), "message", tagger);
         RevTag tag2 = RevTagBuilder.build(null, "tag2",
-                RevObjectTestSupport.hashString("another fake commit id"), "another message", tagger2);
+                RevObjectTestSupport.hashString("another fake commit id"), "another message",
+                tagger2);
         ObjectId tagId = hashCommand.setObject(tag).call();
         ObjectId tagId2 = hashCommand.setObject(tag2).call();
         assertNotNull(tagId);
         assertNotNull(tagId2);
         assertNotSame(tagId, tagId2);
 
+    }
+
+    @Test
+    public void testHashCommitsConsistency() throws Exception {
+        testHashCommitsConsistency(commit1);
+    }
+
+    private void testHashCommitsConsistency(RevObject o) throws Exception {
+        ObjectId expected = o.getId();
+        ObjectId actual = hashCommand.setObject(o).call();
+
+        assertEquals(expected, actual);
     }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/plumbing/WriteTree2Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/plumbing/WriteTree2Test.java
@@ -670,7 +670,7 @@ public class WriteTree2Test extends RepositoryTestCase {
             db.put(fakenId);
         }
         if (!metadataId.isNull()) {
-            RevFeatureType fakeType = RevFeatureTypeBuilder.build(metadataId, pointsType);
+            RevFeatureType fakeType = RevFeatureTypeBuilder.create(metadataId, pointsType);
             if (!db.exists(fakeType.getId())) {
                 db.put(fakeType);
             }


### PR DESCRIPTION
Fix a bug by which re-hashing a commit would result in a different SHA-1
    
    HashObjectFunnels.CommitFunnel was funneling the commit id,
    when the id is not part of the contents of a RevObject, and
    hence it shall not be considered when computing it's hash.
    
    For backwards compatibility with versions prior to 1.2,
    CommitFunnel now has a hardcoded ObjectId.NULL null id
    funneled where the commit ids was being funneled before.
    
    This workaround is ok because the only actual way RevCommit
    instances were created is through CommitBuilder, which first
    created a fake RevCommit with NULL id, hashed it out, and used
    the resulting id to create the final RevCommit instance.
---
Compute SHA-1 ids without creating fake objects first.
    
    Most RevObject builders created its concrete RevObject instance
    by first faking one with ObjectId.NULL as id and then passing
    it through the HashObject command to obtain the actual hash, to
    finally creating the actual RevObject instance with the proper id.
    
    This patch makes that intermediate step unnecessary.
    
