### PR TITLE
Ensure that RocksDb objects are properly closed/disposed

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbDAGStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbDAGStore.java
@@ -45,14 +45,18 @@ class RocksdbDAGStore {
 
     private ColumnFamilyHandle column;
 
+    private BloomFilter bloomFilter;
+    private ColumnFamilyOptions colFamilyOptions;
+
     public RocksdbDAGStore(RocksDB db) {
         this.db = db;
         try {
             // enable bloom filter to speed up RocksDB.get() calls
             BlockBasedTableConfig tableFormatConfig = new BlockBasedTableConfig();
-            tableFormatConfig.setFilter(new BloomFilter());
+            bloomFilter = new BloomFilter();
+            tableFormatConfig.setFilter(bloomFilter);
 
-            ColumnFamilyOptions colFamilyOptions = new ColumnFamilyOptions();
+            colFamilyOptions = new ColumnFamilyOptions();
             colFamilyOptions.setTableFormatConfig(tableFormatConfig);
 
             byte[] tableNameKey = "trees".getBytes(Charsets.UTF_8);
@@ -74,6 +78,8 @@ class RocksdbDAGStore {
         readOptions.close();
         writeOptions.close();
         column.close();
+        bloomFilter.close();
+        colFamilyOptions.close();
         db = null;
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbNodeStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/RocksdbNodeStore.java
@@ -43,14 +43,18 @@ class RocksdbNodeStore {
 
     private ColumnFamilyHandle column;
 
+    private BloomFilter bloomFilter;
+    private ColumnFamilyOptions colFamilyOptions;
+
     public RocksdbNodeStore(RocksDB db) {
         this.db = db;
         try {
             // enable bloom filter to speed up RocksDB.get() calls
             BlockBasedTableConfig tableFormatConfig = new BlockBasedTableConfig();
-            tableFormatConfig.setFilter(new BloomFilter());
+            bloomFilter = new BloomFilter();
+            tableFormatConfig.setFilter(bloomFilter);
 
-            ColumnFamilyOptions colFamilyOptions = new ColumnFamilyOptions();
+            colFamilyOptions = new ColumnFamilyOptions();
             colFamilyOptions.setTableFormatConfig(tableFormatConfig);
 
             byte[] tableNameKey = "nodes".getBytes(Charsets.UTF_8);
@@ -73,6 +77,8 @@ class RocksdbNodeStore {
         readOptions.close();
         writeOptions.close();
         column.close();
+        colFamilyOptions.close();
+        bloomFilter.close();
         db = null;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy_putTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy_putTest.java
@@ -189,6 +189,8 @@ public class QuadTreeClusteringStrategy_putTest {
         // [1, 2, 2] will have one un-promotable
         dag = support.findDAG(quadStrategy, "[1, 2, 2]");
         /// assertEquals(dag.numUnpromotable(), 1);
+
+        quadStrategy.dispose();
     }
 
     @Test
@@ -293,6 +295,7 @@ public class QuadTreeClusteringStrategy_putTest {
 
             // build the tree
             origTree = DAGTreeBuilder.build(origTreeBuilder, support.store());
+            origTreeBuilder.dispose();
         }
 
         // create a new builder based on the original tree
@@ -322,6 +325,8 @@ public class QuadTreeClusteringStrategy_putTest {
 
         RevTree newTree = DAGTreeBuilder.build(updateBuilder, support.store());
         assertEquals(expectedSize, newTree.size());
+
+        updateBuilder.dispose();
     }
 
     private void print(ClusteringStrategy st, DAG root) {

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -105,7 +105,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <sqljdbc4.version>3.0</sqljdbc4.version>
     <hikaricp.version>2.4.2</hikaricp.version>
-    <rocksdb.version>4.13.4</rocksdb.version>
+    <rocksdb.version>5.7.2</rocksdb.version>
     <postgresql.version>42.1.1</postgresql.version>
     <springweb.version>4.2.5.RELEASE</springweb.version>
 

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksConnectionManager.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksConnectionManager.java
@@ -127,6 +127,20 @@ class RocksConnectionManager extends ConnectionManager<DBConfig, DBHandle> {
                     ColumnFamilyDescriptor mdd = newColDescriptor("metadata");
                     metadata = db.createColumnFamily(mdd);
                 }
+                //This usually happens only when creating a database -
+                //Column Family "default" is not handled correctly; this
+                //makes sure its put into the extraColumns so it will be correctly
+                //released when the DB is closed.
+                if (!dbconfig.getColumnFamilyNames().contains("default")) {
+                    int index = 0;
+                    for (ColumnFamilyDescriptor descriptor : colDescriptors) {
+                        if (new String(descriptor.columnFamilyName()).equals("default")) {
+                            extraColumns.put("default", colFamiliesTarget.get( index));
+                        }
+                        index++;
+                    }
+
+                }
                 for (String name : dbconfig.getColumnFamilyNames()) {
                     ColumnFamilyDescriptor colDescriptor;
                     ColumnFamilyHandle colHandle;

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
@@ -205,7 +205,7 @@ public class RocksdbObjectStore extends AbstractObjectStore implements ObjectSto
 
     private boolean exists(RocksDBReference dbRef, ReadOptions readOptions, byte[] key) {
         int size = RocksDB.NOT_FOUND;
-        if (dbRef.db().keyMayExist(key, new StringBuffer())) {
+        if (dbRef.db().keyMayExist(key, new StringBuilder(0))) {
             try {
                 size = dbRef.db().get(key, NO_DATA);
             } catch (RocksDBException e) {


### PR DESCRIPTION
This includes groldan's upgrading rocks PR.

I noticed three problems with our use of RocksDB;
a) ColumnFamilyHandles must be closed BEFORE the database is closed
cf. https://github.com/facebook/rocksdb/wiki/RocksJava-Basics#opening-a-database-with-column-families
b) sometimes objects were not being closed (and closed by finalizer)
c) test cases were not disposing of objects 
