### PR TITLE
Single PG connection pool per test class

### DIFF
--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/DataSourceManagerTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/DataSourceManagerTest.java
@@ -53,15 +53,15 @@ public class DataSourceManagerTest {
     public @Test void testAcquireRelease() {
         DataSourceManager dsm = new DataSourceManager();
         ConnectionConfig config = testConfig.getEnvironment().connectionConfig;
-        DataSource ds1 = dsm.acquire(config);
+        DataSource ds1 = dsm.acquire(config.getKey());
         assertNotNull(ds1);
-        DataSource ds2 = dsm.acquire(config);
+        DataSource ds2 = dsm.acquire(config.getKey());
         assertSame(ds1, ds2);
 
         dsm.release(ds1);
         dsm.release(ds2);
 
-        DataSource ds3 = dsm.acquire(config);
+        DataSource ds3 = dsm.acquire(config.getKey());
         assertNotNull(ds1);
         assertNotSame(ds1, ds3);
         dsm.release(ds3);
@@ -113,6 +113,6 @@ public class DataSourceManagerTest {
 
         expected.expect(IllegalStateException.class);
         expected.expectMessage("PostgreSQL JDBC Driver version not supported by GeoGig: 9.11");
-        dsm.acquire(testConfig.getEnvironment().connectionConfig);
+        dsm.acquire(testConfig.getEnvironment().connectionConfig.getKey());
     }
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGBlobStoreTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGBlobStoreTest.java
@@ -14,14 +14,17 @@ import java.io.File;
 import javax.sql.DataSource;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.storage.impl.TransactionBlobStore;
 import org.locationtech.geogig.storage.impl.TransactionBlobStoreTest;
 
 public class PGBlobStoreTest extends TransactionBlobStoreTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     private DataSource dataSource;
 

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGConfigDatabaseTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGConfigDatabaseTest.java
@@ -13,6 +13,7 @@ import static org.junit.Assert.assertEquals;
 
 import java.net.URISyntaxException;
 
+import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -23,8 +24,10 @@ import org.locationtech.geogig.storage.impl.ConfigDatabaseTest;
 
 public class PGConfigDatabaseTest extends ConfigDatabaseTest<PGConfigDatabase> {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected PGConfigDatabase createDatabase(Platform platform) {
@@ -43,7 +46,7 @@ public class PGConfigDatabaseTest extends ConfigDatabaseTest<PGConfigDatabase> {
     public void testNoRepository() {
 
         PGTestProperties props = new PGTestProperties();
-        PGConfigDatabase globalOnlydb = new PGConfigDatabase(props.getConfig(null));
+        PGConfigDatabase globalOnlydb = new PGConfigDatabase(props.newConfig(null));
         try {
             exception.expect(ConfigException.class);
             globalOnlydb.put("section.int", 1);

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGConflictsDatabaseConformanceTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGConflictsDatabaseConformanceTest.java
@@ -14,6 +14,7 @@ import java.sql.Connection;
 import javax.sql.DataSource;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.storage.impl.ConflictsDatabaseConformanceTest;
 import org.mockito.Answers;
@@ -22,8 +23,10 @@ import org.mockito.Mock;
 public class PGConflictsDatabaseConformanceTest
         extends ConflictsDatabaseConformanceTest<PGConflictsDatabase> {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private Connection mockConnection;

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGIndexDatabaseConformanceTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGIndexDatabaseConformanceTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql;
 import java.io.IOException;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.repository.Platform;
@@ -23,8 +24,10 @@ import com.google.common.base.Throwables;
 
 public class PGIndexDatabaseConformanceTest extends IndexDatabaseConformanceTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     ConfigDatabase configdb;
 

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGObjectStoreConformanceTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGObjectStoreConformanceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.locationtech.geogig.model.ObjectId;
@@ -36,8 +37,10 @@ import com.google.common.collect.Lists;
 
 public class PGObjectStoreConformanceTest extends ObjectStoreConformanceTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     ConfigDatabase configdb;
 
@@ -104,12 +107,12 @@ public class PGObjectStoreConformanceTest extends ObjectStoreConformanceTest {
 
         Iterator<RevObject> objects = db.getAll(Lists.newArrayList(originalObject.getId()),
                 new BulkOpListener() {
-            public void found(ObjectId object, @Nullable Integer storageSizeBytes) {
+                    public void found(ObjectId object, @Nullable Integer storageSizeBytes) {
                         Iterator<RevObject> subQueryObjects = db.getAll(Lists.newArrayList(object));
                         assertTrue(subQueryObjects.hasNext());
                         assertEquals(originalObject, subQueryObjects.next());
-            }
-        });
+                    }
+                });
 
         assertTrue(objects.hasNext());
         assertEquals(originalObject, objects.next());

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGRefDatabaseTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGRefDatabaseTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.locationtech.geogig.repository.Platform;
@@ -30,8 +31,10 @@ import com.google.common.base.Throwables;
 
 public class PGRefDatabaseTest extends RefDatabaseTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     ConfigDatabase configdb;
 

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
@@ -71,7 +71,7 @@ public class PGStorageTest {
                 schema, user, password, "another_repository", tablePrefix);
         assertNotEquals(repositoryName, noReposiotryName.getRepositoryName());
 
-        final DataSource expected = testConfig.openDataSource();
+        final DataSource expected = testConfig.getDataSource();
 
         DataSource actual = PGStorage.newDataSource(sameEnv);
         try {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGTestDataSourceProvider.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGTestDataSourceProvider.java
@@ -1,0 +1,104 @@
+/* Copyright (c) 2015-2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.postgresql;
+
+import java.io.File;
+
+import javax.sql.DataSource;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.rules.ExternalResource;
+import org.locationtech.geogig.storage.postgresql.Environment.ConnectionConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * Utility to be used as a {@link Rule} or {@link ClassRule} that provides access to a
+ * {@link DataSource} for the PostgreSQL database the tests should run against.
+ *
+ */
+public class PGTestDataSourceProvider extends ExternalResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PGTestDataSourceProvider.class);
+
+    private Environment.ConnectionConfig connectionConfig;
+
+    private PGTestProperties props;
+
+    private DataSource dataSource;
+
+    public @Override void before() throws AssumptionViolatedException {
+        loadProperties();
+        org.junit.Assume.assumeTrue(isEnabled());
+
+        {// won't even get there if the above statement is not true
+            String repositoryId = null;
+            Environment config = props.newConfig(repositoryId);
+            connectionConfig = config.connectionConfig;
+        }
+        getDataSource();
+    }
+
+    public @Override void after() {
+        connectionConfig = null;
+        closeDataSource();
+    }
+
+    public void closeDataSource() {
+        if (dataSource != null) {
+            PGStorage.closeDataSource(dataSource);
+            dataSource = null;
+        }
+    }
+
+    public synchronized DataSource getDataSource() {
+        Preconditions.checkNotNull(connectionConfig);
+        if (dataSource == null) {
+            dataSource = PGStorage.newDataSource(connectionConfig);
+        }
+        return dataSource;
+    }
+
+    private boolean notified = false;
+
+    public boolean isEnabled() {
+        final boolean enabled = props.get(PGTestProperties.TESTS_ENABLED_KEY, Boolean.class)
+                .or(Boolean.FALSE).booleanValue();
+        if (!enabled && !notified) {
+            final String home = System.getProperty("user.home");
+            String propsFile = new File(home, PGTestProperties.CONFIG_FILE).getAbsolutePath();
+            LOG.info("PostgreSQL backend tests disabled. Configure " + propsFile);
+            notified = true;
+        }
+        return enabled;
+    }
+
+    private void loadProperties() {
+        this.props = new PGTestProperties();
+    }
+
+    public synchronized ConnectionConfig getConnectionConfig() {
+        return connectionConfig;
+    }
+
+    public Environment newEnvironment(String repositoryId, String tablePrefix) {
+        Environment config = props.newConfig(repositoryId, tablePrefix);
+        return config;
+    }
+
+    public PGTestProperties getTestProperties() {
+        return props;
+    }
+
+}

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGTestProperties.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGTestProperties.java
@@ -32,18 +32,11 @@ public class PGTestProperties extends OnlineTestProperties {
         super(CONFIG_FILE, DEFAULTS);
     }
 
-    public static boolean isTestsEnabled() {
-        PGTestProperties props = new PGTestProperties();
-        final boolean enabled = props.get(PGTestProperties.TESTS_ENABLED_KEY, Boolean.class)
-                .or(Boolean.FALSE).booleanValue();
-        return enabled;
+    public Environment newConfig(@Nullable String repositoryId) {
+        return newConfig(repositoryId, null);
     }
 
-    public Environment getConfig(@Nullable String repositoryId) {
-        return getConfig(repositoryId, null);
-    }
-
-    public Environment getConfig(@Nullable String repositoryId, @Nullable String tablePrefix) {
+    public Environment newConfig(@Nullable String repositoryId, @Nullable String tablePrefix) {
         String server = get(Environment.KEY_DB_SERVER, String.class).orNull();
         String port = get(Environment.KEY_DB_PORT, String.class).or("5432");
         String schema = get(Environment.KEY_DB_SCHEMA, String.class).or("public");

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/PGTestUtil.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/PGTestUtil.java
@@ -9,14 +9,23 @@
  */
 package org.locationtech.geogig.storage.postgresql.functional;
 
-import org.locationtech.geogig.storage.postgresql.PGTestProperties;
+import org.junit.internal.AssumptionViolatedException;
+import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
+
+import com.google.common.base.Preconditions;
 
 import cucumber.api.PendingException;
 
 public class PGTestUtil {
 
-    public static void checkPgTestsEnabled() throws PendingException {
-        if (!PGTestProperties.isTestsEnabled()) {
+    private static PGTestDataSourceProvider perTestSuiteDataSourceProvider;
+
+    public static void beforeClass() throws PendingException {
+        perTestSuiteDataSourceProvider = new PGTestDataSourceProvider();
+        try {
+            perTestSuiteDataSourceProvider.before();
+        } catch (AssumptionViolatedException disabled) {
             System.err.println(
                     "#######################################################################################################");
             System.err.println(
@@ -29,5 +38,15 @@ public class PGTestUtil {
                     "#######################################################################################################");
             throw new PendingException();
         }
+    }
+
+    public static void afterClass() {
+        perTestSuiteDataSourceProvider.after();
+    }
+
+    public static PGTemporaryTestConfig newTestConfig(String repoName) {
+        Preconditions.checkNotNull(perTestSuiteDataSourceProvider);
+        Preconditions.checkState(perTestSuiteDataSourceProvider.isEnabled());
+        return new PGTemporaryTestConfig(repoName, perTestSuiteDataSourceProvider);
     }
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/PostgreSQLStepDefinitions.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/PostgreSQLStepDefinitions.java
@@ -18,7 +18,6 @@ import org.locationtech.geogig.cli.test.functional.TestRepoURIBuilder;
 import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
 
-import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
 import cucumber.runtime.java.StepDefAnnotation;
@@ -58,13 +57,10 @@ public class PostgreSQLStepDefinitions {
         }
 
         @Override
-        public URI newRepositoryURI(String name, Platform platform) throws URISyntaxException {
-            PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(name);
-            try {
-                testConfig.before();
-            } catch (Throwable e) {
-                throw Throwables.propagate(e);
-            }
+        public URI newRepositoryURI(String repoName, Platform platform) throws URISyntaxException {
+            PGTemporaryTestConfig testConfig = PGTestUtil.newTestConfig(repoName);
+            testConfig.before();
+
             String repoURI = testConfig.getRepoURL();
             testConfigs.add(testConfig);
             return new URI(repoURI);
@@ -73,14 +69,8 @@ public class PostgreSQLStepDefinitions {
         @Override
         public URI buildRootURI(Platform platform) {
             PGTemporaryTestConfig testConfig = testConfigs.get(testConfigs.size() - 1);
-            String rootURI = testConfig.getRepoURL()
-                    .replace("/" + testConfig.getEnvironment().getRepositoryName(), "");
-            URI rootUri = null;
-            try {
-                rootUri = new URI(rootURI);
-            } catch (URISyntaxException e) {
-                Throwables.propagate(e);
-            }
+            String rootURI = testConfig.getRootURI();
+            URI rootUri = URI.create(rootURI);
             return rootUri;
         }
     }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGGenralFunctionalTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGGenralFunctionalTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql.functional;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.junit.Cucumber;
 
 /**
@@ -30,7 +31,12 @@ import cucumber.api.junit.Cucumber;
 public class RunPGGenralFunctionalTest {
 
     @org.junit.BeforeClass
-    public static void checkPostgresTestConfig() {
-        PGTestUtil.checkPgTestsEnabled();
+    public static void checkPostgresTestConfig() throws PendingException {
+        PGTestUtil.beforeClass();
+    }
+
+    @org.junit.AfterClass
+    public static void afterClass() throws PendingException {
+        PGTestUtil.afterClass();
     }
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGPlumbingFunctionalTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGPlumbingFunctionalTest.java
@@ -13,6 +13,7 @@ package org.locationtech.geogig.storage.postgresql.functional;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.junit.Cucumber;
 
 /**
@@ -31,8 +32,13 @@ import cucumber.api.junit.Cucumber;
 public class RunPGPlumbingFunctionalTest {
 
     @org.junit.BeforeClass
-    public static void checkPostgresTestConfig() {
-        PGTestUtil.checkPgTestsEnabled();
+    public static void checkPostgresTestConfig() throws PendingException {
+        PGTestUtil.beforeClass();
+    }
+
+    @org.junit.AfterClass
+    public static void afterClass() throws PendingException {
+        PGTestUtil.afterClass();
     }
 
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGPorcelainFunctionalTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGPorcelainFunctionalTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql.functional;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.junit.Cucumber;
 
 /**
@@ -30,7 +31,12 @@ import cucumber.api.junit.Cucumber;
 public class RunPGPorcelainFunctionalTest {
 
     @org.junit.BeforeClass
-    public static void checkPostgresTestConfig() {
-        PGTestUtil.checkPgTestsEnabled();
+    public static void checkPostgresTestConfig() throws PendingException {
+        PGTestUtil.beforeClass();
+    }
+
+    @org.junit.AfterClass
+    public static void afterClass() throws PendingException {
+        PGTestUtil.afterClass();
     }
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGRemoteFunctionalTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/functional/RunPGRemoteFunctionalTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql.functional;
 import org.junit.runner.RunWith;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.junit.Cucumber;
 
 /**
@@ -30,7 +31,12 @@ import cucumber.api.junit.Cucumber;
 public class RunPGRemoteFunctionalTest {
 
     @org.junit.BeforeClass
-    public static void checkPostgresTestConfig() {
-        PGTestUtil.checkPgTestsEnabled();
+    public static void checkPostgresTestConfig() throws PendingException {
+        PGTestUtil.beforeClass();
+    }
+
+    @org.junit.AfterClass
+    public static void afterClass() throws PendingException {
+        PGTestUtil.afterClass();
     }
 }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGCheckSparsePathTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGCheckSparsePathTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 
 import com.google.inject.Guice;
 import com.google.inject.util.Modules;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 public class PGCheckSparsePathTest
         extends org.locationtech.geogig.test.integration.CheckSparsePathTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGCommitOpTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGCommitOpTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.integration.CommitOpTest;
 
 import com.google.inject.Guice;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 
 public class PGCommitOpTest extends CommitOpTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGDiffOpTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGDiffOpTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.integration.DiffOpTest;
 
 import com.google.inject.Guice;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 
 public class PGDiffOpTest extends DiffOpTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGFindCommonAncestorTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGFindCommonAncestorTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 
 import com.google.inject.Guice;
 import com.google.inject.util.Modules;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 public class PGFindCommonAncestorTest
         extends org.locationtech.geogig.test.integration.FindCommonAncestorTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGGraphDatabaseTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGGraphDatabaseTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql.integration;
 import java.io.IOException;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.storage.ConfigDatabase;
@@ -22,13 +23,16 @@ import org.locationtech.geogig.storage.postgresql.PGConfigDatabase;
 import org.locationtech.geogig.storage.postgresql.PGGraphDatabase;
 import org.locationtech.geogig.storage.postgresql.PGStorage;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 
 import com.google.common.base.Throwables;
 
 public class PGGraphDatabaseTest extends GraphDatabaseTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     ConfigDatabase configdb;
 

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGLogOpTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGLogOpTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.integration.LogOpTest;
 
 import com.google.inject.Guice;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 
 public class PGLogOpTest extends LogOpTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRebaseOpTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRebaseOpTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.integration.RebaseOpTest;
 
 import com.google.inject.Guice;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 
 public class PGRebaseOpTest extends RebaseOpTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevParseTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevParseTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -17,14 +18,17 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 
 import com.google.inject.Guice;
 import com.google.inject.util.Modules;
 
 public class PGRevParseTest extends RevParseTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevTreeBuilderTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevTreeBuilderTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql.integration;
 import java.io.IOException;
 
 import org.junit.After;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.model.impl.CanonicalTreeBuilderTest;
 import org.locationtech.geogig.storage.ConfigDatabase;
@@ -21,11 +22,14 @@ import org.locationtech.geogig.storage.postgresql.PGConfigDatabase;
 import org.locationtech.geogig.storage.postgresql.PGObjectDatabase;
 import org.locationtech.geogig.storage.postgresql.PGStorage;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 
 public class PGRevTreeBuilderTest extends CanonicalTreeBuilderTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     ConfigDatabase configDb;
 

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevertOpTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/integration/PGRevertOpTest.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.storage.postgresql.integration;
 
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.locationtech.geogig.di.GeogigModule;
 import org.locationtech.geogig.di.HintsModule;
@@ -16,6 +17,7 @@ import org.locationtech.geogig.repository.Context;
 import org.locationtech.geogig.repository.Hints;
 import org.locationtech.geogig.storage.postgresql.PGStorageModule;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.integration.RevertOpTest;
 
 import com.google.inject.Guice;
@@ -23,8 +25,10 @@ import com.google.inject.util.Modules;
 
 public class PGRevertOpTest extends RevertOpTest {
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     @Override
     protected Context createInjector() {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/performance/PGObjectDatabaseStressTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/performance/PGObjectDatabaseStressTest.java
@@ -44,15 +44,16 @@ import org.locationtech.geogig.model.impl.RevObjectTestSupport;
 import org.locationtech.geogig.repository.Platform;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.BulkOpListener.CountingListener;
-import org.locationtech.geogig.storage.cache.ObjectCache;
 import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ObjectInfo;
 import org.locationtech.geogig.storage.ObjectStore;
+import org.locationtech.geogig.storage.cache.ObjectCache;
 import org.locationtech.geogig.storage.fs.IniFileConfigDatabase;
 import org.locationtech.geogig.storage.postgresql.Environment;
 import org.locationtech.geogig.storage.postgresql.PGObjectDatabase;
 import org.locationtech.geogig.storage.postgresql.PGStorage;
 import org.locationtech.geogig.storage.postgresql.PGTemporaryTestConfig;
+import org.locationtech.geogig.storage.postgresql.PGTestDataSourceProvider;
 import org.locationtech.geogig.test.TestPlatform;
 import org.locationtech.geogig.test.performance.EnablePerformanceTestRule;
 
@@ -70,8 +71,10 @@ import com.vividsolutions.jts.io.WKTReader;
 public class PGObjectDatabaseStressTest {
     private static final MemoryMXBean MEMORY_MX_BEAN = ManagementFactory.getMemoryMXBean();
 
-    @Rule
-    public PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(getClass().getSimpleName());
+    public static @ClassRule PGTestDataSourceProvider ds = new PGTestDataSourceProvider();
+
+    public @Rule PGTemporaryTestConfig testConfig = new PGTemporaryTestConfig(
+            getClass().getSimpleName(), ds);
 
     /**
      * Enables this test only if the geogig.runPerformanceTests=true system property was provided
@@ -266,7 +269,7 @@ public class PGObjectDatabaseStressTest {
 
         Iterator<NodeRef> refs = Iterators.transform(nodes.iterator(),
                 (n) -> NodeRef.create("layer", n));
-        
+
         Iterator<ObjectInfo<RevFeature>> iterator = db.getObjects(refs, listener, RevFeature.class);
         final int returnedObjectCount = Iterators.size(iterator);
 

--- a/src/web/app/src/main/java/org/locationtech/geogig/web/MultiRepositoryProvider.java
+++ b/src/web/app/src/main/java/org/locationtech/geogig/web/MultiRepositoryProvider.java
@@ -126,7 +126,7 @@ public class MultiRepositoryProvider implements RepositoryProvider {
             final RemovalCause cause = notification.getCause();
             final String repositoryName = notification.getKey();
             final Repository repo = notification.getValue();
-            LOG.info("Disposing repository {}. Cause: " + cause(cause));
+            LOG.info("Disposing repository {}. Cause: {}", repositoryName, cause(cause));
             try {
                 if (repo != null && repo.isOpen()) {
                     repo.close();
@@ -246,7 +246,8 @@ public class MultiRepositoryProvider implements RepositoryProvider {
                 }
                 final URI repoUri = URI.create(repositoryUri.get().toString());
                 final RepositoryResolver resolver = RepositoryResolver.lookup(repoUri);
-                final Repository repository = GlobalContextBuilder.builder().build(hints).repository();
+                final Repository repository = GlobalContextBuilder.builder().build(hints)
+                        .repository();
                 if (resolver.repoExists(repoUri)) {
                     // open it
                     repository.open();

--- a/src/web/functional/src/test/java/org/geogig/web/postgresql/functional/PGWebTestRepoURIBuilder.java
+++ b/src/web/functional/src/test/java/org/geogig/web/postgresql/functional/PGWebTestRepoURIBuilder.java
@@ -48,7 +48,7 @@ public final class PGWebTestRepoURIBuilder extends TestRepoURIBuilder {
 
     @Override
     public void after() {
-        Environment environment = pgTestProperties.getConfig(null, tablePrefix);
+        Environment environment = pgTestProperties.newConfig(null, tablePrefix);
         DataSource dataSource = PGStorageTestUtil.newDataSource(environment);
         try {
             TableNames tables = environment.getTables();

--- a/src/web/functional/src/test/java/org/geogig/web/postgresql/functional/RunPGFunctionalTest.java
+++ b/src/web/functional/src/test/java/org/geogig/web/postgresql/functional/RunPGFunctionalTest.java
@@ -13,6 +13,7 @@ import org.junit.runner.RunWith;
 import org.locationtech.geogig.storage.postgresql.functional.PGTestUtil;
 
 import cucumber.api.CucumberOptions;
+import cucumber.api.PendingException;
 import cucumber.api.junit.Cucumber;
 
 
@@ -36,8 +37,13 @@ import cucumber.api.junit.Cucumber;
                 "org.geogig.web.postgresql.functional" }, features = {
                 "src/test/resources/features/commands", "src/test/resources/features/repo" })
 public class RunPGFunctionalTest {
+
     @org.junit.BeforeClass
-    public static void checkPostgresTestConfig() {
-        PGTestUtil.checkPgTestsEnabled();
+    public static void checkPostgresTestConfig() throws PendingException {
+        PGTestUtil.beforeClass();
     }
-}
+
+    @org.junit.AfterClass
+    public static void afterClass() throws PendingException {
+        PGTestUtil.afterClass();
+    }}


### PR DESCRIPTION
Running the pg tests implied the creation and destruction
of several connection pools per test case, for the same database.

This patch introduces PGTestDataSourceProvider as a JUnit
ExternalResource to be used either as an @Rule or @ClassRule,
so that the javax.sql.DataSource can be used on a test class or
test case basis, as appropriate.

Most test classes are updated to configure the test DataSource
once for all its test cases.

It also has a performance impact. For a fast laptop with a local PG the results look something like this:

Before:
```
Tests run: 3117, Failures: 0, Errors: 0, Skipped: 1

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 09:26 min
[INFO] Finished at: 2017-08-30T15:35:08-03:00
[INFO] Final Memory: 35M/645M
[INFO] ------------------------------------------------------------------------
```
After:
```
Tests run: 3117, Failures: 0, Errors: 0, Skipped: 1

[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 08:46 min
[INFO] Finished at: 2017-08-30T15:47:51-03:00
[INFO] Final Memory: 28M/449M
[INFO] ------------------------------------------------------------------------
```