### PR TITLE
Temporary meassure to fix the build on Windows

### DIFF
--- a/src/core/src/test/java/org/locationtech/geogig/test/TestPlatform.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/TestPlatform.java
@@ -55,4 +55,30 @@ public class TestPlatform extends DefaultPlatform implements Platform, Cloneable
         return getClass().getSimpleName() + "[home=" + this.userHomeDirectory + ", pwd="
                 + super.workingDir + "]";
     }
+
+    //Make sure that all the times are unique (make sure clock ticks between calls)
+    @Override
+    public synchronized long currentTimeMillis() {
+        boolean keep_going = true;
+        int i = 0;
+        long current = super.currentTimeMillis();
+        while (keep_going) {
+            if (current <= lastCreatedTimestamp) {
+                try {
+                    Thread.sleep(1);
+                } catch (Exception e) {
+                    //do nothing
+                }
+            } else {
+                lastCreatedTimestamp = current;
+                return current;
+            }
+            i++;
+            keep_going = i < 50; // don't run forever -- this should never be a problem (except for system clock resets)
+            current = super.currentTimeMillis();
+        }
+        return current; //waited too long
+    }
+
+    static volatile long lastCreatedTimestamp = 0;
 }

--- a/src/core/src/test/java/org/locationtech/geogig/test/TestPlatformTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/TestPlatformTest.java
@@ -1,0 +1,40 @@
+/* Copyright (c) 2012-2016 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.test;
+
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.locationtech.geogig.repository.Platform;
+
+import java.io.File;
+import java.io.IOException;
+
+import static org.junit.Assert.assertNotEquals;
+
+public class TestPlatformTest {
+
+    @Rule
+    public TemporaryFolder tempFolder = new TemporaryFolder();
+
+    //simple test -- ensure that the platform clock is always increase (no repeated values).
+    @Test
+    public void testClock() throws IOException {
+        Platform testPlatform = new TestPlatform(tempFolder.getRoot());
+
+        long lastTime = 0;
+        for (int t=0;t<100; t++) {
+            long time = testPlatform.currentTimeMillis();
+            assertNotEquals(time,lastTime);
+            lastTime = time;
+        }
+    }
+}


### PR DESCRIPTION
Ensure test case commit times are unique + logOp doesn't re-traverse

This was originally manifested as a windows build failure.  Root cause was that the log times
were exactly the same time - resulting in the LogOp returning rows in the wrong order.

This fixes:
a) LogOp - fixed implementation so it doesn't accidently follow a history path twice
b) TestPlatform - ensure that times are always increase (never equal)

Nonetheless, this is just a temporary fix, the real fix needs to:
- Add explicit test cases for when the commits have the same timestamp
- Make sure the historiracl log order is predictable in those cases