### PR TITLE
Update to RocksDB 5.7.3

### DIFF
--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -96,7 +96,7 @@
     <slf4j.version>1.7.5</slf4j.version>
     <sqljdbc4.version>3.0</sqljdbc4.version>
     <hikaricp.version>2.4.2</hikaricp.version>
-    <rocksdb.version>5.7.2</rocksdb.version>
+    <rocksdb.version>5.7.3</rocksdb.version>
     <postgresql.version>42.1.1</postgresql.version>
     <springweb.version>4.3.7.RELEASE</springweb.version>
     <servlet-api.version>3.1.0</servlet-api.version>


### PR DESCRIPTION
A CQ is in place with LocationTech to get version 5.7.3 of RocksDB approved here: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=14177
Update the dependency to be in sync with that version.