### PR TITLE
[backport to 1.1.x] Prevent NPE when a merge conflict has a deleted feature.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,5 +28,8 @@ script:
 services: postgresql
 addons:
   postgresql: "9.4"
+  apt:
+    packages:
+      - postgresql-9.4-postgis-2.3
 notifications:
   email: false

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/PagedMergeScenarioConsumer.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/PagedMergeScenarioConsumer.java
@@ -96,7 +96,7 @@ public class PagedMergeScenarioConsumer extends MergeScenarioConsumer {
      */
     @Override
     public void unconflicted(DiffEntry diff) {
-        if (diff.newObjectType().equals(RevObject.TYPE.FEATURE) && shouldKeep()) {
+        if (RevObject.TYPE.FEATURE.equals(diff.newObjectType()) && shouldKeep()) {
             unconflicted.add(diff);
         }
     }

--- a/src/web/api/src/test/java/org/locationtech/geogig/web/api/TestData.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/web/api/TestData.java
@@ -126,7 +126,7 @@ public class TestData {
 
     public static final SimpleFeature line1, line2, line3;
 
-    public static final SimpleFeature poly1, poly2, poly3;
+    public static final SimpleFeature poly1, poly2, poly3, poly4, poly1_modified1, poly1_modified2;
 
     static {
         try {
@@ -156,7 +156,12 @@ public class TestData {
                 "POLYGON ((-11 -11, -11 -9, -9 -9, -9 -11, -11 -11))");
         poly3 = feature(polysType, "Polygon.3", "StringProp3_3", 3000,
                 "POLYGON ((9 9, 9 11, 11 11, 11 9, 9 9))");
-
+        poly4 = feature(polysType, "Polygon.4", "StringProp3_4", 4000,
+                "POLYGON ((4 4, 4 5, 5 5, 5 4, 4 4))");
+        poly1_modified1 = feature(polysType, "Polygon.1", "StringProp3_1", 1000,
+                "POLYGON ((-4 -4, -4 4, 4 4, 4 -4, -4 -4))");
+        poly1_modified2 = feature(polysType, "Polygon.1", "StringProp3_1", 1000,
+                "POLYGON ((-5 -5, -5 5, 5 5, 5 -5, -5 -5))");
     }
 
     private Repository repo;


### PR DESCRIPTION
This will fix the issue for the 1.1.x branch, but only for those building this branch themselves as there is currently no plan to publish any 1.1.X maintenance release.