### PR TITLE
Fix issues with Windows build.

### DIFF
--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ParentsControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ParentsControllerTest.java
@@ -85,10 +85,11 @@ public class ParentsControllerTest extends AbstractControllerTest {
             MockHttpServletRequestBuilder get =
                     MockMvcRequestBuilders.get(
                             "/repos/repo1/repo/getparents?commitId=" + oid);
-            String[] actualIds = perform(get).andExpect(status().isOk())
+            String response = perform(get).andExpect(status().isOk())
                     .andExpect(content().contentType(MediaType.TEXT_PLAIN))
                     // verify the bytes
-                    .andReturn().getResponse().getContentAsString().split("\\s");
+                    .andReturn().getResponse().getContentAsString();
+            String[] actualIds = response.split("\\s+");
             if (actualIds.length == 1 && actualIds[0].isEmpty()) {
                 // the actual IDs is empty
                 actualIds = new String[0];

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/PostgisControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/PostgisControllerTest.java
@@ -42,11 +42,6 @@ import com.google.common.collect.Lists;
 
 public class PostgisControllerTest extends AbstractControllerTest {
 
-    @After
-    public void after() {
-        AsyncContext.close();
-    }
-
     @Test
     public void testImportNoTransaction() throws Exception {
         PostgisController.dataStoreFactory = TestHelper.createTestFactory();

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/TaskControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/TaskControllerTest.java
@@ -41,11 +41,6 @@ import com.google.common.io.Files;
 
 public class TaskControllerTest extends AbstractControllerTest {
 
-    @After
-    public void after() {
-        AsyncContext.close();
-    }
-
     @Test
     public void testTaskList() throws Exception {
         AsyncContext context = AsyncContext.get();


### PR DESCRIPTION
AsyncContext is a singleton.  On fast machines under parallel execution, sometimes one of the tests will close it while the other tests are still using it, causing some errors.