### PR TITLE
Update to GeoTools 19 and enable the use of Java 9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ cache:
     - "$HOME/.m2"
 language: java
 jdk:
-  - oraclejdk8
+  - oraclejdk9
 before_install: 
   - cd src/parent
   - sudo apt-get install libspatialite-dev

--- a/src/core/src/test/java/org/locationtech/geogig/data/EPSGBoundsCalcTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/data/EPSGBoundsCalcTest.java
@@ -32,10 +32,19 @@ import com.vividsolutions.jts.geom.Point;
 
 public class EPSGBoundsCalcTest extends RepositoryTestCase {
 
+    private static final double TOLERANCE = 0.000000002;
+
     @Override
     protected void setUpInternal() throws Exception {
         injector.configDatabase().put("user.name", "mthompson");
         injector.configDatabase().put("user.email", "mthompson@boundlessgeo.com");
+    }
+
+    private void assertEnvelopesEqual(Envelope expected, Envelope actual) {
+        assertEquals("MinX values not equal", expected.getMinX(), actual.getMinX(), TOLERANCE);
+        assertEquals("MaxX values not equal", expected.getMaxX(), actual.getMaxX(), TOLERANCE);
+        assertEquals("MinY values not equal", expected.getMinY(), actual.getMinY(), TOLERANCE);
+        assertEquals("MaxY values not equal", expected.getMaxY(), actual.getMaxY(), TOLERANCE);
     }
 
     @Test
@@ -53,7 +62,7 @@ public class EPSGBoundsCalcTest extends RepositoryTestCase {
         Envelope bounds;
         for (int i=0; i<testArray.length; i++) {
             bounds = new EPSGBoundsCalc().getCRSBounds(testArray[i]);
-            assertEquals(testEnvelopes[i], bounds);
+            assertEnvelopesEqual(testEnvelopes[i], bounds);
         }
     }
 
@@ -127,8 +136,8 @@ public class EPSGBoundsCalcTest extends RepositoryTestCase {
             ft = featureType.get();
 
         //double check the actual bounds
-        Envelope bounds = new EPSGBoundsCalc().getCRSBounds(ft);
-        Envelope actual = new Envelope(205723.76927073707, 794276.2307292629, 3128220.0383561817, 9329005.182379141);
-        assertEquals(actual,bounds);
+        Envelope actual = new EPSGBoundsCalc().getCRSBounds(ft);
+        Envelope expected = new Envelope(205723.76927073707, 794276.2307292629, 3128220.0383561817, 9329005.182379141);
+        assertEnvelopesEqual(expected, actual);
     }
 }

--- a/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactoryTest.java
+++ b/src/datastore/src/test/java/org/locationtech/geogig/geotools/data/reader/ExtraDataPropertyAccessorFactoryTest.java
@@ -24,7 +24,6 @@ import java.util.Map;
 import java.util.ServiceLoader;
 
 import org.eclipse.jdt.annotation.Nullable;
-import org.geotools.factory.FactoryRegistry;
 import org.geotools.factory.Hints;
 import org.geotools.filter.expression.PropertyAccessor;
 import org.geotools.filter.expression.PropertyAccessorFactory;
@@ -98,7 +97,7 @@ public class ExtraDataPropertyAccessorFactoryTest {
     @Test
     public void testLowLevelSPI() {
         Iterator<PropertyAccessorFactory> factories;
-        factories = FactoryRegistry.lookupProviders(PropertyAccessorFactory.class);
+        factories = ServiceLoader.load(PropertyAccessorFactory.class).iterator();
         while (factories.hasNext()) {
             PropertyAccessorFactory factory = factories.next();
             if (factory instanceof ExtraDataPropertyAccessorFactory) {

--- a/src/parent/pom.xml
+++ b/src/parent/pom.xml
@@ -82,7 +82,7 @@
     <compress-lzf.version>1.0.3</compress-lzf.version>
     <cucumber-java.version>1.2.4</cucumber-java.version>
     <gson.version>2.4</gson.version>
-    <gt.version>18.0</gt.version>
+    <gt.version>19-SNAPSHOT</gt.version>
     <guava.version>18.0</guava.version>
     <guice.version>4.0</guice.version>
     <jcommander.version>1.48</jcommander.version>
@@ -105,7 +105,7 @@
     <war.plugin.version>2.4</war.plugin.version>
     <jetty.plugin.version>7.1.6.v20100715</jetty.plugin.version>
     <dependency.plugin.version>2.2</dependency.plugin.version>
-    <surefire.plugin.version>2.17</surefire.plugin.version>
+    <surefire.plugin.version>2.20.1</surefire.plugin.version>
     <assembly.plugin.version>2.2-beta-5</assembly.plugin.version>
 
     <test.maxHeapSize>512M</test.maxHeapSize>
@@ -495,10 +495,15 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.1</version>
         <configuration>
-          <source>1.8</source>
-          <target>1.8</target>
+          <source>1.9</source>
+          <target>1.9</target>
+          <release>9</release>
           <debug>true</debug>
           <encoding>UTF-8</encoding>
+          <compilerArgs>
+            <arg>--add-modules</arg>
+            <arg>java.xml.bind</arg>
+          </compilerArgs>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
Updates the GeoTools dependency to 19-SNAPSHOT. GeoTools 19 is the first version that will run under Java 9 (see https://github.com/geotools/geotools/pull/1670)