### PR TITLE
Fix PostgreSQL getVersion logic

### DIFF
--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.storage.postgresql;
 import static java.lang.String.format;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -204,6 +205,20 @@ public class PGStorageTest {
             }
         } finally {
             PGStorage.closeDataSource(source);
+        }
+    }
+
+    @Test
+    public void testGetVersionFromQueryResult() {
+        // ensure PG reported versions don't break
+        // versions can be {major}.{minor} or {major}.{minor}.{patch}
+        try {
+            assertNotNull(PGStorage.getVersionFromQueryResult("9.4.0"));
+            assertNotNull(PGStorage.getVersionFromQueryResult("10.1"));
+        } catch (Exception ex) {
+            // test failed
+            ex.printStackTrace();
+            fail("Version string not handled");
         }
     }
 


### PR DESCRIPTION
Since PostgreSQL 10, the server version reported can be something like `10.1`, which does not match the pattern with prior versions (ex. `9.4.0`). This PR eases the restriction and interprets a version of `x.y` as `{major}`.`{minor}` and implies a `patch` version of `0`