### PR TITLE
Reduce memory footprint of object model

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/model/Bucket.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/Bucket.java
@@ -53,18 +53,24 @@ public abstract class Bucket implements Bounded {
     }
 
     private static class BucketImpl extends Bucket {
-        private final ObjectId bucketTree;
+        private final int bucketTree_h1;
+
+        private final long bucketTree_h2;
+
+        private final long bucketTree_h3;
 
         private final Float32Bounds bounds;
 
         private BucketImpl(ObjectId id, Float32Bounds bounds) {
-            this.bucketTree = id;
+            this.bucketTree_h1 = RevObjects.h1(id);
+            this.bucketTree_h2 = RevObjects.h2(id);
+            this.bucketTree_h3 = RevObjects.h3(id);
             this.bounds = bounds;
         }
 
         @Override
         public ObjectId getObjectId() {
-            return bucketTree;
+            return ObjectId.create(bucketTree_h1, bucketTree_h2, bucketTree_h3);
         }
 
         @Override

--- a/src/api/src/main/java/org/locationtech/geogig/model/Float32Bounds.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/Float32Bounds.java
@@ -14,19 +14,16 @@ import org.eclipse.jdt.annotation.Nullable;
 import com.vividsolutions.jts.geom.Coordinate;
 import com.vividsolutions.jts.geom.Envelope;
 
-
 /**
- * This represents a bounds - much like a JTS Envelope.
- * However, to save space, this uses Float32 numbers instead of Float64.
- * The original Envelope will be contained by the Float32Bounds.
+ * This represents a bounds - much like a JTS Envelope. However, to save space, this uses Float32
+ * numbers instead of Float64. The original Envelope will be contained by the Float32Bounds.
  *
- * NOTE:
- *     * this will usually (not always) larger than the original envelope
- *     * This bounds will always contain (or be equal to) the original envelope
- *     * for every Float32 number, there is an exact Float64 representation
+ * NOTE: * this will usually (not always) larger than the original envelope * This bounds will
+ * always contain (or be equal to) the original envelope * for every Float32 number, there is an
+ * exact Float64 representation
  */
 class Float32Bounds {
-    
+
     /**
      * The "null object" to represent an empty node
      * 
@@ -34,16 +31,18 @@ class Float32Bounds {
      */
     private static final Float32Bounds EMPTY = new Float32Bounds(new Envelope());
 
-    //defaults - xmin > xmax (no area)
+    // defaults - xmin > xmax (no area)
     float xmin = Float.MIN_VALUE;
-    float xmax = 0;
-    float ymin = Float.MIN_VALUE;
-    float ymax = 0;
 
+    float xmax = 0;
+
+    float ymin = Float.MIN_VALUE;
+
+    float ymax = 0;
 
     private Float32Bounds(Envelope doublePrecisionEnv) {
         if ((doublePrecisionEnv == null) || (doublePrecisionEnv.isNull())) {
-            return; //done!
+            return; // done!
         }
         set(doublePrecisionEnv);
     }
@@ -68,8 +67,8 @@ class Float32Bounds {
             return;
         }
 
-        //convert to float32, but ensure that the new bounds contain the old bounds
-        //NOTE: every float32 can be exactly expressed as a double
+        // convert to float32, but ensure that the new bounds contain the old bounds
+        // NOTE: every float32 can be exactly expressed as a double
 
         xmin = (float) doublePrecisionEnv.getMinX();
         if (((double) xmin) > doublePrecisionEnv.getMinX()) {
@@ -92,7 +91,6 @@ class Float32Bounds {
         }
     }
 
-
     public Envelope asEnvelope() {
         if (isNull())
             return new Envelope();
@@ -112,7 +110,7 @@ class Float32Bounds {
                 env.getMaxY() < ymin);
     }
 
-    //To be careful, the resulting envelope is aligned with the float32 envelope!
+    // To be careful, the resulting envelope is aligned with the float32 envelope!
     public void expand(Envelope env) {
         if (isNull())
             return;
@@ -126,7 +124,6 @@ class Float32Bounds {
     public boolean isNull() {
         return xmin > xmax;
     }
-
 
     @Override
     public String toString() {
@@ -151,10 +148,8 @@ class Float32Bounds {
         if (other.isNull() != this.isNull())
             return false;
 
-        return other.xmin == this.xmin &&
-                other.ymin == this.ymin &&
-                other.xmax == this.xmax &&
-                other.ymax == this.ymax;
+        return other.xmin == this.xmin && other.ymin == this.ymin && other.xmax == this.xmax
+                && other.ymax == this.ymax;
 
     }
 
@@ -162,7 +157,8 @@ class Float32Bounds {
     public int hashCode() {
         if (isNull())
             return 1;
-        return Float.floatToRawIntBits(xmin) ^ Float.floatToRawIntBits(ymin) ^ Float.floatToRawIntBits(xmax) ^ Float.floatToRawIntBits(ymax);
+        return Float.floatToRawIntBits(xmin) ^ Float.floatToRawIntBits(ymin)
+                ^ Float.floatToRawIntBits(xmax) ^ Float.floatToRawIntBits(ymax);
     }
 
     /**
@@ -173,5 +169,8 @@ class Float32Bounds {
     public static Float32Bounds valueOf(@Nullable Envelope bounds) {
         return bounds == null || bounds.isNull() ? EMPTY : new Float32Bounds(bounds);
     }
-}
 
+    static Float32Bounds valueOf(float x1, float x2, float y1, float y2) {
+        return new Float32Bounds(x1, x2, y1, y2);
+    }
+}

--- a/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
@@ -118,7 +118,7 @@ public class HashObjectFunnels {
         HashObjectFunnels.tree(hasher, trees, features, buckets);
 
         final byte[] rawKey = hasher.hash().asBytes();
-        final ObjectId id = ObjectId.createNoClone(rawKey);
+        final ObjectId id = ObjectId.create(rawKey);
 
         return id;
     }

--- a/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/HashObjectFunnels.java
@@ -225,10 +225,14 @@ public class HashObjectFunnels {
 
         @Override
         public void funnel(RevTree from, PrimitiveSink into) {
-            ImmutableList<Node> trees = from.trees();
-            ImmutableList<Node> features = from.features();
-            ImmutableSortedMap<Integer, Bucket> buckets = from.buckets();
-            funnel(into, trees, features, buckets);
+            RevObjectTypeFunnel.funnel(TYPE.TREE, into);
+            from.forEachTree((n) -> NodeFunnel.funnel(n, into));
+            from.forEachFeature((n) -> NodeFunnel.funnel(n, into));
+
+            from.forEachBucket((index, bucket) -> {
+                Funnels.integerFunnel().funnel(index, into);
+                ObjectIdFunnel.funnel(bucket.getObjectId(), into);
+            });
         }
 
         public void funnel(PrimitiveSink into, List<Node> trees, List<Node> features,

--- a/src/api/src/main/java/org/locationtech/geogig/model/Node.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/Node.java
@@ -122,7 +122,9 @@ public abstract class Node implements Bounded, Comparable<Node> {
         /**
          * Id of the object this ref points to
          */
-        private final ObjectId objectId;
+        private final int objectId_h1;
+
+        private final long objectId_h2, objectId_h3;
 
         private final ExtraData extraData;
 
@@ -134,7 +136,9 @@ public abstract class Node implements Bounded, Comparable<Node> {
             checkNotNull(oid);
             checkNotNull(metadataId);
             this.name = name;
-            this.objectId = oid;
+            this.objectId_h1 = RevObjects.h1(oid);
+            this.objectId_h2 = RevObjects.h2(oid);
+            this.objectId_h3 = RevObjects.h3(oid);
             this.metadataId = metadataId.isNull() ? null : metadataId;
             this.extraData = ExtraData.of(extraData);
             this.bounds = Float32Bounds.valueOf(bounds);
@@ -157,7 +161,7 @@ public abstract class Node implements Bounded, Comparable<Node> {
          * @return the id of the {@link RevObject} this Node points to
          */
         public ObjectId getObjectId() {
-            return objectId;
+            return ObjectId.create(objectId_h1, objectId_h2, objectId_h3);
         }
 
         @Override

--- a/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
@@ -185,105 +185,11 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         Preconditions.checkArgument(hash.length() == NUM_CHARS, hash,
                 String.format("ObjectId.valueOf: Invalid hash string %s", hash));
         //@formatter:off
-        int h1 = toInt(
-                byteN(hash, 0), 
-                byteN(hash, 1), 
-                byteN(hash, 2), 
-                byteN(hash, 3));
-        long h2 = toLong(
-                byteN(hash, 4), 
-                byteN(hash, 5), 
-                byteN(hash, 6), 
-                byteN(hash, 7),
-                byteN(hash, 8), 
-                byteN(hash, 9), 
-                byteN(hash, 10), 
-                byteN(hash, 11));
-        long h3 = toLong(
-                byteN(hash, 12), 
-                byteN(hash, 13), 
-                byteN(hash, 14), 
-                byteN(hash, 15),
-                byteN(hash, 16), 
-                byteN(hash, 17), 
-                byteN(hash, 18), 
-                byteN(hash, 19));
+        int h1 = RevObjects.h1(hash);
+        long h2 = RevObjects.h2(hash);
+        long h3 = RevObjects.h3(hash);
         //@formatter:on
         return create(h1, h2, h3);
-    }
-
-    private static int toInt(byte b1, byte b2, byte b3, byte b4) {
-        int i = b1 & 0xFF;
-        i = (i << 8) | b2 & 0xFF;
-        i = (i << 8) | b3 & 0xFF;
-        i = (i << 8) | b4 & 0xFF;
-        return i;
-    }
-
-    private static long toLong(byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7,
-            byte b8) {
-        long l = b1 & 0xFF;
-        l = (l << 8) | b2 & 0xFF;
-        l = (l << 8) | b3 & 0xFF;
-        l = (l << 8) | b4 & 0xFF;
-        l = (l << 8) | b5 & 0xFF;
-        l = (l << 8) | b6 & 0xFF;
-        l = (l << 8) | b7 & 0xFF;
-        l = (l << 8) | b8 & 0xFF;
-        return l;
-    }
-
-    /**
-     * Custom implementation to extract a byte from an hex encoded string without incurring in
-     * String.substring()
-     */
-    private static byte byteN(String hexString, int byteIndex) {
-        char c1 = hexString.charAt(2 * byteIndex);
-        char c2 = hexString.charAt(2 * byteIndex + 1);
-        byte b1 = hexToByte(c1);
-        byte b2 = hexToByte(c2);
-        int b = b1 << 4;
-        b |= b2;
-        return (byte) b;
-    }
-
-    private static byte hexToByte(char c) {
-        switch (c) {
-        case '0':
-            return 0;
-        case '1':
-            return 1;
-        case '2':
-            return 2;
-        case '3':
-            return 3;
-        case '4':
-            return 4;
-        case '5':
-            return 5;
-        case '6':
-            return 6;
-        case '7':
-            return 7;
-        case '8':
-            return 8;
-        case '9':
-            return 9;
-        case 'a':
-            return 10;
-        case 'b':
-            return 11;
-        case 'c':
-            return 12;
-        case 'd':
-            return 13;
-        case 'e':
-            return 14;
-        case 'f':
-            return 15;
-        default:
-            throw new IllegalArgumentException();
-        }
     }
 
     /**

--- a/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
@@ -69,9 +69,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         NULL = new ObjectId(new byte[20]);
     }
 
-    private final int h1;
+    final int h1;
 
-    private final long h2, h3;
+    final long h2, h3;
 
     /**
      * Constructs a new object id with the given byte code.

--- a/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/ObjectId.java
@@ -13,13 +13,13 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 import java.io.Serializable;
-import java.util.Arrays;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Ordering;
 import com.google.common.hash.HashFunction;
 import com.google.common.hash.Hashing;
-import com.google.common.primitives.UnsignedBytes;
+import com.google.common.primitives.UnsignedInts;
+import com.google.common.primitives.UnsignedLongs;
 
 /**
  * A unique identifier for a {@link RevObject}, which is created by passing a {@link HashFunction}
@@ -69,14 +69,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         NULL = new ObjectId(new byte[20]);
     }
 
-    private final byte[] hashCode;
+    private final int h1;
 
-    /**
-     * Constructs a new {@code NULL} object id.
-     */
-    public ObjectId() {
-        this.hashCode = NULL.hashCode;
-    }
+    private final long h2, h3;
 
     /**
      * Constructs a new object id with the given byte code.
@@ -84,18 +79,60 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      * @param raw the byte code to use
      */
     public ObjectId(byte[] raw) {
-        this(raw, true);
-    }
-
-    private ObjectId(byte[] raw, boolean cloneArg) {
-        Preconditions.checkNotNull(raw);
-        Preconditions.checkArgument(raw.length == NUM_BYTES, "expected a byte[%s], got byte[%s]",
+        Preconditions.checkArgument(raw.length >= NUM_BYTES, "expected a byte[%s], got byte[%s]",
                 NUM_BYTES, raw.length);
-        this.hashCode = cloneArg ? raw.clone() : raw;
+        this.h1 = readH1(raw);
+        this.h2 = readH2(raw);
+        this.h3 = readH3(raw);
     }
 
+    private ObjectId(int h1, long h2, long h3) {
+        this.h1 = h1;
+        this.h2 = h2;
+        this.h3 = h3;
+    }
+
+    private static int readH1(byte[] raw) {
+        int h = byteN(raw, 0) << 24;
+        h |= byteN(raw, 1) << 16;
+        h |= byteN(raw, 2) << 8;
+        h |= byteN(raw, 3) << 0;
+        return h;
+    }
+
+    private static long readH2(byte[] raw) {
+        return readLong(raw, 4);
+    }
+
+    private static long readH3(byte[] raw) {
+        return readLong(raw, 12);
+    }
+
+    private static long readLong(byte[] raw, int offset) {
+        long h = ((long) byteN(raw, offset)) << 56;
+        h |= ((long) byteN(raw, offset + 1)) << 48;
+        h |= ((long) byteN(raw, offset + 2)) << 40;
+        h |= ((long) byteN(raw, offset + 3)) << 32;
+        h |= ((long) byteN(raw, offset + 4)) << 24;
+        h |= ((long) byteN(raw, offset + 5)) << 16;
+        h |= ((long) byteN(raw, offset + 6)) << 8;
+        h |= ((long) byteN(raw, offset + 7)) << 0;
+        return h;
+    }
+
+    /**
+     * @deprecated use #create
+     */
     public static ObjectId createNoClone(byte[] rawHash) {
-        return new ObjectId(rawHash, false);
+        return new ObjectId(rawHash);
+    }
+
+    public static ObjectId create(byte[] raw) {
+        return new ObjectId(raw);
+    }
+
+    public static ObjectId create(int h1, long h2, long h3) {
+        return new ObjectId(h1, h2, h3);
     }
 
     /**
@@ -112,13 +149,11 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      */
     @Override
     public boolean equals(Object o) {
-        if (o == this) {
-            return true;
+        if (o instanceof ObjectId) {
+            ObjectId i = (ObjectId) o;
+            return this == o || (h1 == i.h1 && h2 == i.h2 && h3 == i.h3);
         }
-        if (!(o instanceof ObjectId)) {
-            return false;
-        }
-        return Arrays.equals(hashCode, ((ObjectId) o).hashCode);
+        return false;
     }
 
     /**
@@ -126,10 +161,7 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      */
     @Override
     public int hashCode() {
-        return 17 ^ ((hashCode[0] & 0xFF)//
-                | ((hashCode[1] & 0xFF) << 8)//
-                | ((hashCode[2] & 0xFF) << 16)//
-                | ((hashCode[3] & 0xFF) << 24));
+        return 31 ^ (h1 == 0 ? 1 : h1);
     }
 
     /**
@@ -152,15 +184,106 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         Preconditions.checkNotNull(hash);
         Preconditions.checkArgument(hash.length() == NUM_CHARS, hash,
                 String.format("ObjectId.valueOf: Invalid hash string %s", hash));
+        //@formatter:off
+        int h1 = toInt(
+                byteN(hash, 0), 
+                byteN(hash, 1), 
+                byteN(hash, 2), 
+                byteN(hash, 3));
+        long h2 = toLong(
+                byteN(hash, 4), 
+                byteN(hash, 5), 
+                byteN(hash, 6), 
+                byteN(hash, 7),
+                byteN(hash, 8), 
+                byteN(hash, 9), 
+                byteN(hash, 10), 
+                byteN(hash, 11));
+        long h3 = toLong(
+                byteN(hash, 12), 
+                byteN(hash, 13), 
+                byteN(hash, 14), 
+                byteN(hash, 15),
+                byteN(hash, 16), 
+                byteN(hash, 17), 
+                byteN(hash, 18), 
+                byteN(hash, 19));
+        //@formatter:on
+        return create(h1, h2, h3);
+    }
 
-        // this is perhaps the worse way of doing this...
+    private static int toInt(byte b1, byte b2, byte b3, byte b4) {
+        int i = b1 & 0xFF;
+        i = (i << 8) | b2 & 0xFF;
+        i = (i << 8) | b3 & 0xFF;
+        i = (i << 8) | b4 & 0xFF;
+        return i;
+    }
 
-        final byte[] raw = new byte[NUM_BYTES];
-        final int radix = 16;
-        for (int i = 0; i < NUM_BYTES; i++) {
-            raw[i] = (byte) Integer.parseInt(hash.substring(2 * i, 2 * i + 2), radix);
+    private static long toLong(byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7,
+            byte b8) {
+        long l = b1 & 0xFF;
+        l = (l << 8) | b2 & 0xFF;
+        l = (l << 8) | b3 & 0xFF;
+        l = (l << 8) | b4 & 0xFF;
+        l = (l << 8) | b5 & 0xFF;
+        l = (l << 8) | b6 & 0xFF;
+        l = (l << 8) | b7 & 0xFF;
+        l = (l << 8) | b8 & 0xFF;
+        return l;
+    }
+
+    /**
+     * Custom implementation to extract a byte from an hex encoded string without incurring in
+     * String.substring()
+     */
+    private static byte byteN(String hexString, int byteIndex) {
+        char c1 = hexString.charAt(2 * byteIndex);
+        char c2 = hexString.charAt(2 * byteIndex + 1);
+        byte b1 = hexToByte(c1);
+        byte b2 = hexToByte(c2);
+        int b = b1 << 4;
+        b |= b2;
+        return (byte) b;
+    }
+
+    private static byte hexToByte(char c) {
+        switch (c) {
+        case '0':
+            return 0;
+        case '1':
+            return 1;
+        case '2':
+            return 2;
+        case '3':
+            return 3;
+        case '4':
+            return 4;
+        case '5':
+            return 5;
+        case '6':
+            return 6;
+        case '7':
+            return 7;
+        case '8':
+            return 8;
+        case '9':
+            return 9;
+        case 'a':
+            return 10;
+        case 'b':
+            return 11;
+        case 'c':
+            return 12;
+        case 'd':
+            return 13;
+        case 'e':
+            return 14;
+        case 'f':
+            return 15;
+        default:
+            throw new IllegalArgumentException();
         }
-        return new ObjectId(raw, false);
     }
 
     /**
@@ -197,9 +320,17 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      * @see java.lang.Comparable#compareTo(java.lang.Object)
      */
     public int compareTo(final ObjectId o) {
-        byte[] left = this.hashCode;
-        byte[] right = o.hashCode;
-        return UnsignedBytes.lexicographicalComparator().compare(left, right);
+        if (this == o) {
+            return 0;
+        }
+        int c = UnsignedInts.compare(h1, o.h1);
+        if (c == 0) {
+            c = UnsignedLongs.compare(h2, o.h2);
+            if (c == 0) {
+                c = UnsignedLongs.compare(h3, o.h3);
+            }
+        }
+        return c;
     }
 
     /**
@@ -207,7 +338,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      *         do not affect this object.
      */
     public byte[] getRawValue() {
-        return hashCode.clone();
+        byte[] raw = new byte[NUM_BYTES];
+        getRawValue(raw);
+        return raw;
     }
 
     /**
@@ -236,7 +369,9 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
         Preconditions.checkArgument(length >= 0);
         Preconditions.checkArgument(length <= NUM_BYTES);
         Preconditions.checkArgument(target.length >= length);
-        System.arraycopy(hashCode, 0, target, 0, length);
+        for (int i = 0; i < length; i++) {
+            target[i] = (byte) byteN(i);
+        }
     }
 
     /**
@@ -249,17 +384,40 @@ public final class ObjectId implements Comparable<ObjectId>, Serializable {
      */
     public int byteN(final int index) {
         Preconditions.checkArgument(index >= 0 && index < NUM_BYTES);
-        int b = this.hashCode[index] & 0xFF;
-        return b;
+        long word;
+        int byteOffset;
+
+        if (index < 4) {
+            word = h1;
+            byteOffset = 3 - index;
+        } else if (index < 12) {
+            word = h2;
+            byteOffset = 7 - (index - 4);
+        } else {
+            word = h3;
+            byteOffset = 7 - (index - 12);
+        }
+
+        int byteN;
+        int bitOffset = byteOffset * 8;
+        byteN = (int) (word >>> bitOffset) & 0xFF;
+        return byteN;
+    }
+
+    private static int byteN(final byte[] raw, final int index) {
+        return raw[index] & 0xFF;
     }
 
     public static ObjectId readFrom(DataInput in) throws IOException {
-        byte[] rawid = new byte[ObjectId.NUM_BYTES];
-        in.readFully(rawid);
-        return new ObjectId(rawid);
+        int h1 = in.readInt();
+        long h2 = in.readLong();
+        long h3 = in.readLong();
+        return create(h1, h2, h3);
     }
 
     public void writeTo(DataOutput out) throws IOException {
-        out.write(this.hashCode);
+        out.writeInt(h1);
+        out.writeLong(h2);
+        out.writeLong(h3);
     }
 }

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
@@ -70,14 +70,14 @@ public class RevObjects {
      */
     public static Iterator<Node> children(RevTree tree, Comparator<Node> comparator) {
         checkNotNull(comparator);
+        if (tree.treesSize() == 0) {
+            return tree.features().iterator();
+        }
+        if (tree.featuresSize() == 0) {
+            return tree.trees().iterator();
+        }
         ImmutableList<Node> trees = tree.trees();
         ImmutableList<Node> features = tree.features();
-        if (trees.isEmpty()) {
-            return features.iterator();
-        }
-        if (features.isEmpty()) {
-            return trees.iterator();
-        }
         return Iterators.mergeSorted(ImmutableList.of(trees.iterator(), features.iterator()),
                 comparator);
     }

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
@@ -51,9 +51,9 @@ public class RevObjects {
         Preconditions.checkArgument(numBytes > 0 && numBytes <= ObjectId.NUM_BYTES);
 
         StringBuilder sb = target == null ? new StringBuilder(2 * numBytes) : target;
-        byte b;
+        int b;
         for (int i = 0; i < numBytes; i++) {
-            b = (byte) id.byteN(i);
+            b = id.byteN(i);
             sb.append(HEX_DIGITS[(b >> 4) & 0xf]).append(HEX_DIGITS[b & 0xf]);
         }
         return sb;

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
@@ -94,4 +94,122 @@ public class RevObjects {
         return id.h3;
     }
 
+    public static int h1(String hash) {
+        Preconditions.checkArgument(hash.length() >= 8);
+        //@formatter:off
+        int h1 = toInt(
+                byteN(hash, 0), 
+                byteN(hash, 1), 
+                byteN(hash, 2), 
+                byteN(hash, 3));
+        //@formatter:on
+        return h1;
+    }
+
+    public static long h2(String hash) {
+        Preconditions.checkArgument(hash.length() >= 24);
+        //@formatter:off
+        long h2 = toLong(
+                byteN(hash, 4), 
+                byteN(hash, 5), 
+                byteN(hash, 6), 
+                byteN(hash, 7),
+                byteN(hash, 8), 
+                byteN(hash, 9), 
+                byteN(hash, 10), 
+                byteN(hash, 11));
+        //@formatter:on
+        return h2;
+    }
+
+    public static long h3(String hash) {
+        Preconditions.checkArgument(hash.length() >= 40);
+        //@formatter:off
+        long h3 = toLong(
+                byteN(hash, 12), 
+                byteN(hash, 13), 
+                byteN(hash, 14), 
+                byteN(hash, 15),
+                byteN(hash, 16), 
+                byteN(hash, 17), 
+                byteN(hash, 18), 
+                byteN(hash, 19));
+        //@formatter:on
+        return h3;
+    }
+
+    private static int toInt(byte b1, byte b2, byte b3, byte b4) {
+        int i = b1 & 0xFF;
+        i = (i << 8) | b2 & 0xFF;
+        i = (i << 8) | b3 & 0xFF;
+        i = (i << 8) | b4 & 0xFF;
+        return i;
+    }
+
+    private static long toLong(byte b1, byte b2, byte b3, byte b4, byte b5, byte b6, byte b7,
+            byte b8) {
+        long l = b1 & 0xFF;
+        l = (l << 8) | b2 & 0xFF;
+        l = (l << 8) | b3 & 0xFF;
+        l = (l << 8) | b4 & 0xFF;
+        l = (l << 8) | b5 & 0xFF;
+        l = (l << 8) | b6 & 0xFF;
+        l = (l << 8) | b7 & 0xFF;
+        l = (l << 8) | b8 & 0xFF;
+        return l;
+    }
+
+    /**
+     * Custom implementation to extract a byte from an hex encoded string without incurring in
+     * String.substring()
+     */
+    private static byte byteN(String hexString, int byteIndex) {
+        char c1 = hexString.charAt(2 * byteIndex);
+        char c2 = hexString.charAt(2 * byteIndex + 1);
+        byte b1 = hexToByte(c1);
+        byte b2 = hexToByte(c2);
+        int b = b1 << 4;
+        b |= b2;
+        return (byte) b;
+    }
+
+    private static byte hexToByte(char c) {
+        switch (c) {
+        case '0':
+            return 0;
+        case '1':
+            return 1;
+        case '2':
+            return 2;
+        case '3':
+            return 3;
+        case '4':
+            return 4;
+        case '5':
+            return 5;
+        case '6':
+            return 6;
+        case '7':
+            return 7;
+        case '8':
+            return 8;
+        case '9':
+            return 9;
+        case 'a':
+            return 10;
+        case 'b':
+            return 11;
+        case 'c':
+            return 12;
+        case 'd':
+            return 13;
+        case 'e':
+            return 14;
+        case 'f':
+            return 15;
+        default:
+            throw new IllegalArgumentException();
+        }
+    }
+
 }

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevObjects.java
@@ -82,4 +82,16 @@ public class RevObjects {
                 comparator);
     }
 
+    public static int h1(ObjectId id) {
+        return id.h1;
+    }
+
+    public static long h2(ObjectId id) {
+        return id.h2;
+    }
+
+    public static long h3(ObjectId id) {
+        return id.h3;
+    }
+
 }

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevTree.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevTree.java
@@ -10,6 +10,8 @@
 package org.locationtech.geogig.model;
 
 import java.util.Comparator;
+import java.util.function.BiConsumer;
+import java.util.function.Consumer;
 
 import org.locationtech.geogig.storage.ObjectStore;
 
@@ -186,6 +188,21 @@ public interface RevTree extends RevObject {
     public ImmutableList<Node> trees();
 
     /**
+     * @return the number of {@link Node}s in the {@link #trees} property
+     */
+    public default int treesSize() {
+        return trees().size();
+    }
+
+    /**
+     * Performs the given action for each element of the {@link #trees} collection respecting its
+     * iteration order
+     */
+    public default void forEachTree(Consumer<Node> consumer) {
+        trees().forEach(consumer);
+    }
+
+    /**
      * The {@link TYPE#FEATURE feature} nodes held directly by this tree.
      * <p>
      * A {@code RevTree} instance may hold as many feature nodes as allowed by it's builder before
@@ -210,6 +227,21 @@ public interface RevTree extends RevObject {
     public ImmutableList<Node> features();
 
     /**
+     * @return the number of {@link Node}s in the {@link #features} property
+     */
+    public default int featuresSize() {
+        return features().size();
+    }
+
+    /**
+     * Performs the given action for each element of the {@link #features} collection respecting its
+     * iteration order
+     */
+    public default void forEachFeature(Consumer<Node> consumer) {
+        features().forEach(consumer);
+    }
+
+    /**
      * The mapping of (zero-based) bucket index to the bucket (pointer to {@link RevTree} instance)
      * this revtree has been split into.
      * <p>
@@ -224,4 +256,22 @@ public interface RevTree extends RevObject {
      * @apiNote the returned map does not contain {@code null} keys nor values
      */
     public ImmutableSortedMap<Integer, Bucket> buckets();
+
+    /**
+     * @return the number of buckets in the {@link #buckets} property
+     */
+    public default int bucketsSize() {
+        return buckets().size();
+    }
+
+    /**
+     * Performs the given action for each element of the {@link #buckets} collection respecting its
+     * iteration order, which is the order of the bucket index.
+     * 
+     * @param consumer a consumer that accepts a tuple given by the bucket index and the bucket
+     *        itself
+     */
+    public default void forEachBucket(BiConsumer<Integer, Bucket> consumer) {
+        buckets().forEach(consumer);
+    }
 }

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevTree.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevTree.java
@@ -10,6 +10,7 @@
 package org.locationtech.geogig.model;
 
 import java.util.Comparator;
+import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
@@ -194,6 +195,10 @@ public interface RevTree extends RevObject {
         return trees().size();
     }
 
+    public default Node getTree(int index) {
+        return trees().get(index);
+    }
+
     /**
      * Performs the given action for each element of the {@link #trees} collection respecting its
      * iteration order
@@ -231,6 +236,10 @@ public interface RevTree extends RevObject {
      */
     public default int featuresSize() {
         return features().size();
+    }
+
+    public default Node getFeature(int index) {
+        return features().get(index);
     }
 
     /**
@@ -273,5 +282,9 @@ public interface RevTree extends RevObject {
      */
     public default void forEachBucket(BiConsumer<Integer, Bucket> consumer) {
         buckets().forEach(consumer);
+    }
+
+    public default Optional<Bucket> getBucket(int bucketIndex) {
+        return Optional.ofNullable(buckets().get(Integer.valueOf(bucketIndex)));
     }
 }

--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -103,7 +103,7 @@ public final class IndexInfo {
         final Hasher hasher = ObjectId.HASH_FUNCTION.newHasher();
         hasher.putBytes(treeName.getBytes(Charsets.UTF_8));
         hasher.putBytes(attributeName.getBytes(Charsets.UTF_8));
-        return ObjectId.createNoClone(hasher.hash().asBytes());
+        return ObjectId.create(hasher.hash().asBytes());
     }
 
     public static Set<String> getMaterializedAttributeNames(IndexInfo info) {

--- a/src/api/src/test/java/org/locationtech/geogig/model/HashObjectFunnelsTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/HashObjectFunnelsTest.java
@@ -218,7 +218,7 @@ public class HashObjectFunnelsTest {
         byte[] rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
 
-        ObjectId id1 = ObjectId.createNoClone(rawKey);
+        ObjectId id1 = ObjectId.create(rawKey);
 
         trees.add(testNode);
         features.add(testNode);
@@ -230,7 +230,7 @@ public class HashObjectFunnelsTest {
         rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
 
-        ObjectId id2 = ObjectId.createNoClone(rawKey);
+        ObjectId id2 = ObjectId.create(rawKey);
 
         assertNotSame(id1, id2);
 
@@ -293,13 +293,13 @@ public class HashObjectFunnelsTest {
 
         byte[] rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
-        ObjectId emptyFeatureId1 = ObjectId.createNoClone(rawKey);
+        ObjectId emptyFeatureId1 = ObjectId.create(rawKey);
 
         hasher = Hashing.sha1().newHasher();
         HashObjectFunnels.feature(hasher, ImmutableList.of());
         rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
-        ObjectId emptyFeatureId2 = ObjectId.createNoClone(rawKey);
+        ObjectId emptyFeatureId2 = ObjectId.create(rawKey);
 
         assertEquals(emptyFeatureId1, emptyFeatureId2);
 
@@ -352,13 +352,13 @@ public class HashObjectFunnelsTest {
 
         rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
-        ObjectId featureId1 = ObjectId.createNoClone(rawKey);
+        ObjectId featureId1 = ObjectId.create(rawKey);
 
         hasher = Hashing.sha1().newHasher();
         HashObjectFunnels.feature(hasher, Lists.transform(values, (value) -> value.orNull()));
         rawKey = hasher.hash().asBytes();
         assertEquals(ObjectId.NUM_BYTES, rawKey.length);
-        ObjectId featureId2 = ObjectId.createNoClone(rawKey);
+        ObjectId featureId2 = ObjectId.create(rawKey);
 
         assertEquals(featureId1, featureId2);
 

--- a/src/api/src/test/java/org/locationtech/geogig/model/ObjectIdTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/model/ObjectIdTest.java
@@ -29,7 +29,7 @@ public class ObjectIdTest extends TestCase {
 
     @Test
     public void testEquals() {
-        ObjectId nullId = new ObjectId();
+        ObjectId nullId = ObjectId.valueOf("0000000000000000000000000000000000000000");
         ObjectId id1 = ObjectId.valueOf("abc123000000000000001234567890abcdef0000");
         ObjectId id2 = ObjectId.valueOf("abc123000000000000001234567890abcdef0000");
         assertNotSame(id1, id2);
@@ -41,8 +41,10 @@ public class ObjectIdTest extends TestCase {
 
     @Test
     public void testToStringAndValueOf() {
-        ObjectId id1 = ObjectId.valueOf("abc123000000000000001234567890abcdef0000");
+        final String hexString = "abc123000000000000001234567890abcdef0000";
+        ObjectId id1 = ObjectId.valueOf(hexString);
         String stringRep = id1.toString();
+        assertEquals(hexString, stringRep);
         ObjectId valueOf = ObjectId.valueOf(stringRep);
         assertEquals(id1, valueOf);
 
@@ -58,13 +60,35 @@ public class ObjectIdTest extends TestCase {
 
     @Test
     public void testByeN() {
-        ObjectId oid = new ObjectId(new byte[] { 00, 01, 02, 03, (byte) 0xff, 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0, 0 });
-        assertEquals(0, oid.byteN(0));
-        assertEquals(1, oid.byteN(1));
-        assertEquals(2, oid.byteN(2));
-        assertEquals(3, oid.byteN(3));
-        assertEquals(255, oid.byteN(4));
+        //@formatter:off
+        byte[] raw = new byte[] { 
+                (byte) 0xab, 
+                01, 
+                02, 
+                03, 
+                (byte) 0xff, 
+                4, 
+                8, 
+                16, 
+                32, 
+                64, 
+                (byte) 128, 
+                -1, 
+                -2,
+                -4, 
+                -8, 
+                -16, 
+                -32, 
+                -64, 
+                -128, 
+                0 };
+        //@formatter:on
+        ObjectId oid = ObjectId.create(raw);
+        for (int i = 0; i < raw.length; i++) {
+            int expected = raw[i] & 0xFF;
+            int actual = oid.byteN(i);
+            assertEquals("At index " + i, expected, actual);
+        }
 
         try {
             oid.byteN(-1);
@@ -119,12 +143,12 @@ public class ObjectIdTest extends TestCase {
     }
 
     @Test
-    public void testCreateNoClone() {
+    public void testCreate() {
         byte[] rawBytes = new byte[] { (byte) 0xab, 01, 02, 03, (byte) 0xff, 0, 0, 0, 0, 0, 0, 0, 0,
                 0, 0, 0, 0, 0, 0, 0 };
-        ObjectId id = ObjectId.createNoClone(rawBytes);
-        rawBytes[1] = 5;
-        assertEquals(5, id.byteN(1));
+        ObjectId id1 = ObjectId.create(rawBytes);
+        ObjectId id2 = ObjectId.create(rawBytes);
+        assertEquals(id1, id2);
     }
 
     @Test

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/AbstractRevObject.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/AbstractRevObject.java
@@ -14,6 +14,7 @@ import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevFeatureType;
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.model.RevObjects;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
 
@@ -29,11 +30,18 @@ import com.google.common.base.Preconditions;
  * @see RevTag
  */
 public abstract class AbstractRevObject implements RevObject {
-    private final ObjectId id;
+
+    private final int h1;
+
+    private final long h2;
+
+    private final long h3;
 
     public AbstractRevObject(final ObjectId id) {
         Preconditions.checkNotNull(id);
-        this.id = id;
+        this.h1 = RevObjects.h1(id);
+        this.h2 = RevObjects.h2(id);
+        this.h3 = RevObjects.h3(id);
     }
 
     /**
@@ -42,7 +50,7 @@ public abstract class AbstractRevObject implements RevObject {
      * @return unique hash of this object.
      */
     public final ObjectId getId() {
-        return id;
+        return ObjectId.create(h1, h2, h3);
     }
 
     /**
@@ -55,6 +63,6 @@ public abstract class AbstractRevObject implements RevObject {
         if (!(o instanceof RevObject)) {
             return false;
         }
-        return id.equals(((RevObject) o).getId());
+        return getId().equals(((RevObject) o).getId());
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTreeBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTreeBuilder.java
@@ -9,6 +9,7 @@
  */
 package org.locationtech.geogig.model.impl;
 
+import java.util.List;
 import java.util.SortedMap;
 import java.util.function.BooleanSupplier;
 
@@ -92,8 +93,8 @@ public interface RevTreeBuilder {
     public @Nullable RevTree build(BooleanSupplier abortFlag);
 
     static RevTree build(final long size, final int childTreeCount,
-            @Nullable ImmutableList<Node> trees, @Nullable ImmutableList<Node> features,
-            @Nullable ImmutableSortedMap<Integer, Bucket> buckets) {
+            @Nullable List<Node> trees, @Nullable List<Node> features,
+            @Nullable SortedMap<Integer, Bucket> buckets) {
 
         ObjectId id = HashObject.hashTree(trees, features, buckets);
         return RevTreeImpl.create(id, size, childTreeCount, trees, features, buckets);

--- a/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTreeImpl.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/impl/RevTreeImpl.java
@@ -154,9 +154,9 @@ abstract class RevTreeImpl extends AbstractRevObject implements RevTree {
 
     @Override
     public String toString() {
-        final int nSubtrees = trees().size();
-        final int nBuckets = buckets().size();
-        final int nFeatures = features().size();
+        final int nSubtrees = treesSize();
+        final int nBuckets = bucketsSize();
+        final int nFeatures = featuresSize();
 
         StringBuilder builder = new StringBuilder();
         builder.append("Tree[");

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGNode.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/DAGNode.java
@@ -9,8 +9,6 @@
  */
 package org.locationtech.geogig.model.internal;
 
-import static com.google.common.base.Preconditions.checkState;
-
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -19,9 +17,6 @@ import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.storage.datastream.FormatCommonV2_2;
 import org.locationtech.geogig.storage.datastream.Varint;
-
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 
 abstract class DAGNode {
 
@@ -126,18 +121,10 @@ abstract class DAGNode {
         @Override
         public final Node resolve(TreeCache cache) {
             RevTree tree = cache.resolve(leafRevTreeId);
-            ImmutableList<Node> collection = collection(tree);
-            Node node;
-            try {
-                node = collection.get(nodeIndex);
-            } catch (IndexOutOfBoundsException e) {
-                e.printStackTrace();
-                throw e;
-            }
-            return node;
+            return resolve(tree);
         }
 
-        protected abstract ImmutableList<Node> collection(RevTree tree);
+        protected abstract Node resolve(RevTree tree);
 
         @Override
         public boolean isNull() {
@@ -167,10 +154,8 @@ abstract class DAGNode {
         }
 
         @Override
-        protected ImmutableList<Node> collection(RevTree tree) {
-            Preconditions.checkState(!tree.trees().isEmpty());
-            ImmutableList<Node> trees = tree.trees();
-            return trees;
+        protected Node resolve(RevTree tree) {
+            return tree.getTree(this.nodeIndex);
         }
 
     }
@@ -182,10 +167,8 @@ abstract class DAGNode {
         }
 
         @Override
-        protected ImmutableList<Node> collection(RevTree tree) {
-            checkState(!tree.features().isEmpty());
-            ImmutableList<Node> features = tree.features();
-            return features;
+        protected Node resolve(RevTree tree) {
+            return tree.getFeature(this.nodeIndex);
         }
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/QuadTreeClusteringStrategy.java
@@ -31,7 +31,6 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSortedMap;
 import com.vividsolutions.jts.geom.Envelope;
 
 /**
@@ -222,12 +221,11 @@ final class QuadTreeClusteringStrategy extends ClusteringStrategy {
             } else {
                 normalizedSizeLimit = normalizedSizeLimit();
                 // it may be a quad wit sub-quads instead of an unpromotables tree
-                ImmutableSortedMap<Integer, Bucket> buckets = originalTree.buckets();
-                boolean isValidQuad = !buckets.isEmpty();
+                boolean isValidQuad = originalTree.bucketsSize() > 0;
                 for (Quadrant q : Quadrant.VALUES) {
-                    Bucket treeBucket = buckets.get(Integer.valueOf(q.getBucketNumber()));
-                    if (treeBucket != null) {
-                        Envelope bucketBounds = treeBucket.bounds().orNull();
+                    java.util.Optional<Bucket> treeBucket = originalTree.getBucket(q.getBucketNumber());
+                    if (treeBucket.isPresent()) {
+                        Envelope bucketBounds = treeBucket.get().bounds().orNull();
                         Quadrant bucketQuad = computeQuadrant(bucketBounds, childDepthIndex);
                         if (bucketQuad == null) {
                             isValidQuad = false;

--- a/src/core/src/main/java/org/locationtech/geogig/model/internal/TreeCache.java
+++ b/src/core/src/main/java/org/locationtech/geogig/model/internal/TreeCache.java
@@ -9,7 +9,9 @@
  */
 package org.locationtech.geogig.model.internal;
 
+import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -24,7 +26,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
-import com.google.common.collect.Iterables;
 
 class TreeCache {
 
@@ -58,8 +59,10 @@ class TreeCache {
         if (internalId == null) {
             tree = store.getTree(treeId);
             getTreeId(tree);
-            if (!tree.buckets().isEmpty()) {
-                preload(Iterables.transform(tree.buckets().values(), (b) -> b.getObjectId()));
+            if (tree.bucketsSize() > 0) {
+                List<ObjectId> bucketIds = new ArrayList<>(tree.bucketsSize());
+                tree.forEachBucket((i, b) -> bucketIds.add(b.getObjectId()));
+                preload(bucketIds);
             }
         } else {
             tree = resolve(internalId.intValue());

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/HashObject.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/HashObject.java
@@ -81,7 +81,7 @@ public class HashObject extends AbstractGeoGigOp<ObjectId> {
         final Funnel<RevObject> funnel = (Funnel<RevObject>) FUNNELS[object.getType().value()];
         funnel.funnel(object, hasher);
         final byte[] rawKey = hasher.hash().asBytes();
-        final ObjectId id = ObjectId.createNoClone(rawKey);
+        final ObjectId id = ObjectId.create(rawKey);
 
         return id;
     }
@@ -123,7 +123,7 @@ public class HashObject extends AbstractGeoGigOp<ObjectId> {
         funnel.accept(hasher);
 
         final byte[] rawKey = hasher.hash().asBytes();
-        final ObjectId id = ObjectId.createNoClone(rawKey);
+        final ObjectId id = ObjectId.create(rawKey);
 
         return id;
     }

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/diff/DepthTreeIterator.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/diff/DepthTreeIterator.java
@@ -222,7 +222,7 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
         private Iterator<Node> children;
 
         public Children(RevTree tree) {
-            if (!tree.buckets().isEmpty()) {
+            if (tree.bucketsSize() > 0) {
                 this.children = new Buckets(tree);
             } else {
                 this.children = Iterators.filter(
@@ -244,9 +244,9 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
         private Iterator<Node> features;
 
         public Features(RevTree tree) {
-            if (!tree.features().isEmpty()) {
+            if (tree.featuresSize() > 0) {
                 this.features = Iterators.filter(tree.features().iterator(), boundsFilter);
-            } else if (!tree.buckets().isEmpty()) {
+            } else if (tree.bucketsSize() > 0) {
                 this.features = new FeatureBuckets(tree);
             } else {
                 this.features = Collections.emptyIterator();
@@ -269,9 +269,9 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
         public Trees(RevTree tree) {
             if (tree.numTrees() == 0) {
                 this.trees = Collections.emptyIterator();
-            } else if (!tree.trees().isEmpty()) {
+            } else if (tree.treesSize() > 0) {
                 this.trees = Iterators.filter(tree.trees().iterator(), boundsFilter);
-            } else if (!tree.buckets().isEmpty()) {
+            } else if (tree.bucketsSize() > 0) {
                 this.trees = new TreeBuckets(tree);
             } else {
                 this.trees = Collections.emptyIterator();
@@ -297,7 +297,7 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
         private Iterator<Node> bucketEntries;
 
         public Buckets(RevTree tree) {
-            Preconditions.checkArgument(!tree.buckets().isEmpty());
+            Preconditions.checkArgument(tree.bucketsSize() > 0);
             buckets = Iterators.filter(tree.buckets().values().iterator(), boundsFilter);
             bucketEntries = Collections.emptyIterator();
             // may it be a mixed tree (having both direct children and buckets)
@@ -323,7 +323,7 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
          */
         protected Iterator<Node> resolveBucketEntries(ObjectId bucketId) {
             RevTree bucketTree = source.getTree(bucketId);
-            if (!bucketTree.buckets().isEmpty()) {
+            if (bucketTree.bucketsSize() > 0) {
                 return new Buckets(bucketTree);
             }
             return new Children(bucketTree);
@@ -345,10 +345,10 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
             if (bucketTree.numTrees() == 0) {
                 return Collections.emptyIterator();
             }
-            if (!bucketTree.trees().isEmpty()) {
+            if (bucketTree.treesSize() > 0) {
                 return new Trees(bucketTree);
             }
-            if (!bucketTree.buckets().isEmpty()) {
+            if (bucketTree.bucketsSize() > 0) {
                 return new TreeBuckets(bucketTree);
             }
             return Collections.emptyIterator();
@@ -367,10 +367,10 @@ public class DepthTreeIterator extends AbstractIterator<NodeRef> {
         @Override
         protected Iterator<Node> resolveBucketEntries(ObjectId bucketId) {
             RevTree bucketTree = source.getTree(bucketId);
-            if (!bucketTree.buckets().isEmpty()) {
+            if (bucketTree.bucketsSize() > 0) {
                 return new FeatureBuckets(bucketTree);
             }
-            if (!bucketTree.features().isEmpty()) {
+            if (bucketTree.featuresSize() > 0) {
                 return new Features(bucketTree);
             }
             return Collections.emptyIterator();

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeStatusBuilder.java
@@ -212,14 +212,12 @@ public class MergeStatusBuilder extends MergeScenarioConsumer {
 
         @Override
         public void write(DataOutputStream out, ObjectId value) throws IOException {
-            out.write(value.getRawValue());
+            value.writeTo(out);
         }
 
         @Override
         public ObjectId read(DataInputStream in) throws IOException {
-            byte[] raw = new byte[ObjectId.NUM_BYTES];
-            in.readFully(raw);
-            return ObjectId.createNoClone(raw);
+            return ObjectId.readFrom(in);
         }
     };
 

--- a/src/core/src/main/java/org/locationtech/geogig/repository/impl/DepthSearch.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/impl/DepthSearch.java
@@ -26,8 +26,6 @@ import org.locationtech.geogig.storage.ObjectStore;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Lists;
 
 /**
@@ -140,20 +138,22 @@ public class DepthSearch {
             return Optional.absent();
         }
 
-        if (!parent.trees().isEmpty() || !parent.features().isEmpty()) {
-            if (!parent.trees().isEmpty()) {
-                ImmutableList<Node> refs = parent.trees();
-                for (int i = 0; i < refs.size(); i++) {
-                    if (directChildName.equals(refs.get(i).getName())) {
-                        return Optional.of(refs.get(i));
+        if (parent.treesSize() > 0 || parent.featuresSize() > 0) {
+            if (parent.treesSize() > 0) {
+                final int size = parent.treesSize();
+                for (int i = 0; i < size; i++) {
+                    Node node = parent.getTree(i);
+                    if (directChildName.equals(node.getName())) {
+                        return Optional.of(node);
                     }
                 }
             }
-            if (!parent.features().isEmpty()) {
-                ImmutableList<Node> refs = parent.features();
-                for (int i = 0; i < refs.size(); i++) {
-                    if (directChildName.equals(refs.get(i).getName())) {
-                        return Optional.of(refs.get(i));
+            if (parent.featuresSize() > 0) {
+                final int size = parent.featuresSize();
+                for (int i = 0; i < size; i++) {
+                    Node node = parent.getFeature(i);
+                    if (directChildName.equals(node.getName())) {
+                        return Optional.of(node);
                     }
                 }
             }
@@ -161,8 +161,7 @@ public class DepthSearch {
         }
 
         Integer bucket = refOrder.bucket(directChildName, subtreesDepth);
-        ImmutableSortedMap<Integer, Bucket> buckets = parent.buckets();
-        Bucket subtreeBucket = buckets.get(bucket);
+        Bucket subtreeBucket = parent.getBucket(bucket.intValue()).orElse(null);
         if (subtreeBucket == null) {
             return Optional.absent();
         }

--- a/src/core/src/main/java/org/locationtech/geogig/repository/impl/SpatialOps.java
+++ b/src/core/src/main/java/org/locationtech/geogig/repository/impl/SpatialOps.java
@@ -81,9 +81,9 @@ public class SpatialOps {
 
     public static Envelope boundsOf(RevTree tree) {
         Envelope env = new Envelope();
-        tree.buckets().values().forEach((b) -> b.expand(env));
-        tree.trees().forEach((t) -> t.expand(env));
-        tree.features().forEach((f) -> f.expand(env));
+        tree.forEachBucket((i, b) -> b.expand(env));
+        tree.forEachTree(n -> n.expand(env));
+        tree.forEachFeature(n -> n.expand(env));
         return env;
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1.java
@@ -144,10 +144,10 @@ public class DataStreamSerializationFactoryV1 implements ObjectSerializingFactor
             try {
                 FormatCommonV1.writeHeader(data, "commit");
                 data.writeByte(COMMIT_TREE_REF);
-                data.write(commit.getTreeId().getRawValue());
+                commit.getTreeId().writeTo(data);
                 for (ObjectId pId : commit.getParentIds()) {
                     data.writeByte(COMMIT_PARENT_REF);
-                    data.write(pId.getRawValue());
+                    pId.writeTo(data);
                 }
                 data.writeByte(COMMIT_AUTHOR_PREFIX);
                 FormatCommonV1.writePerson(commit.getAuthor(), data);

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
@@ -83,9 +83,7 @@ public class FormatCommonV1 {
     }
 
     public final static ObjectId readObjectId(DataInput in) throws IOException {
-        byte[] bytes = new byte[ObjectId.NUM_BYTES];
-        in.readFully(bytes);
-        return ObjectId.createNoClone(bytes);
+        return ObjectId.readFrom(in);
     }
 
     public static final byte COMMIT_TREE_REF = 0x01;
@@ -129,7 +127,7 @@ public class FormatCommonV1 {
     }
 
     public static void writeTag(RevTag tag, DataOutput out) throws IOException {
-        out.write(tag.getCommitId().getRawValue());
+        tag.getCommitId().writeTo(out);
         out.writeUTF(tag.getName());
         out.writeUTF(tag.getMessage());
         writePerson(tag.getTagger(), out);
@@ -141,9 +139,7 @@ public class FormatCommonV1 {
             throw new IllegalArgumentException("Commit should include a tree ref");
         }
 
-        final byte[] treeIdBytes = new byte[20];
-        in.readFully(treeIdBytes);
-        final ObjectId treeId = ObjectId.createNoClone(treeIdBytes);
+        final ObjectId treeId = ObjectId.readFrom(in);
         final Builder<ObjectId> parentListBuilder = ImmutableList.builder();
 
         while (true) {
@@ -151,9 +147,7 @@ public class FormatCommonV1 {
             if (tag != COMMIT_PARENT_REF) {
                 break;
             } else {
-                final byte[] parentIdBytes = new byte[20];
-                in.readFully(parentIdBytes);
-                parentListBuilder.add(ObjectId.createNoClone(parentIdBytes));
+                parentListBuilder.add(ObjectId.readFrom(in));
             }
         }
 
@@ -238,16 +232,13 @@ public class FormatCommonV1 {
 
     public static Node readNode(DataInput in) throws IOException {
         final String name = in.readUTF();
-        final byte[] objectId = new byte[20];
-        in.readFully(objectId);
-        final byte[] metadataId = new byte[20];
-        in.readFully(metadataId);
+        final ObjectId objectId = ObjectId.readFrom(in);
+        final ObjectId metadataId = ObjectId.readFrom(in);
         final RevObject.TYPE contentType = RevObject.TYPE.valueOf(in.readByte());
         final Envelope bbox = readBBox(in);
         Map<String, Object> extraData = DataStreamValueSerializerV1.INSTANCE.readMap(in);
         final Node node;
-        node = Node.create(name, ObjectId.createNoClone(objectId),
-                ObjectId.createNoClone(metadataId), contentType, bbox, extraData);
+        node = Node.create(name, objectId, metadataId, contentType, bbox, extraData);
         return node;
     }
 
@@ -268,16 +259,13 @@ public class FormatCommonV1 {
 
     public static NodeRef readNodeRef(DataInput in) throws IOException {
         Node node = readNode(in);
-        final byte[] metadataId = new byte[20];
-        in.readFully(metadataId);
+        final ObjectId metadataId = ObjectId.readFrom(in);
         String parentPath = in.readUTF();
-        return new NodeRef(node, parentPath, ObjectId.createNoClone(metadataId));
+        return new NodeRef(node, parentPath, metadataId);
     }
 
     public static final Bucket readBucket(DataInput in) throws IOException {
-        final byte[] hash = new byte[20];
-        in.readFully(hash);
-        ObjectId objectId = ObjectId.createNoClone(hash);
+        ObjectId objectId = ObjectId.readFrom(in);
         Envelope bounds = readBBox(in);
         return Bucket.create(objectId, bounds);
     }
@@ -404,7 +392,7 @@ public class FormatCommonV1 {
     public static void writeBucket(int index, Bucket bucket, DataOutput data, Envelope envBuff) {
         try {
             data.writeInt(index);
-            data.write(bucket.getObjectId().getRawValue());
+            bucket.getObjectId().writeTo(data);
             envBuff.setToNull();
             bucket.expand(envBuff);
             writeBoundingBox(envBuff, data);
@@ -420,8 +408,8 @@ public class FormatCommonV1 {
     public static void writeNode(Node node, DataOutput data, Envelope envBuff) {
         try {
             data.writeUTF(node.getName());
-            data.write(node.getObjectId().getRawValue());
-            data.write(node.getMetadataId().or(ObjectId.NULL).getRawValue());
+            node.getObjectId().writeTo(data);
+            node.getMetadataId().or(ObjectId.NULL).writeTo(data);
             int typeN = node.getType().value();
             data.writeByte(typeN);
             envBuff.setToNull();
@@ -452,7 +440,7 @@ public class FormatCommonV1 {
 
     public static void writeNodeRef(NodeRef nodeRef, DataOutput data) throws IOException {
         writeNode(nodeRef.getNode(), data);
-        data.write(nodeRef.getMetadataId().getRawValue());
+        nodeRef.getMetadataId().writeTo(data);
         data.writeUTF(nodeRef.getParentPath());
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2.java
@@ -104,9 +104,7 @@ public class FormatCommonV2 {
     }
 
     public final ObjectId readObjectId(DataInput in) throws IOException {
-        byte[] bytes = new byte[ObjectId.NUM_BYTES];
-        in.readFully(bytes);
-        return ObjectId.createNoClone(bytes);
+        return ObjectId.readFrom(in);
     }
 
     /**
@@ -148,18 +146,18 @@ public class FormatCommonV2 {
     }
 
     public void writeTag(RevTag tag, DataOutput out) throws IOException {
-        out.write(tag.getCommitId().getRawValue());
+        tag.getCommitId().writeTo(out);
         out.writeUTF(tag.getName());
         out.writeUTF(tag.getMessage());
         writePerson(tag.getTagger(), out);
     }
 
     public void writeCommit(RevCommit commit, DataOutput data) throws IOException {
-        data.write(commit.getTreeId().getRawValue());
+        commit.getTreeId().writeTo(data);
         final int nParents = commit.getParentIds().size();
         writeUnsignedVarInt(nParents, data);
         for (ObjectId pId : commit.getParentIds()) {
-            data.write(pId.getRawValue());
+            pId.writeTo(data);
         }
 
         writePerson(commit.getAuthor(), data);
@@ -428,7 +426,7 @@ public class FormatCommonV2 {
 
         writeUnsignedVarInt(index, data);
 
-        data.write(bucket.getObjectId().getRawValue());
+        bucket.getObjectId().writeTo(data);
         envBuff.setToNull();
         bucket.expand(envBuff);
         if (envBuff.isNull()) {
@@ -530,9 +528,9 @@ public class FormatCommonV2 {
 
         data.writeByte(typeAndMasks);
         data.writeUTF(node.getName());
-        data.write(node.getObjectId().getRawValue());
+        node.getObjectId().writeTo(data);
         if (metadataMask == METADATA_PRESENT_MASK) {
-            data.write(node.getMetadataId().or(ObjectId.NULL).getRawValue());
+            node.getMetadataId().or(ObjectId.NULL).writeTo(data);
         }
         if (BOUNDS_BOX2D_MASK == boundsMask) {
             writeBoundingBox(env.getMinX(), env.getMaxX(), env.getMinY(), env.getMaxY(), data);
@@ -602,7 +600,7 @@ public class FormatCommonV2 {
 
     public void writeNodeRef(NodeRef nodeRef, DataOutput data) throws IOException {
         writeNode(nodeRef.getNode(), data);
-        data.write(nodeRef.getMetadataId().getRawValue());
+        nodeRef.getMetadataId().writeTo(data);
         data.writeUTF(nodeRef.getParentPath());
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV2_2.java
@@ -39,7 +39,7 @@ public class FormatCommonV2_2  extends FormatCommonV2_1 {
 
         writeUnsignedVarInt(index, data);
 
-        data.write(bucket.getObjectId().getRawValue());
+        bucket.getObjectId().writeTo(data);
         envBuff.setToNull();
         bucket.expand(envBuff);
         writeBounds(envBuff,data);
@@ -117,9 +117,9 @@ public class FormatCommonV2_2  extends FormatCommonV2_1 {
 
         data.writeByte(typeAndMasks);
         data.writeUTF(node.getName());
-        data.write(node.getObjectId().getRawValue());
+        node.getObjectId().writeTo(data);
         if (metadataMask == METADATA_PRESENT_MASK) {
-            data.write(node.getMetadataId().or(ObjectId.NULL).getRawValue());
+            node.getMetadataId().or(ObjectId.NULL).writeTo(data);
         }
         writeBounds(env,data);
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/BucketSet.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/BucketSet.java
@@ -14,7 +14,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
-import java.util.Map;
 
 import org.locationtech.geogig.model.Bucket;
 import org.locationtech.geogig.model.ObjectId;
@@ -64,7 +63,7 @@ class BucketSet {
                     out.writeDouble(bounds.getMaxY());
                 }
             } catch (IOException e) {
-                throw Throwables.propagate(e);
+                throw new RuntimeException(e);
             }
         });
     }
@@ -95,14 +94,12 @@ class BucketSet {
         DataInput in = data.asDataInput(off);
         try {
             int index;
-            byte[] oidbuff = new byte[ObjectId.NUM_BYTES];
             ObjectId id;
             double minx, maxx, miny, maxy;
             Envelope bounds;
             for (int i = 0; i < size; i++) {
                 index = in.readUnsignedByte();
-                in.readFully(oidbuff);
-                id = new ObjectId(oidbuff);
+                id = ObjectId.readFrom(in);
                 minx = in.readDouble();
                 if (Double.isNaN(minx)) {
                     bounds = null;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/DataBuffer.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/DataBuffer.java
@@ -116,12 +116,13 @@ class DataBuffer {
     }
 
     public ObjectId getObjectId(final int offset) {
-        byte[] buff = new byte[ObjectId.NUM_BYTES];
         // duplicate() instead of mark()/reset() to preserve thread safety
         ByteBuffer raw = this.raw.duplicate();
         raw.position(offset);
-        raw.get(buff);
-        return ObjectId.createNoClone(buff);
+        int h1 = raw.getInt();
+        long h2 = raw.getLong();
+        long h3 = raw.getLong();
+        return ObjectId.create(h1, h2, h3);
     }
 
     public void get(byte[] buff, final int offset) {

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/RevTreeFormat.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/v2_3/RevTreeFormat.java
@@ -133,24 +133,19 @@ class RevTreeFormat {
         StringTable stringTable = StringTable.unique();
         Header.encode(out, tree);
 
-        ImmutableList<Node> trees = tree.trees();
-        ImmutableList<Node> features = tree.features();
-        ImmutableSortedMap<Integer, Bucket> buckets = tree.buckets();
-
-        offsetOfTreesNodeset = trees.isEmpty() ? 0 : buff.size();
-        if (!trees.isEmpty()) {
-            NodeSet.encode(out, trees, stringTable);
+        offsetOfTreesNodeset = tree.treesSize() == 0 ? 0 : buff.size();
+        if (tree.treesSize() > 0) {
+            NodeSet.encode(out, tree.trees(), stringTable);
         }
 
-        offsetOfFeaturesNodeset = features.isEmpty() ? 0 : buff.size();
-        if (!features.isEmpty()) {
-            NodeSet.encode(out, features, stringTable);
+        offsetOfFeaturesNodeset = tree.featuresSize() == 0 ? 0 : buff.size();
+        if (tree.featuresSize() > 0) {
+            NodeSet.encode(out, tree.features(), stringTable);
         }
 
-        offsetOfBuckets = buckets.isEmpty() ? 0 : buff.size();
-        if (!buckets.isEmpty()) {
-            BucketSet.encode(out, buckets, stringTable);
-        }
+        offsetOfBuckets = tree.bucketsSize() == 0 ? 0 : buff.size();
+        BucketSet.encode(out, tree, stringTable);
+
         offsetOfStringTable = buff.size();
         stringTable.encode(out);
         offsetOfTail = buff.size();

--- a/src/core/src/test/java/org/locationtech/geogig/model/impl/RevObjectTestSupport.java
+++ b/src/core/src/test/java/org/locationtech/geogig/model/impl/RevObjectTestSupport.java
@@ -141,7 +141,7 @@ public class RevObjectTestSupport {
         if (randomIds) {
             byte[] raw = new byte[ObjectId.NUM_BYTES];
             RND.nextBytes(raw);
-            oid = ObjectId.createNoClone(raw);
+            oid = ObjectId.create(raw);
         } else {// predictable id
             oid = RevObjectTestSupport.hashString(name);
         }
@@ -178,7 +178,7 @@ public class RevObjectTestSupport {
     public static ObjectId hashString(final String strToHash) {
         Preconditions.checkNotNull(strToHash);
         HashCode hashCode = ObjectId.HASH_FUNCTION.hashString(strToHash, Charset.forName("UTF-8"));
-        return ObjectId.createNoClone(hashCode.asBytes());
+        return ObjectId.create(hashCode.asBytes());
     }
 
     public static Set<Node> getTreeNodes(RevTree tree, ObjectStore source) {

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGConflictsDatabase.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGConflictsDatabase.java
@@ -234,9 +234,9 @@ public class PGConflictsDatabase implements ConflictsDatabase {
                         @Nullable
                         byte[] ancestorb = rs.getBytes(2);
                         ObjectId ancestor = ancestorb == null ? ObjectId.NULL
-                                : ObjectId.createNoClone(ancestorb);
-                        ObjectId ours = ObjectId.createNoClone(rs.getBytes(3));
-                        ObjectId theirs = ObjectId.createNoClone(rs.getBytes(4));
+                                : ObjectId.create(ancestorb);
+                        ObjectId ours = ObjectId.create(rs.getBytes(3));
+                        ObjectId theirs = ObjectId.create(rs.getBytes(4));
                         conflict = new Conflict(path, ancestor, ours, theirs);
                     }
                 }
@@ -303,10 +303,10 @@ public class PGConflictsDatabase implements ConflictsDatabase {
                         if (ancestorb == null) {
                             ancestor = ObjectId.NULL;
                         } else {
-                            ancestor = ObjectId.createNoClone(ancestorb);
+                            ancestor = ObjectId.create(ancestorb);
                         }
-                        ObjectId ours = ObjectId.createNoClone(rs.getBytes(3));
-                        ObjectId theirs = ObjectId.createNoClone(rs.getBytes(4));
+                        ObjectId ours = ObjectId.create(rs.getBytes(3));
+                        ObjectId theirs = ObjectId.create(rs.getBytes(4));
                         conflicts.add(new Conflict(path, ancestor, ours, theirs));
                     }
                 }
@@ -356,9 +356,9 @@ public class PGConflictsDatabase implements ConflictsDatabase {
                         @Nullable
                         byte[] ancestorb = rs.getBytes(2);
                         ObjectId ancestor = ancestorb == null ? ObjectId.NULL
-                                : ObjectId.createNoClone(ancestorb);
-                        ObjectId ours = ObjectId.createNoClone(rs.getBytes(3));
-                        ObjectId theirs = ObjectId.createNoClone(rs.getBytes(4));
+                                : ObjectId.create(ancestorb);
+                        ObjectId ours = ObjectId.create(rs.getBytes(3));
+                        ObjectId theirs = ObjectId.create(rs.getBytes(4));
                         batch.add(new Conflict(path, ancestor, ours, theirs));
                     }
                 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGId.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGId.java
@@ -14,9 +14,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 
 import org.locationtech.geogig.model.ObjectId;
-
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
+import org.locationtech.geogig.model.RevObjects;
 
 /**
  * Converts {@link ObjectId}s to and from its stored representation.
@@ -25,75 +23,40 @@ import com.google.common.io.ByteStreams;
  */
 final class PGId {
 
-    private final byte[] id;
+    private final int h1;
 
-    public PGId(byte[] oid) {
-        this.id = oid;
-    }
+    private final long h2;
 
-    public static int intHash(ObjectId id) {
-        final int hash1 = ((id.byteN(0) << 24) //
-                | (id.byteN(1) << 16) //
-                | (id.byteN(2) << 8) //
-                | (id.byteN(3)));
-        return hash1;
-    }
+    private final long h3;
 
-    public static int intHash(byte[] id) {
-        final int hash1 = ((((int) id[0]) << 24) //
-                | (((int) id[1] & 0xFF) << 16) //
-                | (((int) id[2] & 0xFF) << 8) //
-                | (((int) id[3] & 0xFF)));
-        return hash1;
+    public PGId(final int h1, final long h2, final long h3) {
+        this.h1 = h1;
+        this.h2 = h2;
+        this.h3 = h3;
     }
 
     public int hash1() {
-        return PGId.intHash(this.id);
+        return h1;
     }
 
     public long hash2() {
-        final long hash2 = ((((long) id[4]) << 56) //
-                | (((long) id[5] & 0xFF) << 48)//
-                | (((long) id[6] & 0xFF) << 40) //
-                | (((long) id[7] & 0xFF) << 32) //
-                | (((long) id[8] & 0xFF) << 24) //
-                | (((long) id[9] & 0xFF) << 16) //
-                | (((long) id[10] & 0xFF) << 8)//
-                | (((long) id[11] & 0xFF)));
-        return hash2;
+        return h2;
     }
 
     public long hash3() {
-        final long hash3 = ((((long) id[12]) << 56) //
-                | (((long) id[13] & 0xFF) << 48)//
-                | (((long) id[14] & 0xFF) << 40) //
-                | (((long) id[15] & 0xFF) << 32) //
-                | (((long) id[16] & 0xFF) << 24) //
-                | (((long) id[17] & 0xFF) << 16) //
-                | (((long) id[18] & 0xFF) << 8)//
-                | (((long) id[19] & 0xFF)));
-        return hash3;
+        return h3;
     }
 
     public ObjectId toObjectId() {
-        return ObjectId.createNoClone(id);
+        return ObjectId.create(h1, h2, h3);
     }
 
     public static PGId valueOf(ObjectId oid) {
-        return valueOf(oid.getRawValue());
-    }
-
-    public static PGId valueOf(byte[] oid) {
-        return new PGId(oid);
+        return valueOf(RevObjects.h1(oid), RevObjects.h2(oid), RevObjects.h3(oid));
     }
 
     public static PGId valueOf(final int h1, final long h2, final long h3) {
-        ByteArrayDataOutput out = ByteStreams.newDataOutput();
-        out.writeInt(h1);
-        out.writeLong(h2);
-        out.writeLong(h3);
-        byte[] raw = out.toByteArray();
-        return new PGId(raw);
+        return new PGId(h1, h2, h3);
     }
 
     @Override

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGObjectStore.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGObjectStore.java
@@ -59,6 +59,7 @@ import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.RevFeature;
 import org.locationtech.geogig.model.RevFeatureType;
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.model.RevObjects;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
@@ -265,7 +266,7 @@ public class PGObjectStore implements ObjectStore {
         checkState(isOpen(), "db is closed");
         config.checkRepositoryExists();
 
-        final int hash1 = PGId.intHash(ObjectId.toRaw(partialId));
+        final int hash1 = RevObjects.h1(partialId);
         final String sql = format(
                 "SELECT ((id).h2), ((id).h3) FROM %s WHERE ((id).h1) = ? LIMIT 1000",
                 objectsTable());

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbConflictsDatabase.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbConflictsDatabase.java
@@ -535,7 +535,7 @@ public class RocksdbConflictsDatabase implements ConflictsDatabase, Closeable {
         private static final byte HAS_THEIRS = 0b00000100;
 
         void write(DataOutput out, ObjectId value) throws IOException {
-            out.write(value.getRawValue());
+            value.writeTo(out);
         }
 
         public byte[] write(Conflict c) throws IOException {
@@ -545,9 +545,7 @@ public class RocksdbConflictsDatabase implements ConflictsDatabase, Closeable {
         }
 
         ObjectId readId(DataInput in) throws IOException {
-            byte[] raw = new byte[ObjectId.NUM_BYTES];
-            in.readFully(raw);
-            return ObjectId.createNoClone(raw);
+            return ObjectId.readFrom(in);
         }
 
         public void write(DataOutput out, Conflict value) throws IOException {

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbGraphDatabase.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbGraphDatabase.java
@@ -458,9 +458,7 @@ public class RocksdbGraphDatabase implements GraphDatabase {
                     return ObjectId.NULL;
                 }
                 Preconditions.checkState(ObjectId.NUM_BYTES == size);
-                byte[] hash = new byte[size];
-                input.readFully(hash);
-                return ObjectId.createNoClone(hash);
+                return ObjectId.readFrom(input);
             }
 
             public void objectToEntry(@Nullable ObjectId object, DataOutput output)
@@ -469,7 +467,7 @@ public class RocksdbGraphDatabase implements GraphDatabase {
                     output.writeByte(0);
                 } else {
                     output.writeByte(ObjectId.NUM_BYTES);
-                    output.write(object.getRawValue());
+                    object.writeTo(output);
                 }
             }
         }

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbIndexDatabase.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbIndexDatabase.java
@@ -258,7 +258,7 @@ public class RocksdbIndexDatabase extends RocksdbObjectStore implements IndexDat
         }
 
         if (indexTreeBytes != null) {
-            return Optional.of(ObjectId.createNoClone(indexTreeBytes));
+            return Optional.of(ObjectId.create(indexTreeBytes));
         }
         return Optional.absent();
     }

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
@@ -349,7 +349,7 @@ public class RocksdbObjectStore extends AbstractObjectStore implements ObjectSto
                             return matches;
                         }
                     }
-                    ObjectId id = ObjectId.createNoClone(key);
+                    ObjectId id = ObjectId.create(key);
                     matches.add(id);
                     it.next();
                 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/BinaryPackedObjects.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/BinaryPackedObjects.java
@@ -255,7 +255,7 @@ public final class BinaryPackedObjects {
             if (offset == len)
                 break;
         }
-        ObjectId id = ObjectId.createNoClone(rawBytes);
+        ObjectId id = ObjectId.create(rawBytes);
         return id;
     }
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/spring/service/LegacyApplyChangesService.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/spring/service/LegacyApplyChangesService.java
@@ -114,7 +114,7 @@ public class LegacyApplyChangesService extends AbstractRepositoryService {
                 break;
             }
         }
-        ObjectId id = ObjectId.createNoClone(rawBytes);
+        ObjectId id = ObjectId.create(rawBytes);
         return id;
     }
 }

--- a/src/web/api/src/main/java/org/locationtech/geogig/web/api/ResponseWriter.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/web/api/ResponseWriter.java
@@ -25,7 +25,6 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.geotools.metadata.iso.citation.Citations;
 import org.geotools.referencing.CRS;
 import org.locationtech.geogig.data.FeatureBuilder;
-import org.locationtech.geogig.model.Bucket;
 import org.locationtech.geogig.model.FieldType;
 import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.NodeRef;
@@ -346,20 +345,17 @@ public class ResponseWriter {
         writeElement("id", tree.getId().toString());
         writeElement("size", Long.toString(tree.size()));
         writeElement("numtrees", Integer.toString(tree.numTrees()));
+
         out.writeStartArray("subtree");
-        for (Node ref : tree.trees()) {
-            writeNode(ref, "subtree");
-        }
+        tree.forEachTree((t) -> writeNode(t, "subtree"));
         out.writeEndArray();
+
         out.writeStartArray("feature");
-        for (Node ref : tree.features()) {
-            writeNode(ref, "feature");
-        }
+        tree.forEachFeature((f) -> writeNode(f, "feature"));
         out.writeEndArray();
+
         out.writeStartArray("bucket");
-        for (Entry<Integer, Bucket> entry : tree.buckets().entrySet()) {
-            Integer bucketIndex = entry.getKey();
-            Bucket bucket = entry.getValue();
+        tree.forEachBucket((bucketIndex, bucket) -> {
             out.writeStartArrayElement("bucket");
             writeElement("bucketindex", bucketIndex.toString());
             writeElement("bucketid", bucket.getObjectId().toString());
@@ -373,7 +369,7 @@ public class ResponseWriter {
             writeElement("maxy", Double.toString(env.getMaxY()));
             out.writeEndElement();
             out.writeEndArrayElement();
-        }
+        });
         out.writeEndArray();
         out.writeEndElement();
     }

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/BatchObjectsControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/BatchObjectsControllerTest.java
@@ -122,7 +122,7 @@ public class BatchObjectsControllerTest extends AbstractControllerTest {
             // read the OID bytes from the stream
             bais.read(rawId);
             // parse the OID into an object
-            ObjectId oid = ObjectId.createNoClone(rawId);
+            ObjectId oid = ObjectId.create(rawId);
             // now read the RevObject from the stream
             serialFac.read(oid, bais);
             // increment the number of RevObjects read

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/TaskControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/TaskControllerTest.java
@@ -270,7 +270,7 @@ public class TaskControllerTest extends AbstractControllerTest {
                 .andReturn();
 
         ObjectId fromResponse = ObjectId
-                .createNoClone(result.getResponse().getContentAsByteArray());
+                .create(result.getResponse().getContentAsByteArray());
         assertEquals(fakeObjectId, fromResponse);
 
     }


### PR DESCRIPTION
This PR contains commits that reduce the memory footprint of the Rev* objects by about 30%.
It does so by:
- Reducing memory footprint of `ObjectId` by storing the 20 bytes of the SHA1 hash in an ObjectId as an int and two longs, instead of a byte[20], the memory footprint of a single ObjectId is reduced from ~56 bytes to ~32 bytes.
-  That reduces the memory footprint of `RevTree`'s `RevTreeImpl` default implementation:
    Avg size of leaf tree with 512 entries: before 107960 bytes, after 87440 bytes.
    Avg size of buckets tree with 32 entries: before 4624 bytes, after 3304 bytes.
- Further reduce memory footprint of RevTree implementation ,  achieving a 30% reduction, by storing the `Node`s bounds as four float instance variables , the list of nodes as of `Node[]`, and the buckets as an `IndexedBucket[]` (inner class) instead of a `TreeMap<Integer, Bucket>`
    Avg size of leaf tree with 512 entries: before 107960 bytes, after 79184  bytes.
    Avg size of buckets tree with 32 entries: before 4624 bytes, after 3264 bytes.
- Add methods to RevTree to allow traversing its contents without potentially creating defensive copies
- Use `ObjectId.readFrom()/writeTo()` where appropriate, instead of creating lots of `byte[]` for serialization/deserialization
