### PR TITLE
Fix non-numeric PostgreSQL version string parsing

### DIFF
--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGStorage.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGStorage.java
@@ -161,8 +161,17 @@ public class PGStorage {
     }
 
     static Version getVersionFromQueryResult(final String versionQueryResult) {
+        // version string may not be a simple x.y.x value. Let's just take it from the front and stop at the first
+        // non-digit, non-decimal-point character
+        final String regex = "[^0-9.]";
+        // replace first non-digit, non-decimal point with XXX
+        String marked = versionQueryResult.replaceFirst(regex, "XXX");
+        if (marked.contains("XXX")) {
+            // no throw away everything starting with XXX
+            marked = marked.substring(0, marked.indexOf("XXX"));
+        }
         final List<Integer> versions = Lists.transform(
-                Splitter.on('.').splitToList(versionQueryResult), (s) -> Integer.parseInt(s));
+                Splitter.on('.').splitToList(marked), (s) -> Integer.parseInt(s));
         // version string can be either
         // {major}.{minor}.{patch}
         // or (since PostgreSQL 10)

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/PGStorageTest.java
@@ -213,6 +213,7 @@ public class PGStorageTest {
         try {
             assertNotNull(PGStorage.getVersionFromQueryResult("9.4.0"));
             assertNotNull(PGStorage.getVersionFromQueryResult("10.1"));
+            assertNotNull(PGStorage.getVersionFromQueryResult("10.3 (Debian 10.3-1.pgdg90+1)"));
         } catch (Exception ex) {
             // test failed
             ex.printStackTrace();


### PR DESCRIPTION
Apparently PostgreSQL can return a version string that has alphanumeric characters, as opposed to simply versions in the format of `X.Y` or `X.Y.Z`. This PR tries to prune non-numeric valuse from the version string.