### PR TITLE
Split MergeScenarioReport unconflicted count into trees and features

### DIFF
--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeScenarioReport.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/MergeScenarioReport.java
@@ -11,32 +11,34 @@ package org.locationtech.geogig.plumbing.merge;
 
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.locationtech.geogig.model.DiffEntry;
+import org.locationtech.geogig.model.RevObject.TYPE;
+
 /**
  * A class that counts the changes introduced by a branch to be merged, divided in categories
  * according to how they can (or can't) be merged into the destination branch
  */
 public class MergeScenarioReport {
 
-    private final AtomicLong conflicts, unconflicted, merged;
-
-    public MergeScenarioReport() {
-        conflicts = new AtomicLong();
-        unconflicted = new AtomicLong();
-        merged = new AtomicLong();
-    }
+    private final AtomicLong conflicts = new AtomicLong(), unconflictedFeatures = new AtomicLong(),
+            unconflictedTrees = new AtomicLong(), merged = new AtomicLong();
 
     public void addConflict() {
         conflicts.incrementAndGet();
 
     }
 
-    public void addUnconflicted() {
-        unconflicted.incrementAndGet();
+    public void addUnconflicted(DiffEntry diff) {
+        TYPE type = (diff.isAdd() ? diff.getNewObject() : diff.getOldObject()).getType();
+        if (TYPE.FEATURE == type) {
+            unconflictedFeatures.incrementAndGet();
+        } else {
+            unconflictedTrees.incrementAndGet();
+        }
     }
 
     public void addMerged() {
         merged.incrementAndGet();
-
     }
 
     /**
@@ -49,12 +51,24 @@ public class MergeScenarioReport {
     }
 
     /**
-     * Returns the number of unconflicted features.
-     * 
-     * @return
+     * @return the number of unconflicted features and trees.
      */
     public long getUnconflicted() {
-        return unconflicted.get();
+        return unconflictedFeatures.get() + unconflictedTrees.get();
+    }
+
+    /**
+     * @return the number of unconflicted features.
+     */
+    public long getUnconflictedFeatures() {
+        return unconflictedFeatures.get();
+    }
+
+    /**
+     * @return the number of unconflicted trees.
+     */
+    public long getUnconflictedTrees() {
+        return unconflictedTrees.get();
     }
 
     /**

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportCommitConflictsOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportCommitConflictsOp.java
@@ -118,14 +118,14 @@ public class ReportCommitConflictsOp extends AbstractGeoGigOp<MergeScenarioRepor
                         }
                     } else {
                         consumer.unconflicted(diff);
-                        report.addUnconflicted();
+                        report.addUnconflicted(diff);
                     }
                     break;
                 case REMOVED:
                     if (obj.isPresent()) {
                         if (obj.get().getId().equals(diff.oldObjectId())) {
                             consumer.unconflicted(diff);
-                            report.addUnconflicted();
+                            report.addUnconflicted(diff);
                         } else {
                             consumer.conflicted(new Conflict(path, diff.oldObjectId(),
                                     ObjectId.NULL, obj.get().getId()));
@@ -141,7 +141,7 @@ public class ReportCommitConflictsOp extends AbstractGeoGigOp<MergeScenarioRepor
                         // one
                         if (!diff.isChange()) {
                             consumer.unconflicted(diff);
-                            report.addUnconflicted();
+                            report.addUnconflicted(diff);
                         }
                     } else {
                         String refSpec = Ref.HEAD + ":" + path;
@@ -152,7 +152,7 @@ public class ReportCommitConflictsOp extends AbstractGeoGigOp<MergeScenarioRepor
                             // the missing file.
                             // We add it and consider it unconflicted
                             consumer.unconflicted(diff);
-                            report.addUnconflicted();
+                            report.addUnconflicted(diff);
                             break;
                         }
                         RevFeature feature = (RevFeature) obj.get();
@@ -208,7 +208,7 @@ public class ReportCommitConflictsOp extends AbstractGeoGigOp<MergeScenarioRepor
                         }
                         if (ok) {
                             consumer.unconflicted(diff);
-                            report.addUnconflicted();
+                            report.addUnconflicted(diff);
                         } else {
                             consumer.conflicted(new Conflict(path, diff.oldObjectId(),
                                     diff.newObjectId(), obj.get().getId()));

--- a/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportMergeScenarioOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/plumbing/merge/ReportMergeScenarioOp.java
@@ -187,7 +187,7 @@ public class ReportMergeScenarioOp extends AbstractGeoGigOp<MergeScenarioReport>
             if (ours == null) {
                 // Only "their" branch modified the path
                 consumer.unconflicted(theirs);
-                report.addUnconflicted();
+                report.addUnconflicted(theirs);
             } else if (theirs == null) {
                 // Only "our" branch modified the path
                 // nothing else to do
@@ -265,7 +265,7 @@ public class ReportMergeScenarioOp extends AbstractGeoGigOp<MergeScenarioReport>
                     // the branch, which means that it exists in the merge into tree and there
                     // is no need to report the to merge change as merged.
                     consumer.unconflicted(theirsDiff);
-                    report.addUnconflicted();
+                    report.addUnconflicted(theirsDiff);
                 } else {
                     ObjectId featureTypeId = oursDiff.getNewObject().getMetadataId();
                     FeatureInfo merged = FeatureInfo.insert(mergedFeature, featureTypeId, path);


### PR DESCRIPTION
For reporting purposes, differentiate between non conflicted changes to features and trees