### PR TITLE
Make ServiceLoader calls work with Spring Boot fat jar URLClassLoader

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/storage/StorageProvider.java
+++ b/src/api/src/main/java/org/locationtech/geogig/storage/StorageProvider.java
@@ -66,7 +66,8 @@ public abstract class StorageProvider {
      *         {@link StorageProvider} key.
      */
     public static Iterable<StorageProvider> findProviders() {
-        ServiceLoader<StorageProvider> loader = ServiceLoader.load(StorageProvider.class);
+        ServiceLoader<StorageProvider> loader = ServiceLoader.load(StorageProvider.class,
+                StorageProvider.class.getClassLoader());
         return ImmutableList.copyOf(loader.iterator());
     }
 }

--- a/src/core/src/main/java/org/locationtech/geogig/hooks/Hookables.java
+++ b/src/core/src/main/java/org/locationtech/geogig/hooks/Hookables.java
@@ -52,7 +52,8 @@ public class Hookables {
     }
 
     public static ImmutableList<CommandHook> loadClasspathHooks() {
-        ServiceLoader<CommandHook> loader = ServiceLoader.load(CommandHook.class);
+        ServiceLoader<CommandHook> loader = ServiceLoader.load(CommandHook.class,
+                CommandHook.class.getClassLoader());
         ImmutableList<CommandHook> SPIHooks = ImmutableList.copyOf(loader.iterator());
         return SPIHooks;
     }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/CloneOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/CloneOp.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.eclipse.jdt.annotation.Nullable;
+import org.locationtech.geogig.di.CanRunDuringConflict;
 import org.locationtech.geogig.model.NodeRef;
 import org.locationtech.geogig.model.Ref;
 import org.locationtech.geogig.model.RevObject;
@@ -70,6 +71,7 @@ import com.google.common.collect.Iterables;
  * 
  * @since 1.0
  */
+@CanRunDuringConflict // so the interceptor doesn't try to check for conflicts when cloning
 public class CloneOp extends AbstractGeoGigOp<Repository> {
 
     private static final String DEFAULT_REMOTE_NAME = NodeRef.nodeFromPath(Ref.ORIGIN);

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/DeduplicationService.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/DeduplicationService.java
@@ -41,7 +41,8 @@ public interface DeduplicationService {
 
     public static Deduplicator create() {
         final Logger LOG = LoggerFactory.getLogger(DeduplicationService.class);
-        ServiceLoader<DeduplicationService> loader = ServiceLoader.load(DeduplicationService.class);
+        ServiceLoader<DeduplicationService> loader = ServiceLoader.load(DeduplicationService.class,
+                DeduplicationService.class.getClassLoader());
         List<DeduplicationService> services = Lists.newArrayList(loader.iterator());
 
         DeduplicationService service;

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/RemoteResolver.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/RemoteResolver.java
@@ -61,7 +61,8 @@ public interface RemoteResolver {
             remoteHints = new Hints();
         }
 
-        Iterator<RemoteResolver> resolvers = ServiceLoader.load(RemoteResolver.class).iterator();
+        Iterator<RemoteResolver> resolvers = ServiceLoader
+                .load(RemoteResolver.class, RemoteResolver.class.getClassLoader()).iterator();
 
         while (resolvers.hasNext()) {
             RemoteResolver resolver = resolvers.next();


### PR DESCRIPTION
ServiceLoader.load(Class) defaults to using the current thread's
context class loader, which doesn't work on a spring boot fat jar
packaged app.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>