### PR TITLE
Fix NPE for invalid PostgreSQL repo URI for clone

### DIFF
--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
@@ -123,6 +123,11 @@ public class PGRepositoryResolver extends RepositoryResolver {
         hints.set(Hints.REPOSITORY_URL, repositoryLocation.toString());
         Context context = GlobalContextBuilder.builder().build(hints);
         Repository repository = new GeoGIG(context).getRepository();
+        // Ensure the repository exists. If it's null, we might have a non-existing repo URI location
+        if (repository == null) {
+            throw new RepositoryConnectionException("Could not connect to repository. Check that the URI is valid: " +
+            repositoryLocation);
+        }
         repository.open();
         return repository;
     }


### PR DESCRIPTION
This should give a better error message and address issue https://github.com/locationtech/geogig/issues/439.

Example error message:
```sh
gg clone $REPO2 ./repo2
Cloning into './repo2'...
Failed to connect to remote: Could not connect to repository. Check that the URI is valid: postgresql://localhost:5432/repos/public/repo2?user=geogig&password=geogig
```