### PR TITLE
improved index filtering

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -89,14 +89,44 @@ public final class IndexInfo {
             return Objects.equals(getTreeName(), i.getTreeName())
                     && Objects.equals(getAttributeName(), i.getAttributeName())
                     && Objects.equals(getIndexType(), i.getIndexType())
-                    && Objects.equals(getMetadata(), i.getMetadata());
+                    && compareMetadatas(getMetadata(), i.getMetadata());
         }
         return false;
     }
 
+    /**
+     * Properly compares two IndexInfo metadatas.  Since some of the values in the map
+     * can be String[], normal Objects.equals() do not work.  We use a better comparison.
+     *
+     * @param meta1
+     * @param meta2
+     * @return
+     */
+    public static boolean compareMetadatas(Map<String, Object> meta1, Map<String, Object> meta2) {
+        if ((meta1 == null) && (meta2 == null))
+            return true; // both null
+        if ((meta1 == null) || (meta2 == null))
+            return false; // one null, the other not
+        if (meta1 == meta2)
+            return true; //both the same reference
+        if (meta1.size() != meta2.size())
+            return false; //different # of entries
+
+        for (Map.Entry<String, Object> entry : meta1.entrySet()) {
+            if (!meta2.containsKey(entry.getKey()))
+                return false;
+            Object v1 = entry.getValue();
+            Object v2 = meta2.get(entry.getKey());
+            if (!Objects.deepEquals(v1, v2))
+                return false;
+        }
+        return true;
+    }
+
+
     @Override
     public int hashCode() {
-        return Objects.hash(getTreeName(), getAttributeName(), getIndexType(), getMetadata());
+        return Objects.hash(getTreeName(), getAttributeName(), getIndexType(), getMetadata().size());
     }
 
     public static ObjectId getIndexId(String treeName, String attributeName) {

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -732,7 +732,15 @@ public class FeatureReaderBuilder {
     private Filter resolveNativeFilter() {
         Filter nativeFilter = this.filter;
         nativeFilter = SimplifyingFilterVisitor.simplify(nativeFilter, nativeSchema);
-        nativeFilter = reprojectFilter(this.filter);
+        nativeFilter = reprojectFilter(nativeFilter);
+
+        String defaultGeometryPName = this.nativeSchema.getGeometryDescriptor().getName().getLocalPart();
+        RenamePropertyFilterVisitor renameBoundsVisitor = new RenamePropertyFilterVisitor("@bounds",defaultGeometryPName);
+        nativeFilter =  (Filter) nativeFilter.accept(renameBoundsVisitor,null);
+
+        InReplacingFilterVisitor inreplacer = new InReplacingFilterVisitor();
+        nativeFilter =  (Filter) nativeFilter.accept(inreplacer,null);
+
         return nativeFilter;
     }
 

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/InReplacingFilterVisitor.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/InReplacingFilterVisitor.java
@@ -1,0 +1,127 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.geotools.filter.function.InFunction;
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.Filter;
+import org.opengis.filter.MultiValuedFilter;
+import org.opengis.filter.Or;
+import org.opengis.filter.PropertyIsEqualTo;
+import org.opengis.filter.expression.Expression;
+import org.opengis.filter.expression.Literal;
+import org.opengis.filter.expression.PropertyName;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/***
+ * This speeds up filter evaluation by converting filters of the form;
+ *       "property" = 'a' OR "property" = 'b' OR "property" = 'c'
+ *                      TO
+ *       IN("property", 'a','b','c') = true
+ *
+ *       This is much faster to evaluate in geogig because a property extraction is very expensive.
+ */
+public class InReplacingFilterVisitor extends DuplicatingFilterVisitor {
+
+        @Override public Object visit(Or filter, Object extraData) {
+                List<Filter> complex = new ArrayList<>();
+                List<Filter> simple = new ArrayList<>();
+                for (Filter f : filter.getChildren()) {
+                        if (isSimpleEquals(f))
+                                simple.add(f);
+                        else
+                                complex.add(f); // these aren't ones we can do anthing about
+                }
+                List<Filter> simplified = simplify(simple, extraData);
+                simplified.addAll(complex);
+                return getFactory(extraData).or(simplified);
+        }
+
+        // given a list of the "simple" items (ie. "property" = 'a')
+        // simplify them to the IN function
+        public List<Filter> simplify(List<Filter> filters, Object extraData) {
+                List<Filter> result = new ArrayList<>();
+                Map<String, List<Object>> grouped = group(filters);
+                for (Map.Entry<String, List<Object>> entry : grouped.entrySet()) {
+                        if (entry.getValue().size() == 1) {
+                                result.add(createEquals(entry.getKey(), entry.getValue().get(0),
+                                        extraData));
+                        } else {
+                                result.add(createInFunction(entry.getKey(), entry.getValue(),
+                                        extraData));
+                        }
+
+                }
+                return result;
+        }
+
+        // given a property and values, create the
+        // IN ("property", v1,v2,v3,v4...) = TRUE FILTER
+        // NOTE: IN is a function (expression), so it need the "= TRUE" to make it a filter
+        private Filter createInFunction(String pname, List<Object> values, Object extraData) {
+                InFunction f = new InFunction();
+                Expression[] params = new Expression[values.size() + 1];
+                int indx = 0;
+                params[indx++] = getFactory(extraData).property(pname);
+                for (Object v : values) {
+                        params[indx++] = getFactory(extraData).literal(v);
+                }
+                //f.setParameters(params);
+                Expression function = getFactory(extraData).function(f.getName(), params);
+                Expression TRUE = getFactory(extraData).literal(true);
+                return getFactory(extraData).equals(function, TRUE);
+        }
+
+        // creates a simple equals
+        // used for properties that have a single "=" (no point in the extra work of the IN function)
+        public PropertyIsEqualTo createEquals(String pname, Object literal, Object extraData) {
+                PropertyName pnameFilter = getFactory(extraData).property(pname);
+                Literal literal1 = getFactory(extraData).literal(literal);
+                return getFactory(extraData)
+                        .equal(pnameFilter, literal1, true, MultiValuedFilter.MatchAction.ANY);
+        }
+
+        // groups a list of the "isSimpleEquals" filters by their property names
+        // result is like
+        //  {
+        //      "property" -> ['a','b','c']
+        //  }
+        public Map<String, List<Object>> group(List<Filter> filters) {
+                Map<String, List<Object>> grouped = new HashMap<>();
+                for (Filter fequals : filters) {
+                        PropertyIsEqualTo equals = (PropertyIsEqualTo) fequals;
+                        PropertyName pnameFilter = (PropertyName) equals.getExpression1();
+                        String pname = pnameFilter.getPropertyName();
+                        Literal valFilter = (Literal) equals.getExpression2();
+                        Object val = valFilter.getValue();
+                        List<Object> vals = grouped.getOrDefault(pname, new ArrayList<>());
+                        vals.add(val);
+                        grouped.put(pname, vals);
+                }
+                return grouped;
+        }
+
+        //check to see if it look like    "property" = value
+        // we also make sure its case-sensitive
+        public boolean isSimpleEquals(Filter expression) {
+                if (expression instanceof PropertyIsEqualTo) {
+                        PropertyIsEqualTo equals = (PropertyIsEqualTo) expression;
+                        if ((equals.getExpression1() instanceof PropertyName) && (equals
+                                .getExpression2() instanceof Literal) && (equals.isMatchingCase()))
+                                return true;
+                }
+                return false;
+        }
+}

--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/RenamePropertyFilterVisitor.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/RenamePropertyFilterVisitor.java
@@ -1,0 +1,39 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * David Blasby (Boundless) - initial implementation
+ */
+
+package org.locationtech.geogig.geotools.data.reader;
+
+import org.geotools.filter.visitor.DuplicatingFilterVisitor;
+import org.opengis.filter.expression.PropertyName;
+
+/**
+ * this is very simple, it changes a property reference.
+ * i.e.  "property" = 'a'     TO    "new_property" = 'a'
+ */
+public class RenamePropertyFilterVisitor extends DuplicatingFilterVisitor {
+
+        String originalPropertyName;
+
+        String newPropertyName;
+
+        public RenamePropertyFilterVisitor(String pName, String newPname) {
+                this.originalPropertyName = pName;
+                this.newPropertyName = newPname;
+        }
+
+        @Override public Object visit(PropertyName expression, Object extraData) {
+                String pName = expression.getPropertyName();
+                if ((pName != null) && (pName.equals(originalPropertyName))) {
+                        return getFactory(extraData)
+                                .property(newPropertyName, expression.getNamespaceContext());
+                }
+                return super.visit(expression, extraData);
+        }
+}


### PR DESCRIPTION
a) there was a bug in the IndexInfo compares - this fixes this.
    Root problem - extra attributes are stored as a String[].  So metadata has "extraAttributes" -> String[].  This caused problems because String[] .equals String[] does "==" comparison.
   This will work on some index databases, but not all (especially PG)

b) We allow a short-cut reference to "@bounds" property to be the default geometry

c) optimization - we convert filters of the form "property" = 'a' OR  "property" = 'b' to
        IN("property", 'a','b') = true
   This is MUCH faster because property access is very slow on nodes.
 