### PR TITLE
allow RenamePropertyFilterVisitor to work with non-spatial datasets

### DIFF
--- a/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
+++ b/src/datastore/src/main/java/org/locationtech/geogig/geotools/data/reader/FeatureReaderBuilder.java
@@ -734,9 +734,12 @@ public class FeatureReaderBuilder {
         nativeFilter = SimplifyingFilterVisitor.simplify(nativeFilter, nativeSchema);
         nativeFilter = reprojectFilter(nativeFilter);
 
-        String defaultGeometryPName = this.nativeSchema.getGeometryDescriptor().getName().getLocalPart();
-        RenamePropertyFilterVisitor renameBoundsVisitor = new RenamePropertyFilterVisitor("@bounds",defaultGeometryPName);
-        nativeFilter =  (Filter) nativeFilter.accept(renameBoundsVisitor,null);
+        if (this.nativeSchema.getGeometryDescriptor() != null) {
+            String defaultGeometryPName = this.nativeSchema.getGeometryDescriptor().getName().getLocalPart();
+            RenamePropertyFilterVisitor renameBoundsVisitor = new RenamePropertyFilterVisitor(
+                    "@bounds", defaultGeometryPName);
+            nativeFilter = (Filter) nativeFilter.accept(renameBoundsVisitor, null);
+        }
 
         InReplacingFilterVisitor inreplacer = new InReplacingFilterVisitor();
         nativeFilter =  (Filter) nativeFilter.accept(inreplacer,null);


### PR DESCRIPTION
For non-spatial datasets, there might not be a default geometry- this handles that case.