### PR TITLE
Add option to syncrhonize indexes for clone,fetch, and pull

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/IndexInfo.java
@@ -17,6 +17,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.Node;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.jts.geom.Envelope;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Preconditions;
@@ -24,8 +25,12 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.common.hash.Hasher;
-import org.locationtech.jts.geom.Envelope;
 
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+
+@EqualsAndHashCode
+@ToString
 public final class IndexInfo {
     public static enum IndexType {
         QUADTREE
@@ -82,21 +87,9 @@ public final class IndexInfo {
         return metadata;
     }
 
-    @Override
-    public boolean equals(Object o) {
-        if (o instanceof IndexInfo) {
-            IndexInfo i = (IndexInfo) o;
-            return Objects.equals(getTreeName(), i.getTreeName())
-                    && Objects.equals(getAttributeName(), i.getAttributeName())
-                    && Objects.equals(getIndexType(), i.getIndexType())
-                    && compareMetadatas(getMetadata(), i.getMetadata());
-        }
-        return false;
-    }
-
     /**
-     * Properly compares two IndexInfo metadatas.  Since some of the values in the map
-     * can be String[], normal Objects.equals() do not work.  We use a better comparison.
+     * Properly compares two IndexInfo metadatas. Since some of the values in the map can be
+     * String[], normal Objects.equals() do not work. We use a better comparison.
      *
      * @param meta1
      * @param meta2
@@ -108,9 +101,9 @@ public final class IndexInfo {
         if ((meta1 == null) || (meta2 == null))
             return false; // one null, the other not
         if (meta1 == meta2)
-            return true; //both the same reference
+            return true; // both the same reference
         if (meta1.size() != meta2.size())
-            return false; //different # of entries
+            return false; // different # of entries
 
         for (Map.Entry<String, Object> entry : meta1.entrySet()) {
             if (!meta2.containsKey(entry.getKey()))
@@ -121,12 +114,6 @@ public final class IndexInfo {
                 return false;
         }
         return true;
-    }
-
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(getTreeName(), getAttributeName(), getIndexType(), getMetadata().size());
     }
 
     public static ObjectId getIndexId(String treeName, String attributeName) {

--- a/src/api/src/main/java/org/locationtech/geogig/storage/IndexDatabase.java
+++ b/src/api/src/main/java/org/locationtech/geogig/storage/IndexDatabase.java
@@ -11,7 +11,6 @@ package org.locationtech.geogig.storage;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.ObjectId;
@@ -21,6 +20,8 @@ import org.locationtech.geogig.repository.RepositoryConnectionException;
 
 import com.google.common.base.Optional;
 
+import lombok.Value;
+
 /**
  * The {@code IndexDatabase} keeps track of spatial and attribute indexes of user-specified data
  * sets.
@@ -29,25 +30,10 @@ import com.google.common.base.Optional;
  */
 public interface IndexDatabase extends ObjectStore {
 
-    public static class IndexTreeMapping {
+    public static @Value class IndexTreeMapping {
         public final ObjectId featureTree;
 
         public final ObjectId indexTree;
-
-        public IndexTreeMapping(ObjectId featureTree, ObjectId indexTree) {
-            this.featureTree = featureTree;
-            this.indexTree = indexTree;
-        }
-
-        public @Override boolean equals(Object o) {
-            return o instanceof IndexTreeMapping
-                    && featureTree.equals(((IndexTreeMapping) o).featureTree)
-                    && indexTree.equals(((IndexTreeMapping) o).indexTree);
-        }
-
-        public @Override int hashCode() {
-            return Objects.hash(featureTree, indexTree);
-        }
     }
 
     /**

--- a/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Clone.java
+++ b/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Clone.java
@@ -90,6 +90,9 @@ public class Clone extends AbstractCommand implements CLICommand {
     @Parameter(description = "<repository> [<directory>|<clone URI>]")
     private List<String> args = new ArrayList<>(2);
 
+    @Parameter(names = { "-I", "--include-indexes" }, description = "Clone also spatial indexes")
+    private boolean withIndexes = false;
+
     /**
      * Executes the clone command using the provided options.
      */
@@ -161,6 +164,7 @@ public class Clone extends AbstractCommand implements CLICommand {
                     .setUserName(username)//
                     .setPassword(password)//
                     .setDepth(depth)//
+                    .setCloneIndexes(withIndexes)//
                     .setProgressListener(cli.getProgressListener());
 
             clone.call();

--- a/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Fetch.java
+++ b/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Fetch.java
@@ -57,6 +57,9 @@ public class Fetch extends AbstractCommand implements CLICommand {
     @Parameter(names = { "--fulldepth" }, description = "Fetch the full history from the repository.")
     private boolean fulldepth = false;
 
+    @Parameter(names = { "-I", "--include-indexes" }, description = "Fetch also spatial indexes")
+    private boolean withIndexes = false;
+
     @Parameter(description = "[<repository>...]")
     private List<String> args;
 
@@ -79,7 +82,8 @@ public class Fetch extends AbstractCommand implements CLICommand {
             fetch.setProgressListener(cli.getProgressListener());
             fetch.setAll(all).setPrune(prune).setFullDepth(fulldepth);
             fetch.setDepth(depth);
-
+            fetch.setFetchIndexes(withIndexes);
+            
             if (args != null) {
                 for (String repo : args) {
                     fetch.addRemote(repo);

--- a/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Pull.java
+++ b/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Pull.java
@@ -64,6 +64,9 @@ public class Pull extends AbstractCommand implements CLICommand {
     @Parameter(names = { "--fulldepth" }, description = "Pull the full history from the repository.")
     private boolean fulldepth = false;
 
+    @Parameter(names = { "-I", "--include-indexes" }, description = "Pull also spatial indexes")
+    private boolean withIndexes = false;
+
     @Parameter(description = "[<repository> [<refspec>...]]")
     private List<String> args;
 
@@ -87,7 +90,8 @@ public class Pull extends AbstractCommand implements CLICommand {
         pull.setProgressListener(cli.getProgressListener());
         pull.setAll(all).setRebase(rebase).setFullDepth(fulldepth);
         pull.setDepth(depth);
-
+        pull.setIncludeIndexes(withIndexes);
+        
         if (args != null) {
             if (args.size() > 0) {
                 pull.setRemote(args.get(0));

--- a/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Push.java
+++ b/src/cli/remoting/src/main/java/org/locationtech/geogig/cli/remoting/Push.java
@@ -53,7 +53,7 @@ public class Push extends AbstractCommand implements CLICommand {
         PushOp push = cli.getGeogig().command(PushOp.class);
         push.setProgressListener(cli.getProgressListener());
         push.setAll(all);
-
+        
         if (args != null) {
             if (args.size() > 0) {
                 push.setRemote(args.get(0));

--- a/src/core/src/main/java/org/locationtech/geogig/hooks/builtin/UpdateIndexesHook.java
+++ b/src/core/src/main/java/org/locationtech/geogig/hooks/builtin/UpdateIndexesHook.java
@@ -16,11 +16,14 @@ import org.locationtech.geogig.repository.ProgressListener;
 
 import com.google.common.base.Optional;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * Hooks into {@link UpdateRef} to update all the indexes that need updating after a branch is
  * updated.
  *
  */
+@Slf4j
 public class UpdateIndexesHook implements CommandHook {
 
     @Override
@@ -52,7 +55,7 @@ public class UpdateIndexesHook implements CommandHook {
                 try {
                     ProgressListener listener = command.getProgressListener();
                     listener.started();
-
+                    log.debug("Calling UpdateIndexesOp for {}", ref);
                     updates = context.command(UpdateIndexesOp.class)//
                             .setRef(ref)//
                             .setProgressListener(listener)//

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/index/UpdateIndexesOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/index/UpdateIndexesOp.java
@@ -21,12 +21,12 @@ import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.ProgressListener;
 import org.locationtech.geogig.repository.impl.SpatialOps;
 import org.locationtech.geogig.storage.IndexDatabase;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
+import org.locationtech.jts.geom.Envelope;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
-import org.locationtech.jts.geom.Envelope;
+
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Given a {@code refSpec} that resolves to a root tree, finds out which indexes are defined for all
@@ -34,9 +34,8 @@ import org.locationtech.jts.geom.Envelope;
  * the current canonical tree versions.
  *
  */
+@Slf4j
 public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
-
-    private static final Logger LOG = LoggerFactory.getLogger(UpdateIndexesOp.class);
 
     private Ref rootRefSpec;
 
@@ -79,6 +78,7 @@ public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
 
         final IndexDatabase indexDatabase = indexDatabase();
 
+        
         List<Index> result = new ArrayList<>();
 
         for (NodeRef treeRef : featureTypeTreeRefs) {
@@ -88,7 +88,7 @@ public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
                 final @Nullable NodeRef oldTreeRef = previousTreeRefs.get(treePath);
 
                 List<Index> updated = updateIndexes(oldTreeRef, treeRef, layerIndexes);
-                if(getProgressListener().isCanceled()){
+                if (getProgressListener().isCanceled()) {
                     return null;
                 }
                 result.addAll(updated);
@@ -111,7 +111,7 @@ public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
         for (IndexInfo index : indexes) {
             indexTreeId = indexDatabase.resolveIndexedTree(index, newCanonicalTreeId);
             if (indexTreeId.isPresent()) {
-                LOG.debug("Index for tree {}({}) exists: {}", newTreeRef.path(), newCanonicalTreeId,
+                log.debug("Index for tree {}({}) exists: {}", newTreeRef.path(), newCanonicalTreeId,
                         indexTreeId.get());
             } else {
                 if (progress.isCanceled()) {
@@ -130,7 +130,8 @@ public class UpdateIndexesOp extends AbstractGeoGigOp<List<Index>> {
                     oldCanonicalTree = RevTree.EMPTY;
                 }
                 final RevTree newCanonicalTree = newCanonicalTreeId.equals(RevTree.EMPTY_TREE_ID)
-                        ? RevTree.EMPTY : objectDatabase().getTree(newCanonicalTreeId);
+                        ? RevTree.EMPTY
+                        : objectDatabase().getTree(newCanonicalTreeId);
 
                 BuildIndexOp cmd = command(BuildIndexOp.class);
                 cmd.setIndex(index);

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/CloneOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/CloneOp.java
@@ -94,6 +94,8 @@ public class CloneOp extends AbstractGeoGigOp<Repository> {
 
     private boolean singleBranch = false;
 
+    private boolean cloneIndexes = false;
+
     /**
      * Executes the clone operation.
      * 
@@ -216,6 +218,11 @@ public class CloneOp extends AbstractGeoGigOp<Repository> {
         return this;
     }
 
+    public CloneOp setCloneIndexes(boolean cloneIndexes) {
+        this.cloneIndexes = cloneIndexes;
+        return this;
+    }
+
     public Optional<String> getBranch() {
         return branch;
     }
@@ -245,6 +252,7 @@ public class CloneOp extends AbstractGeoGigOp<Repository> {
                 .addRemote(remote)//
                 .setDepth(depth)//
                 .setAutofetchTags(true)//
+                .setFetchIndexes(cloneIndexes)//
                 .setProgressListener(progress)//
                 .call();
 

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/FetchOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/FetchOp.java
@@ -70,6 +70,8 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
 
             private boolean fetchTags = true;
 
+            public boolean fetchIndexes;
+
             public FetchArgs build(Repository repo) {
                 if (allRemotes) {
                     remotes.clear();
@@ -105,7 +107,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
                 }
 
                 return new FetchArgs(fetchTags, prune, fullDepth, ImmutableList.copyOf(remotes),
-                        depth);
+                        depth, fetchIndexes);
             }
 
         }
@@ -120,13 +122,16 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
 
         final boolean fetchTags;
 
+        final boolean fetchIndexes;
+
         private FetchArgs(boolean fetchTags, boolean prune, boolean fullDepth,
-                ImmutableList<Remote> remotes, Optional<Integer> depth) {
+                ImmutableList<Remote> remotes, Optional<Integer> depth, boolean fetchIndexes) {
             this.fetchTags = fetchTags;
             this.prune = prune;
             this.fullDepth = fullDepth;
             this.remotes = remotes;
             this.depth = depth;
+            this.fetchIndexes = fetchIndexes;
         }
     }
 
@@ -141,7 +146,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
         argsBuilder.allRemotes = all;
         return this;
     }
-    
+
     /**
      * @param all if {@code true}, fetch from all remotes.
      * @return {@code this}
@@ -179,6 +184,11 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
 
     public boolean isPrune() {
         return argsBuilder.prune;
+    }
+
+    public FetchOp setFetchIndexes(boolean fetchIndexes) {
+        argsBuilder.fetchIndexes = fetchIndexes;
+        return this;
     }
 
     /**
@@ -273,6 +283,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
                         .setPrune(argsBuilder.prune)//
                         .addRemotes(argsBuilder.remotes)//
                         .setAutofetchTags(argsBuilder.fetchTags)//
+                        .setFetchIndexes(argsBuilder.fetchIndexes)//
                         .setProgressListener(getProgressListener())//
                         .call();
             }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/PullOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/PullOp.java
@@ -48,6 +48,8 @@ public class PullOp extends AbstractGeoGigOp<PullResult> {
 
     private boolean fullDepth = false;
 
+    private boolean includeIndexes = false;
+
     private Supplier<Optional<Remote>> remote;
 
     private List<String> refSpecs = new ArrayList<String>();
@@ -180,6 +182,18 @@ public class PullOp extends AbstractGeoGigOp<PullResult> {
         return this;
     }
 
+    /**
+     * If {@code true}, also synchronize the spatial indexes. Defaults to {@code false}.
+     */
+    public PullOp setIncludeIndexes(boolean pullIndexes) {
+        this.includeIndexes = pullIndexes;
+        return this;
+    }
+
+    public boolean isIncludeIndexes() {
+        return includeIndexes;
+    }
+
     public String getAuthor() {
         return authorName.orNull();
     }
@@ -227,6 +241,7 @@ public class PullOp extends AbstractGeoGigOp<PullResult> {
                 .setDepth(depth.or(0))//
                 .setFullDepth(fullDepth)//
                 .setAllRemotes(all)//
+                .setFetchIndexes(includeIndexes)//
                 .setProgressListener(getProgressListener())//
                 .call();
 

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/FetchOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/FetchOp.java
@@ -46,6 +46,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import lombok.AllArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -102,6 +104,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
                 final List<LocalRemoteRef> localToRemoteRemoteRefs = resolveRemoteRefs(remoteRepo);
 
                 final PackRequest request = prepareRequest(localRepo, localToRemoteRemoteRefs);
+                request.syncIndexes(args.fetchIndexes);
 
                 if (progress.isCanceled())
                     return null;
@@ -323,7 +326,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
     /**
      * Immutable state of command arguments
      */
-    private static class FetchArgs {
+    private static @AllArgsConstructor @Value class FetchArgs {
 
         /**
          * Builder for command arguments
@@ -340,6 +343,8 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
             private Optional<Integer> depth = Optional.absent();
 
             private boolean fetchTags = true;
+
+            private boolean fetchIndexes = false;
 
             public FetchArgs build(Repository repo) {
                 if (allRemotes) {
@@ -376,10 +381,12 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
                 }
 
                 return new FetchArgs(fetchTags, prune, fullDepth, ImmutableList.copyOf(remotes),
-                        depth);
+                        depth, fetchIndexes);
             }
 
         }
+
+        final boolean fetchTags;
 
         final boolean prune;
 
@@ -389,16 +396,7 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
 
         final Optional<Integer> depth;
 
-        final boolean fetchTags;
-
-        private FetchArgs(boolean fetchTags, boolean prune, boolean fullDepth,
-                ImmutableList<Remote> remotes, Optional<Integer> depth) {
-            this.fetchTags = fetchTags;
-            this.prune = prune;
-            this.fullDepth = fullDepth;
-            this.remotes = remotes;
-            this.depth = depth;
-        }
+        private boolean fetchIndexes;
     }
 
     /**
@@ -512,4 +510,10 @@ public class FetchOp extends AbstractGeoGigOp<TransferSummary> {
     public List<Remote> getRemotes() {
         return ImmutableList.copyOf(argsBuilder.remotes);
     }
+
+    public FetchOp setFetchIndexes(boolean fetchIndexes) {
+        argsBuilder.fetchIndexes = fetchIndexes;
+        return this;
+    }
+
 }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/LocalPackBuilder.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/LocalPackBuilder.java
@@ -26,7 +26,7 @@ public class LocalPackBuilder extends AbstractPackBuilder {
 
     @Override
     public Pack build() {
-        PackImpl pack = new PackImpl(localRepo, tags, missingCommits);
+        PackImpl pack = new PackImpl(localRepo, tags, missingCommits, missingIndexes);
         return pack;
     }
 

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/LocalPackProcessor.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/LocalPackProcessor.java
@@ -9,26 +9,56 @@
  */
 package org.locationtech.geogig.remotes.pack;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import java.util.Iterator;
 
+import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.remotes.pack.Pack.IndexDef;
+import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.storage.BulkOpListener;
+import org.locationtech.geogig.storage.IndexDatabase;
 import org.locationtech.geogig.storage.ObjectStore;
+
+import com.google.common.base.Optional;
+
+import lombok.NonNull;
 
 public class LocalPackProcessor implements PackProcessor {
 
     private ObjectStore target;
 
-    public LocalPackProcessor(ObjectStore target) {
-        checkNotNull(target);
-        this.target = target;
+    private IndexDatabase targetIndexdb;
+
+    public LocalPackProcessor(@NonNull ObjectStore targetStore,
+            @NonNull IndexDatabase targetIndexdb) {
+        this.target = targetStore;
+        this.targetIndexdb = targetIndexdb;
     }
 
-    @Override
-    public void putAll(Iterator<? extends RevObject> iterator, BulkOpListener listener) {
+    public @Override void putAll(Iterator<? extends RevObject> iterator, BulkOpListener listener) {
         target.putAll(iterator, listener);
+    }
+
+    public @Override void putIndex(IndexDef indexDef, Iterator<RevTree> indexContents,
+            BulkOpListener listener) {
+
+        IndexDatabase indexdb = targetIndexdb;
+
+        String treeName = indexDef.getIndex().getTreeName();
+        String attributeName = indexDef.getIndex().getAttributeName();
+        Optional<IndexInfo> existingIndex = indexdb.getIndexInfo(treeName, attributeName);
+        IndexInfo indexInfo = indexDef.getIndex();
+
+        indexdb.putAll(indexContents, listener);
+
+        if (!existingIndex.isPresent()) {
+            indexInfo = indexdb.createIndexInfo(treeName, attributeName, indexInfo.getIndexType(),
+                    indexInfo.getMetadata());
+        }
+        ObjectId originalTree = indexDef.getCanonical();
+        ObjectId indexedTree = indexDef.getIndexTreeId();
+        indexdb.addIndexedTree(indexInfo, originalTree, indexedTree);
     }
 
 }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/Pack.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/Pack.java
@@ -11,14 +11,28 @@ package org.locationtech.geogig.remotes.pack;
 
 import java.util.List;
 
+import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.remotes.RefDiff;
+import org.locationtech.geogig.repository.IndexInfo;
 import org.locationtech.geogig.repository.ProgressListener;
+
+import lombok.Builder;
+import lombok.NonNull;
+import lombok.Value;
 
 /**
  * @author groldan
  *
  */
 public interface Pack {
+
+    public static @Value @Builder class IndexDef {
+        private final @NonNull IndexInfo index;
+
+        private final @NonNull ObjectId canonical;
+
+        private final @NonNull ObjectId parentIndexTreeId, indexTreeId;
+    }
 
     /**
      * @param target

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackBuilder.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackBuilder.java
@@ -11,8 +11,10 @@ package org.locationtech.geogig.remotes.pack;
 
 import java.util.Set;
 
+import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.RevTag;
+import org.locationtech.geogig.repository.IndexInfo;
 
 public interface PackBuilder {
 
@@ -21,6 +23,9 @@ public interface PackBuilder {
     void startRefResponse(RefRequest req);
 
     void addCommit(RevCommit commit);
+
+    public void addIndex(IndexInfo indexDef, ObjectId canonicalFeatureTreeId,
+            ObjectId oldIndexTreeId, ObjectId newIndexTreeId);
 
     void endRefResponse();
 

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackProcessor.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackProcessor.java
@@ -12,6 +12,7 @@ package org.locationtech.geogig.remotes.pack;
 import java.util.Iterator;
 
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.storage.BulkOpListener;
 
 /**
@@ -25,5 +26,7 @@ import org.locationtech.geogig.storage.BulkOpListener;
 public interface PackProcessor {
 
     public void putAll(Iterator<? extends RevObject> iterator, BulkOpListener listener);
+
+    public void putIndex(Pack.IndexDef index, Iterator<RevTree> indexContents, BulkOpListener listener);
 
 }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackRequest.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PackRequest.java
@@ -46,6 +46,8 @@ public class PackRequest {
 
     private @Nullable RepositoryFilter sparseFilter;
 
+    private boolean syncIndexes;
+
     /**
      * Adds a ref to pack, its {@link Ref#getObjectId() objectId} indicates which version the local
      * copy of the remote ref points to, {@link ObjectId#NULL} must be used in case there's no local
@@ -77,6 +79,15 @@ public class PackRequest {
 
     public Optional<RepositoryFilter> getSparseFilter() {
         return Optional.fromNullable(sparseFilter);
+    }
+
+    public PackRequest syncIndexes(boolean syncIndexes) {
+        this.syncIndexes = syncIndexes;
+        return this;
+    }
+
+    public boolean isSyncIndexes() {
+        return syncIndexes;
     }
 
     /**

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PushOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/PushOp.java
@@ -122,6 +122,8 @@ public class PushOp extends AbstractGeoGigOp<TransferSummary> {
 
     private String remoteName;
 
+    private boolean pushIndexes;
+
     protected @Override TransferSummary _call() {
         final Remote remote = resolveRemote();
         final Repository localRepo = repository();
@@ -134,7 +136,8 @@ public class PushOp extends AbstractGeoGigOp<TransferSummary> {
             final Set<Ref> remoteRefs = getRemoteRefs(remoteRepo);
             final List<PushReq> pushRequests = parseRequests(remoteRefs);
             final PackRequest request = prepareRequest(pushRequests, remoteRefs);
-
+            request.syncIndexes(pushIndexes);
+            
             List<RefDiff> dataTransferResults = localRepo.command(SendPackOp.class)//
                     .setRequest(request)//
                     .setTarget(remoteRepo)//
@@ -584,6 +587,11 @@ public class PushOp extends AbstractGeoGigOp<TransferSummary> {
                     localRef == null ? "" : localRef.getName(), //
                     remoteRef == null ? "" : remoteRef);
         }
+    }
+
+    public PushOp setPushIndexes(boolean pushIndexes) {
+        this.pushIndexes = pushIndexes;
+        return this;
     }
 
 }

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/ReceivePackOp.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/ReceivePackOp.java
@@ -21,6 +21,7 @@ import org.locationtech.geogig.remotes.RefDiff;
 import org.locationtech.geogig.remotes.TransferSummary;
 import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.IndexDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
 
 /**
@@ -48,7 +49,8 @@ public class ReceivePackOp extends AbstractGeoGigOp<List<RefDiff>> {
     protected PackProcessor getPackProcessor() {
         Repository repo = repository();
         ObjectDatabase store = repo.objectDatabase();
-        return new LocalPackProcessor(store);
+        IndexDatabase index = repo.indexDatabase();
+        return new LocalPackProcessor(store, index);
     }
 
     public ReceivePackOp setPack(Pack pack) {

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/RefRequest.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/pack/RefRequest.java
@@ -82,7 +82,7 @@ public class RefRequest {
         if (have != null && have.isNull()) {
             have = null;
         }
-        return new RefRequest(want.getName(), want.getObjectId(), have);
+        return create(want.getName(), want.getObjectId(), have);
     }
 
     public static RefRequest create(String name, ObjectId wantId, @Nullable ObjectId haveId) {

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/CloneOpTest.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/CloneOpTest.java
@@ -58,7 +58,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 /**
- * {@link CloneOpTest} integration test suite for full clones (for shallow and sparse clones see
+ * {@link CloneOp} integration test suite for full clones (for shallow and sparse clones see
  * {@link ShallowCloneTest} and {@link SparseCloneTest})
  *
  */
@@ -66,9 +66,9 @@ public class CloneOpTest extends RemoteRepositoryTestCase {
     @Rule
     public ExpectedException exception = ExpectedException.none();
 
-    private Repository remoteRepo;
+    protected Repository remoteRepo;
 
-    private Repository cloneRepo;
+    protected Repository cloneRepo;
 
     @Override
     protected void setUpInternal() throws Exception {

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/CloneOpWithIndexTest.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/CloneOpWithIndexTest.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2012-2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Johnathan Garrett (LMN Solutions) - initial implementation
+ */
+package org.locationtech.geogig.test.integration.remoting;
+
+import static org.locationtech.geogig.test.integration.remoting.RemotesIndexTestSupport.createIndexes;
+import static org.locationtech.geogig.test.integration.remoting.RemotesIndexTestSupport.verifyClonedIndexes;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.locationtech.geogig.remotes.CloneOp;
+import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.repository.AbstractGeoGigOp.CommandListener;
+import org.locationtech.geogig.repository.Repository;
+
+/**
+ * {@link CloneOp} integration test suite for full clones (for shallow and sparse clones see
+ * {@link ShallowCloneTest} and {@link SparseCloneTest})
+ *
+ */
+public class CloneOpWithIndexTest extends CloneOpTest {
+
+    /**
+     * Override to set setCloneIndexes(true) and add a command hook that creates the indexes on the
+     * remote repo before cloning it
+     */
+    protected @Override CloneOp cloneOp() {
+        CloneOp cloneOp = super.cloneOp().setCloneIndexes(true);
+        cloneOp.addListener(createSpatialIndexBeforeCloneListener);
+        return cloneOp;
+    }
+
+    private CommandListener createSpatialIndexBeforeCloneListener = new CommandListener() {
+
+        public @Override void preCall(AbstractGeoGigOp<?> command) {
+            Repository remote = CloneOpWithIndexTest.this.remoteRepo;
+            createIndexes(remote);
+        }
+
+        public @Override void postCall(AbstractGeoGigOp<?> command, @Nullable Object result,
+                @Nullable RuntimeException exception) {
+
+            Repository remote = CloneOpWithIndexTest.this.remoteRepo;
+            Repository local = command.context().repository();
+            CloneOp op = (CloneOp) command;
+            if (result != null) {
+                verifyClonedIndexes(local, remote, op.getBranch());
+            }
+        }
+    };
+}

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/FetchOpTest.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/FetchOpTest.java
@@ -61,7 +61,7 @@ public class FetchOpTest extends RemoteRepositoryTestCase {
 
     LinkedList<RevCommit> expectedBranch;
 
-    private Repository originRepo, localRepo, upstreamRepo;
+    protected Repository originRepo, localRepo, upstreamRepo;
 
     private Remote origin, upstream;
 
@@ -78,6 +78,11 @@ public class FetchOpTest extends RemoteRepositoryTestCase {
 
     @Override
     protected void setUpInternal() throws Exception {
+
+        localRepo = localGeogig.repo;
+        originRepo = remoteGeogig.repo;
+        upstreamRepo = upstreamGeogig.repo;
+
         // clone the repository
         CloneOp clone = cloneOp();
         // clone.setRepositoryURL(remoteGeogig.envHome.toURI().toString()).call();
@@ -133,10 +138,6 @@ public class FetchOpTest extends RemoteRepositoryTestCase {
         logs = remoteGeogig.geogig.command(LogOp.class).call();
         logged = Lists.newArrayList(logs);
         assertEquals(expectedMaster, logged);
-
-        localRepo = localGeogig.repo;
-        originRepo = remoteGeogig.repo;
-        upstreamRepo = upstreamGeogig.repo;
 
         upstreamRepo.command(CloneOp.class).setRemoteURI(originRepo.getLocation())
                 .setRemoteName("origin").call();

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/FetchOpWithIndexTest.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/FetchOpWithIndexTest.java
@@ -1,0 +1,105 @@
+/* Copyright (c) 2012-2017 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan - initial implementation
+ */
+package org.locationtech.geogig.test.integration.remoting;
+
+import static org.junit.Assert.assertTrue;
+import static org.locationtech.geogig.test.integration.remoting.RemotesIndexTestSupport.createIndexes;
+import static org.locationtech.geogig.test.integration.remoting.RemotesIndexTestSupport.verifyClonedIndexes;
+
+import java.util.Collection;
+import java.util.Set;
+
+import org.eclipse.jdt.annotation.Nullable;
+import org.locationtech.geogig.model.Ref;
+import org.locationtech.geogig.remotes.CloneOp;
+import org.locationtech.geogig.remotes.FetchOp;
+import org.locationtech.geogig.remotes.RefDiff;
+import org.locationtech.geogig.remotes.TransferSummary;
+import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.repository.AbstractGeoGigOp.CommandListener;
+import org.locationtech.geogig.repository.Remote;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+
+import com.google.common.base.Optional;
+
+public class FetchOpWithIndexTest extends FetchOpTest {
+
+    /**
+     * Override to set setCloneIndexes(true) and add a command hook that creates the indexes on the
+     * remote repo before cloning it
+     */
+    protected @Override CloneOp cloneOp() {
+        CloneOp cloneOp = super.cloneOp().setCloneIndexes(true);
+        cloneOp.addListener(createSpatialIndexBeforeCloneListener);
+        return cloneOp;
+    }
+
+    protected @Override FetchOp fetchOp() throws RepositoryConnectionException {
+        FetchOp fetchOp = super.fetchOp();
+        fetchOp.addListener(verifyFetchedIndexesListener);
+        return fetchOp.setFetchIndexes(true);
+    }
+
+    private CommandListener verifyFetchedIndexesListener = new CommandListener() {
+
+        public @Override void preCall(AbstractGeoGigOp<?> command) {// nothing to do
+            createIndexes(FetchOpWithIndexTest.this.originRepo);
+            createIndexes(FetchOpWithIndexTest.this.upstreamRepo);
+        }
+
+        public @Override void postCall(AbstractGeoGigOp<?> command, @Nullable Object result,
+                @Nullable RuntimeException exception) {
+            if (exception != null) {
+                return;
+            }
+            TransferSummary ts = (TransferSummary) result;
+            Set<String> remotes = ts.getRefDiffs().keySet();
+            for (String remoteURI : remotes) {
+                FetchOp op = (FetchOp) command;
+                java.util.Optional<Remote> remoteObj = op.getRemotes().stream()
+                        .filter(r -> remoteURI.equals(r.getFetchURL())).findFirst();
+                assertTrue(remoteObj.isPresent());
+
+                Repository remote;
+                String originURI = originRepo.getLocation().toString();
+                if (originURI.startsWith(remoteURI)) {
+                    remote = originRepo;
+                } else {
+                    remote = upstreamRepo;
+                }
+                Collection<RefDiff> collection = ts.getRefDiffs().get(remoteURI);
+                for (RefDiff rd : collection) {
+                    if (rd.isDelete()) {
+                        continue;
+                    }
+                    Ref newRef = rd.getNewRef();
+                    Repository local = command.context().repository();
+                    String localRef = newRef.getName();
+                    String remoteBranch = remoteObj.get().mapToRemote(localRef).orElse(null);
+                    verifyClonedIndexes(local, remote, Optional.of(localRef),
+                            Optional.of(remoteBranch));
+                }
+            }
+        }
+    };
+
+    private CommandListener createSpatialIndexBeforeCloneListener = new CommandListener() {
+
+        public @Override void preCall(AbstractGeoGigOp<?> command) {
+            Repository remote = FetchOpWithIndexTest.this.originRepo;
+            createIndexes(remote);
+        }
+
+        public @Override void postCall(AbstractGeoGigOp<?> command, @Nullable Object result,
+                @Nullable RuntimeException exception) {
+        }
+    };
+}

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/RemoteRepositoryTestCase.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/RemoteRepositoryTestCase.java
@@ -82,6 +82,8 @@ import org.locationtech.geogig.repository.impl.GeoGIG;
 import org.locationtech.geogig.repository.impl.GlobalContextBuilder;
 import org.locationtech.geogig.test.TestPlatform;
 import org.locationtech.geogig.test.integration.TestContextBuilder;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.io.ParseException;
 import org.opengis.feature.Feature;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.FeatureType;
@@ -98,8 +100,6 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.Multibinder;
-import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.io.ParseException;
 
 public abstract class RemoteRepositoryTestCase {
 

--- a/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/RemotesIndexTestSupport.java
+++ b/src/remoting/src/test/java/org/locationtech/geogig/test/integration/remoting/RemotesIndexTestSupport.java
@@ -1,0 +1,195 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan - initial implementation
+ */
+package org.locationtech.geogig.test.integration.remoting;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import org.locationtech.geogig.data.FindFeatureTypeTrees;
+import org.locationtech.geogig.model.NodeRef;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.Ref;
+import org.locationtech.geogig.model.RevCommit;
+import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.model.impl.RevObjectTestSupport;
+import org.locationtech.geogig.plumbing.RefParse;
+import org.locationtech.geogig.plumbing.RevParse;
+import org.locationtech.geogig.porcelain.BranchListOp;
+import org.locationtech.geogig.porcelain.LogOp;
+import org.locationtech.geogig.porcelain.index.CreateQuadTree;
+import org.locationtech.geogig.porcelain.index.Index;
+import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.IndexDatabase.IndexTreeMapping;
+import org.locationtech.jts.geom.Envelope;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class RemotesIndexTestSupport {
+
+    public static void createIndexes(Repository repo) {
+        ImmutableList<Ref> branches = repo.command(BranchListOp.class).call();
+        branches.forEach(ref -> createIndexes(repo, ref));
+    }
+
+    public static void createIndexes(Repository repo, Ref ref) {
+        Envelope bounds = new Envelope(-180, 180, -90, 90);
+        List<NodeRef> types = repo.command(FindFeatureTypeTrees.class).setRootTreeRef(ref.getName())
+                .call();
+
+        for (NodeRef treeRef : types) {
+            Map<String, IndexInfo> typeIndexes = getIndexes(repo, treeRef.path());
+            if (!typeIndexes.containsKey(treeRef.path())) {
+                Index index = repo.command(CreateQuadTree.class).setBounds(bounds)
+                        .setIndexHistory(true).setTypeTreeRef(treeRef).call();
+                log.info("Created index {} before cloning", index);
+            }
+        }
+    }
+
+    public static void verifyClonedIndexes(Repository local, Repository remote,
+            Optional<String> branch) {
+        verifyClonedIndexes(local, remote, branch, branch);
+    }
+
+    public static void verifyClonedIndexes(Repository local, Repository remote,
+            Optional<String> localRef, Optional<String> remoteRef) {
+        Map<String, IndexInfo> remoteIndexes = getIndexes(remote, remoteRef);
+        Map<String, IndexInfo> localIndexes = getIndexes(local, localRef);
+
+        assertEquals(remoteIndexes.keySet(), localIndexes.keySet());
+        assertEquals(remoteIndexes, localIndexes);
+        for (String treename : remoteIndexes.keySet()) {
+            IndexInfo indexInfo = remoteIndexes.get(treename);
+            verifySameIndexContents(local, remote, indexInfo, localRef, remoteRef);
+        }
+    }
+
+    public static void verifySameIndexContents(Repository local, Repository remote,
+            IndexInfo indexInfo, Optional<String> localRef, Optional<String> remoteRef) {
+
+        Set<IndexTreeMapping> remoteIndexMappings = getIndexMappings(indexInfo, remote, remoteRef);
+        Set<IndexTreeMapping> localIndexMappings = getIndexMappings(indexInfo, local, localRef);
+
+        Map<ObjectId, ObjectId> remoteByCanonical = remoteIndexMappings.stream()
+                .collect(Collectors.toMap(m -> m.featureTree, m -> m.indexTree));
+
+        Map<ObjectId, ObjectId> localByCanonical = localIndexMappings.stream()
+                .collect(Collectors.toMap(m -> m.featureTree, m -> m.indexTree));
+
+        assertEquals(remoteByCanonical.size(), localByCanonical.size());
+        assertEquals(remoteByCanonical, localByCanonical);
+        localByCanonical.forEach((canonicalId, indexId) -> {
+            Set<RevTree> allRemoteIndexContents = RevObjectTestSupport
+                    .getAllTrees(remote.indexDatabase(), indexId);
+            Set<RevTree> allLocalIndexContents = RevObjectTestSupport
+                    .getAllTrees(local.indexDatabase(), indexId);
+
+            assertEquals(allRemoteIndexContents.size(), allLocalIndexContents.size());
+            if(!allRemoteIndexContents.equals(allLocalIndexContents)) {
+                System.err.println("wtf: " + allRemoteIndexContents.equals(allLocalIndexContents));
+            }
+            assertEquals(allRemoteIndexContents, allLocalIndexContents);
+        });
+        log.info("Index {} cloned correctly", indexInfo);
+    }
+
+    private static Set<IndexTreeMapping> getIndexMappings(IndexInfo indexInfo, Repository repo,
+            Optional<String> ref) {
+
+        if (!ref.isPresent()) {
+            return Sets.newHashSet(repo.indexDatabase().resolveIndexedTrees(indexInfo));
+        }
+
+        Set<IndexTreeMapping> mappings = new HashSet<>();
+        List<Ref> branches = getBranches(repo, ref);
+        for (Ref branch : branches) {
+            List<RevCommit> commits = Lists.newArrayList(repo.command(LogOp.class)
+                    .addPath(indexInfo.getTreeName()).setUntil(branch.getObjectId()).call());
+            for (RevCommit c : commits) {
+                String treeRef = String.format("%s:%s", c.getId(), indexInfo.getTreeName());
+                ObjectId canonicalTreeId = repo.command(RevParse.class).setRefSpec(treeRef).call()
+                        .get();
+                Optional<ObjectId> indexedTree = repo.indexDatabase().resolveIndexedTree(indexInfo,
+                        canonicalTreeId);
+                assertTrue(indexedTree.isPresent());
+                mappings.add(new IndexTreeMapping(canonicalTreeId, indexedTree.get()));
+            }
+        }
+        return mappings;
+    }
+
+    public static Map<String, IndexInfo> getIndexes(Repository repo, Optional<String> branch) {
+
+        Map<String, IndexInfo> allIndexes = new HashMap<>();
+
+        List<Ref> branches = getBranches(repo, branch);
+        if (branches.isEmpty()) {
+            return allIndexes;
+        }
+        for (Ref ref : branches) {
+            Map<String, IndexInfo> branchIndexes = getIndexes(repo, ref);
+            allIndexes.putAll(branchIndexes);
+        }
+        return allIndexes;
+    }
+
+    public static List<Ref> getBranches(Repository repo, Optional<String> branch) {
+        List<Ref> branches;
+        if (branch.isPresent()) {
+            Optional<Ref> r = repo.command(RefParse.class).setName(branch.get()).call();
+            if (r.isPresent()) {
+                branches = Collections.singletonList(r.get());
+            } else {
+                return Collections.emptyList();
+            }
+        } else {
+            branches = repo.command(BranchListOp.class).call();
+        }
+        return branches;
+    }
+
+    public static Map<String, IndexInfo> getIndexes(Repository repo, Ref branch) {
+
+        List<NodeRef> types = repo.command(FindFeatureTypeTrees.class)
+                .setRootTreeRef(branch.getName()).call();
+
+        Map<String, IndexInfo> branchIndexes = new HashMap<>();
+        for (NodeRef typeRef : types) {
+            Map<String, IndexInfo> indexes = getIndexes(repo, typeRef.path());
+            branchIndexes.putAll(indexes);
+        }
+        return branchIndexes;
+    }
+
+    public static Map<String, IndexInfo> getIndexes(Repository repo, String featureTreePath) {
+        List<IndexInfo> indexInfos;
+        indexInfos = repo.indexDatabase().getIndexInfos(featureTreePath);
+
+        Map<String, IndexInfo> typeIndexes = indexInfos.stream()
+                .collect(Collectors.toMap(i -> i.getTreeName(), i -> i));
+        return typeIndexes;
+    }
+
+}

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/pack/StreamingPackWriter.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/pack/StreamingPackWriter.java
@@ -15,8 +15,10 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevTag;
+import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.remotes.pack.LocalPackBuilder;
 import org.locationtech.geogig.remotes.pack.Pack;
+import org.locationtech.geogig.remotes.pack.Pack.IndexDef;
 import org.locationtech.geogig.remotes.pack.PackBuilder;
 import org.locationtech.geogig.remotes.pack.PackProcessor;
 import org.locationtech.geogig.remotes.pack.RefRequest;
@@ -88,5 +90,9 @@ public class StreamingPackWriter extends LocalPackBuilder implements PackBuilder
         } catch (IOException e) {
             throw new RuntimeException(e);
         }
+    }
+
+    public @Override void putIndex(IndexDef index, Iterator<RevTree> indexContents, BulkOpListener listener) {
+        throw new UnsupportedOperationException("implement!");
     }
 }


### PR DESCRIPTION
On the command line, use -I or --include-indexes with clone,
pull, and fetch, to also synchronize the upstream repo indexes
on the local repo.

Signed-off-by: Gabriel Roldan <groldan@boundlessgeo.com>