### PR TITLE
Forward port postgres upgrade utility and other CLI commands from 1.2.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ target
 bin/
 #when run from within eclipse, cucumber tests create report folders in the project dir instead of it's target/ directory
 cucumber-report*
+git.properties
 git.geogig.properties
 # Netbeans project files
 nb-configuration.xml

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ nb-configuration.xml
 # IntelliJ module files
 *.iml
 hs_err_pid*
+#KDE
+.directory

--- a/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/LsRepos.java
+++ b/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/LsRepos.java
@@ -1,0 +1,243 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.cli.storage;
+
+import static java.lang.String.format;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.geotools.io.TableWriter;
+import org.locationtech.geogig.cli.AbstractCommand;
+import org.locationtech.geogig.cli.CLICommand;
+import org.locationtech.geogig.cli.CommandFailedException;
+import org.locationtech.geogig.cli.Console;
+import org.locationtech.geogig.cli.GeogigCLI;
+import org.locationtech.geogig.cli.annotation.RequiresRepository;
+import org.locationtech.geogig.data.FindFeatureTypeTrees;
+import org.locationtech.geogig.model.NodeRef;
+import org.locationtech.geogig.model.ObjectId;
+import org.locationtech.geogig.model.Ref;
+import org.locationtech.geogig.model.RevCommit;
+import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.porcelain.BranchListOp;
+import org.locationtech.geogig.porcelain.LogOp;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+import org.locationtech.geogig.repository.RepositoryResolver;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableList;
+
+@RequiresRepository(false)
+@Parameters(commandNames = "ls-repos", commandDescription = "List repositories under a base URI")
+public class LsRepos extends AbstractCommand implements CLICommand {
+
+    @Parameter(description = "<base URI> The URI without a repository name. (e.g. geogig ls-repos postgresql://localhost:5432/geogig_db?user=...&password=...)", arity = 1)
+    private List<URI> baseuri = new ArrayList<>();
+
+    @Parameter(names = { "-v", "--verbose" }, description = "verbose output")
+    private boolean verbose;
+
+    @Parameter(names = { "-c",
+            "--csv" }, description = "If verbose output, use comma separated list instead of table output")
+    private boolean csv;
+
+    protected @Override void runInternal(GeogigCLI cli) throws IOException {
+
+        checkParameter(!baseuri.isEmpty(),
+                "Usage: geogig ls-repos <base URI> (e.g. geogig ls-repos postgresql://localhost:5432/geogig_db?user=...&password=...)");
+
+        URI baseURI = baseuri.get(0);
+        RepositoryResolver resolver = RepositoryResolver.lookup(baseURI);
+        List<String> repoNames = new ArrayList<>(resolver.listRepoNamesUnderRootURI(baseURI));
+        Collections.sort(repoNames);
+        Console console = cli.getConsole();
+        if (verbose) {
+            logVerbose(console, baseURI, repoNames, resolver);
+        } else {
+            for (String name : repoNames) {
+                console.println(name);
+            }
+        }
+    }
+
+    private static class RepoInfo {
+
+        public String name;
+
+        public int numBranches;
+
+        public long totalCommits;
+
+        public int uniqueCommits;
+
+        public Object uniqueLayerNames;
+
+        public long totalFeatures;
+
+    }
+
+    private static class Formatter {
+
+        protected static final List<String> colNames = Arrays.asList("Name", "Branches",
+                "Total commits", "Unique commits", "Feature types", "Total features");
+
+        boolean writeHeader = true;
+
+        protected Collection<RepoInfo> infos = new LinkedBlockingQueue<>();
+
+        protected Console console;
+
+        public Formatter(Console console) {
+            this.console = console;
+        }
+
+        public void append(RepoInfo info) {
+            infos.add(info);
+        }
+
+        public void print(Console console) {
+            List<RepoInfo> infos = getSortedInfos();
+            TableWriter w = new TableWriter(null);
+            w.nextLine(TableWriter.DOUBLE_HORIZONTAL_LINE);
+            writeColumn(w, colNames);
+            w.nextLine();
+            w.nextLine(TableWriter.DOUBLE_HORIZONTAL_LINE);
+            infos.forEach(i -> {
+                writeColumn(w, formatValues(i));
+                w.nextLine();
+            });
+            w.nextLine(TableWriter.DOUBLE_HORIZONTAL_LINE);
+            try {
+                console.println(w.toString());
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        private List<RepoInfo> getSortedInfos() {
+            List<RepoInfo> sorted = new ArrayList<>(this.infos);
+            Collections.sort(sorted, (i1, i2) -> i1.name.compareTo(i2.name));
+            return sorted;
+        }
+
+        private List<String> formatValues(RepoInfo info) {
+            return Arrays.asList(info.name, format("%,d", info.numBranches),
+                    format("%,d", info.totalCommits), format("%,d", info.uniqueCommits),
+                    format("%,d", info.uniqueLayerNames), format("%,d", info.totalFeatures));
+        }
+
+        private void writeColumn(TableWriter w, List<String> values) {
+            for (int i = 0; i < values.size(); i++) {
+                w.write(values.get(i));
+                if (i < values.size() - 1) {
+                    w.nextColumn();
+                }
+            }
+        }
+    }
+
+    private static class CsvFormatter extends Formatter {
+
+        public CsvFormatter(Console console) {
+            super(console);
+        }
+
+        public @Override void append(RepoInfo info) {
+            try {
+                if (writeHeader) {
+                    console.println(Joiner.on(',').join(colNames));
+                    writeHeader = false;
+                }
+                String line = String.format("%s,%d,%d,%d,%d,%d", info.name, info.numBranches,
+                        info.totalCommits, info.uniqueCommits, info.uniqueLayerNames,
+                        info.totalFeatures);
+                // console.println is synchronized, so we're ok being called from a parallel
+                // stream
+                console.println(line);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public @Override void print(Console console) {
+            // do nothing
+        }
+    }
+
+    private void logVerbose(Console console, URI baseURI, List<String> repoNames,
+            RepositoryResolver resolver) {
+        Formatter formatter = this.csv ? new CsvFormatter(console) : new Formatter(console);
+        repoNames.stream().parallel().map(name -> toRepoInfo(resolver, baseURI, name))
+                .forEach(formatter::append);
+        formatter.print(console);
+    }
+
+    private RepoInfo toRepoInfo(RepositoryResolver resolver, URI rootRepoURI, String repoName) {
+        URI repoURI = resolver.buildRepoURI(rootRepoURI, repoName);
+        Repository repo;
+        try {
+            repo = resolver.open(repoURI);
+        } catch (RepositoryConnectionException e) {
+            throw new CommandFailedException(e);
+        }
+        try {
+            return toRepoInfo(repoName, repo);
+        } finally {
+            repo.close();
+        }
+    }
+
+    private RepoInfo toRepoInfo(String name, Repository repo) {
+        RepoInfo info = new RepoInfo();
+        info.name = name;
+        ImmutableList<Ref> branches = repo.command(BranchListOp.class).call();
+        info.numBranches = branches.size();
+        Set<ObjectId> uniqueCommits = new HashSet<>();
+        Set<String> layerNames = new HashSet<>();
+        AtomicLong totalCommits = new AtomicLong();
+        AtomicLong totalFeatures = new AtomicLong();
+        branches.forEach(ref -> {
+            Iterator<RevCommit> commits = repo.command(LogOp.class).setUntil(ref.getObjectId())
+                    .call();
+            commits.forEachRemaining(c -> {
+                totalCommits.incrementAndGet();
+                uniqueCommits.add(c.getId());
+                ObjectId treeId = c.getTreeId();
+                RevTree root = RevTree.EMPTY_TREE_ID.equals(treeId) ? RevTree.EMPTY
+                        : repo.objectDatabase().getTree(treeId);
+                totalFeatures.addAndGet(root.size());
+                if (!root.isEmpty()) {
+                    repo.command(FindFeatureTypeTrees.class).setRootTreeRef(root.getId().toString())
+                            .call().stream().map(NodeRef::name).forEach(layerNames::add);
+                }
+            });
+        });
+
+        info.totalCommits = totalCommits.get();
+        info.uniqueCommits = uniqueCommits.size();
+        info.uniqueLayerNames = layerNames.size();
+        info.totalFeatures = totalFeatures.get();
+        return info;
+    }
+}

--- a/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/PGCreateDDL.java
+++ b/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/PGCreateDDL.java
@@ -1,0 +1,43 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.cli.storage;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.geogig.cli.AbstractCommand;
+import org.locationtech.geogig.cli.CLICommand;
+import org.locationtech.geogig.cli.GeogigCLI;
+import org.locationtech.geogig.cli.annotation.RequiresRepository;
+import org.locationtech.geogig.storage.postgresql.commands.CreateDDL;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+
+@RequiresRepository(false)
+@Parameters(commandNames = "postgres-ddl", commandDescription = "Creates a DDL script to initialize a Geogig PostgreSQL database")
+public class PGCreateDDL extends AbstractCommand implements CLICommand {
+
+    @Parameter(description = "<base URI> The URI without a repository name. (e.g. geogig postgres-ddl postgresql://localhost:5432/geogig_db?user=...&password=...)", arity = 1)
+    private List<URI> baseuri = new ArrayList<>();
+
+    protected @Override void runInternal(GeogigCLI cli) throws IOException {
+        checkParameter(!baseuri.isEmpty(),
+                "Usage: geogig ls-repos <base URI> (e.g. geogig ls-repos postgresql://localhost:5432/geogig_db?user=...&password=...)");
+
+        URI baseURI = baseuri.get(0);
+        List<String> statements = new CreateDDL().setBaseURI(baseURI).call();
+        for (String st : statements) {
+            cli.getConsole().println(st);
+        }
+    }
+}

--- a/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/PGStorageUpgrade.java
+++ b/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/PGStorageUpgrade.java
@@ -1,0 +1,56 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.cli.storage;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.locationtech.geogig.cli.AbstractCommand;
+import org.locationtech.geogig.cli.CLICommand;
+import org.locationtech.geogig.cli.Console;
+import org.locationtech.geogig.cli.GeogigCLI;
+import org.locationtech.geogig.cli.annotation.RequiresRepository;
+import org.locationtech.geogig.repository.ProgressListener;
+import org.locationtech.geogig.repository.impl.GlobalContextBuilder;
+import org.locationtech.geogig.repository.impl.PluginsContextBuilder;
+import org.locationtech.geogig.storage.postgresql.commands.PGDatabaseUpgrade;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.Parameters;
+import com.google.common.base.Stopwatch;
+
+@RequiresRepository(false)
+@Parameters(commandNames = "postgres-upgrade", commandDescription = "Upgrade the schema of a geogig PostgreSQL databse to the latest version")
+public class PGStorageUpgrade extends AbstractCommand implements CLICommand {
+
+    @Parameter(description = "<base URI> The URI without a repository name. (e.g. geogig postgres-upgrade postgresql://localhost:5432/geogig_db?user=...&password=...)", arity = 1)
+    private List<URI> baseuri = new ArrayList<>();
+
+    protected @Override void runInternal(GeogigCLI cli) throws IOException {
+        checkParameter(!baseuri.isEmpty(),
+                "Usage: geogig postgres-upgrade <base URI> (e.g. geogig postgres-upgrade postgresql://localhost:5432/geogig_db?user=...&password=...)");
+
+        URI baseURI = baseuri.get(0);
+        new PGDatabaseUpgrade().setBaseURI(baseURI).setProgressListener(cli.getProgressListener())
+                .call();
+    }
+
+    public static void main(String... args) {
+        Stopwatch sw = Stopwatch.createStarted();
+        GlobalContextBuilder.builder(new PluginsContextBuilder());
+        URI base = URI.create("postgresql://localhost:5432/test?user=postgres&password=geo123");
+        ProgressListener listener = new GeogigCLI(new Console()).getProgressListener();
+        new PGDatabaseUpgrade().setBaseURI(base).setProgressListener(listener).call();
+        System.err.println("done in " + sw.stop());
+    }
+
+}

--- a/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/StorageCommandsModule.java
+++ b/src/cli/app/src/main/java/org/locationtech/geogig/cli/storage/StorageCommandsModule.java
@@ -1,0 +1,24 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.cli.storage;
+
+import org.locationtech.geogig.cli.CLIModule;
+
+import com.google.inject.AbstractModule;
+
+public class StorageCommandsModule extends AbstractModule implements CLIModule {
+
+    protected @Override void configure() {
+        bind(LsRepos.class);
+        bind(PGStorageUpgrade.class);
+        bind(PGCreateDDL.class);
+    }
+
+}

--- a/src/cli/app/src/main/resources/META-INF/services/org.locationtech.geogig.cli.CLIModule
+++ b/src/cli/app/src/main/resources/META-INF/services/org.locationtech.geogig.cli.CLIModule
@@ -1,0 +1,1 @@
+org.locationtech.geogig.cli.storage.StorageCommandsModule

--- a/src/cli/core/src/main/java/org/locationtech/geogig/cli/Console.java
+++ b/src/cli/core/src/main/java/org/locationtech/geogig/cli/Console.java
@@ -17,193 +17,200 @@ import java.io.PrintStream;
 import org.fusesource.jansi.WindowsAnsiOutputStream;
 
 /**
- * Represents the console (i.e. operating system terminal) from where the program is being executed,
- * allowing to read from the terminal's stdin and write to the terminal's stdout.
+ * Represents the console (i.e. operating system terminal) from where the
+ * program is being executed, allowing to read from the terminal's stdin and
+ * write to the terminal's stdout.
  * <p>
- * Additionally, a different pair of input and output streams can be provided explicitly to simulate
- * redirection, for example for unit tests.
+ * Additionally, a different pair of input and output streams can be provided
+ * explicitly to simulate redirection, for example for unit tests.
  *
  */
 public class Console {
 
-    private static final char CARRIAGE_RETURN = '\r';
+	private static final char CARRIAGE_RETURN = '\r';
+	private static final String CLEAR_FROM_CURSOR_TO_END_OF_LINE = "\u001b[0K";
+	private static final String CLEAR_FROM_CURSOR_TO_START_OF_LINE = "\u001b[1K";
+	private static final String CLEAR_LINE = "\u001b[2K";
 
-    private StringBuffer cursorBuffer;
+	private StringBuffer cursorBuffer;
 
-    @SuppressWarnings("unused")
-    private InputStream in;
+	@SuppressWarnings("unused")
+	private InputStream in;
 
-    private PrintStream out;
+	private PrintStream out;
 
-    private boolean ansiEnabled;
+	private boolean ansiEnabled;
 
-    private boolean ansiSupported;
+	private boolean ansiSupported;
 
-    private boolean forceAnsi;
+	private boolean forceAnsi;
 
-    /**
-     * Creates a console reader that reads from {@code sdtin} and writes to {@code sdout}.
-     */
-    public Console() {
-        this(System.in, System.out);
-    }
+	/**
+	 * Creates a console reader that reads from {@code sdtin} and writes to
+	 * {@code sdout}.
+	 */
+	public Console() {
+		this(System.in, System.out);
+	}
 
-    /**
-     * Creates a Console that reads from and writes to the provided streams.
-     * 
-     * @param in the console's input stream
-     * @param out the console's output stream
-     */
-    public Console(InputStream in, OutputStream out) {
-        this.in = in;
-        this.cursorBuffer = new StringBuffer();
-        this.ansiEnabled = true;
-        this.forceAnsi = false;
-        try {
-            this.ansiSupported = checkAnsiSupported(out, checkOS());
-        } catch (UnsatisfiedLinkError e) {
-            this.ansiSupported = false;
-        } catch (Throwable e) {
-            this.ansiSupported = false;
-        }
-        if (out instanceof PrintStream) {
-            this.out = (PrintStream) out;
-        } else {
-            boolean autoFlush = true;
-            this.out = new PrintStream(out, autoFlush);
-        }
-    }
+	/**
+	 * Creates a Console that reads from and writes to the provided streams.
+	 * 
+	 * @param in  the console's input stream
+	 * @param out the console's output stream
+	 */
+	public Console(InputStream in, OutputStream out) {
+		this.in = in;
+		this.cursorBuffer = new StringBuffer();
+		this.ansiEnabled = true;
+		this.forceAnsi = false;
+		try {
+			this.ansiSupported = checkAnsiSupported(out, checkOS());
+		} catch (UnsatisfiedLinkError e) {
+			this.ansiSupported = false;
+		} catch (Throwable e) {
+			this.ansiSupported = false;
+		}
+		if (out instanceof PrintStream) {
+			this.out = (PrintStream) out;
+		} else {
+			boolean autoFlush = true;
+			this.out = new PrintStream(out, autoFlush);
+		}
+	}
 
-    /**
-     * Returns whether writing ANSI escape sequences are supported by the console.
-     * <p>
-     * {@code true} will only be returned if the console's output is not redirected to a file or
-     * piped, this console's output stream is "stdout", and the JVM has been invoked from a terminal
-     * that supports ANSI codes. Setting ansi.enabled as a config option will cause this to return
-     * true.
-     * <p>
-     * If {@link #forceAnsi} is true, this returns true immediately. Otherwise if
-     * {@link #disableAnsi()} has been called, returns {@code false} immediately.
-     * 
-     * @return {@code true} if ANSI terminal color codes are supported by the console, {@code false}
-     *         otherwise.
-     */
-    public boolean isAnsiSupported() {
-        return forceAnsi || (ansiEnabled && ansiSupported);
-    }
+	/**
+	 * Returns whether writing ANSI escape sequences are supported by the console.
+	 * <p>
+	 * {@code true} will only be returned if the console's output is not redirected
+	 * to a file or piped, this console's output stream is "stdout", and the JVM has
+	 * been invoked from a terminal that supports ANSI codes. Setting ansi.enabled
+	 * as a config option will cause this to return true.
+	 * <p>
+	 * If {@link #forceAnsi} is true, this returns true immediately. Otherwise if
+	 * {@link #disableAnsi()} has been called, returns {@code false} immediately.
+	 * 
+	 * @return {@code true} if ANSI terminal color codes are supported by the
+	 *         console, {@code false} otherwise.
+	 */
+	public boolean isAnsiSupported() {
+		return forceAnsi || (ansiEnabled && ansiSupported);
+	}
 
-    public boolean checkAnsiSupported(OutputStream out, String osName) throws Throwable {
-        if (out != System.out) {
-            return false;
-        }
+	public boolean checkAnsiSupported(OutputStream out, String osName) throws Throwable {
+		if (out != System.out) {
+			return false;
+		}
 
-        if (osName.startsWith("windows") && osName.endsWith("10")) {
-            new WindowsAnsiOutputStream(out);
-        } else if (osName.startsWith("windows") && !osName.endsWith("10")) {
-            return false;
-        }
+		if (osName.startsWith("windows") && osName.endsWith("10")) {
+			new WindowsAnsiOutputStream(out);
+		} else if (osName.startsWith("windows") && !osName.endsWith("10")) {
+			return false;
+		}
 
-        if (System.console() == null) {
-            return false;
-        }
-        return true;
-    }
+		if (System.console() == null) {
+			return false;
+		}
+		return true;
+	}
 
-    public String checkOS() {
-        return System.getProperty("os.name").toLowerCase();
-    }
+	public String checkOS() {
+		return System.getProperty("os.name").toLowerCase();
+	}
 
-    /**
-     * Disables ANSI terminal color support, regardless of the auto-detection performed by
-     * {@link #isAnsiSupported()}.
-     * 
-     * @return {@code this}
-     */
-    public Console disableAnsi() {
-        this.ansiEnabled = false;
-        return this;
-    }
+	/**
+	 * Disables ANSI terminal color support, regardless of the auto-detection
+	 * performed by {@link #isAnsiSupported()}.
+	 * 
+	 * @return {@code this}
+	 */
+	public Console disableAnsi() {
+		this.ansiEnabled = false;
+		return this;
+	}
 
-    /**
-     * Enables ANSI terminal color support, regardless of the auto-detection performed by
-     * {@link #isAnsiSupported()}.
-     *
-     * @return {@code this}
-     */
-    public Console enableAnsi() {
-        this.ansiEnabled = true;
-        return this;
-    }
+	/**
+	 * Enables ANSI terminal color support, regardless of the auto-detection
+	 * performed by {@link #isAnsiSupported()}.
+	 *
+	 * @return {@code this}
+	 */
+	public Console enableAnsi() {
+		this.ansiEnabled = true;
+		return this;
+	}
 
-    /**
-     * Flag to force enable ANSI terminal color support, used for windows consoles
-     *
-     * @return {@code this}
-     */
-    public Console setForceAnsi(boolean force) {
-        this.forceAnsi = force;
-        return this;
-    }
+	/**
+	 * Flag to force enable ANSI terminal color support, used for windows consoles
+	 *
+	 * @return {@code this}
+	 */
+	public Console setForceAnsi(boolean force) {
+		this.forceAnsi = force;
+		return this;
+	}
 
-    /**
-     * Writes the given char sequence to the cursor buffer, does not flush the buffer.
-     * 
-     * @param s the character sequence to write to the console
-     * @throws IOException
-     */
-    public synchronized void print(CharSequence s) throws IOException {
-        cursorBuffer.append(s);
-    }
+	/**
+	 * Writes the given char sequence to the cursor buffer, does not flush the
+	 * buffer.
+	 * 
+	 * @param s the character sequence to write to the console
+	 * @throws IOException
+	 */
+	public synchronized void print(CharSequence s) throws IOException {
+		cursorBuffer.append(s);
+	}
 
-    /**
-     * Print a new line, flushing the cursor buffer.
-     * 
-     * @throws IOException
-     */
-    public void println() throws IOException {
-        println("");
-    }
+	/**
+	 * Print a new line, flushing the cursor buffer.
+	 * 
+	 * @throws IOException
+	 */
+	public void println() throws IOException {
+		println("");
+	}
 
-    /**
-     * Prints the {@code line} text to the console and starts a new line, flushing the cursor
-     * buffer.
-     * 
-     * @param line the text to write
-     * @throws IOException
-     */
-    public synchronized void println(CharSequence line) throws IOException {
-        print(line);
-        cursorBuffer.append("\n");
-        flush();
-    }
+	/**
+	 * Prints the {@code line} text to the console and starts a new line, flushing
+	 * the cursor buffer.
+	 * 
+	 * @param line the text to write
+	 * @throws IOException
+	 */
+	public synchronized void println(CharSequence line) throws IOException {
+		print(line);
+		cursorBuffer.append("\n");
+		flush();
+	}
 
-    /**
-     * Forces flushing the cursor buffer to the console's output stream.
-     * 
-     * @throws IOException
-     */
-    public synchronized void flush() throws IOException {
-        String s = cursorBuffer.toString();
-        out.print(s);
-        clearBuffer();
-    }
+	/**
+	 * Forces flushing the cursor buffer to the console's output stream.
+	 * 
+	 * @throws IOException
+	 */
+	public synchronized void flush() throws IOException {
+		String s = cursorBuffer.toString();
+		out.print(s);
+		clearBuffer();
+	}
 
-    /**
-     * Moves the console cursor to the beginning of the line (prints a carriage return {@code '\r'}
-     * character) and redraws the contents of the cursor buffer.
-     * 
-     * @throws IOException
-     */
-    public void redrawLine() throws IOException {
-        cursorBuffer.append(CARRIAGE_RETURN);
-        flush();
-    }
+	/**
+	 * Moves the console cursor to the beginning of the line (prints a carriage
+	 * return {@code '\r'} character) and redraws the contents of the cursor buffer.
+	 * 
+	 * @throws IOException
+	 */
+	public void redrawLine() throws IOException {
+		cursorBuffer.append(CARRIAGE_RETURN);
+		cursorBuffer.append(CLEAR_LINE);
+		flush();
+	}
 
-    /**
-     * Clear the console's un-flushed buffer
-     */
-    public void clearBuffer() {
-        this.cursorBuffer.setLength(0);
-    }
+	/**
+	 * Clear the console's un-flushed buffer
+	 */
+	public void clearBuffer() {
+		this.cursorBuffer.setLength(0);
+	}
 
 }

--- a/src/cli/core/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
+++ b/src/cli/core/src/main/java/org/locationtech/geogig/cli/GeogigCLI.java
@@ -851,8 +851,8 @@ public class GeogigCLI {
                             console.print(description);
                         }
                         String progressDescription = super.getProgressDescription();
-                        console.print(progressDescription);
                         console.redrawLine();
+                        console.print(progressDescription);
                         console.flush();
                     } catch (IOException e) {
                         throw new RuntimeException(e);

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/PGRepositoryResolver.java
@@ -127,10 +127,12 @@ public class PGRepositoryResolver extends RepositoryResolver {
         hints.set(Hints.REPOSITORY_URL, repositoryLocation.toString());
         Context context = GlobalContextBuilder.builder().build(hints);
         Repository repository = new GeoGIG(context).getRepository();
-        // Ensure the repository exists. If it's null, we might have a non-existing repo URI location
+        // Ensure the repository exists. If it's null, we might have a non-existing repo URI
+        // location
         if (repository == null) {
-            throw new RepositoryConnectionException("Could not connect to repository. Check that the URI is valid: " +
-            repositoryLocation);
+            throw new RepositoryConnectionException(
+                    "Could not connect to repository. Check that the URI is valid: "
+                            + repositoryLocation);
         }
         repository.open();
         return repository;

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
@@ -44,7 +44,7 @@ public class CreateDDL extends AbstractGeoGigOp<List<String>> {
 		if (environment != null) {
 			return environment;
 		}
-		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI);
+		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
 		Environment env = environmentBuilder.build();
 		return env;
 	}

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
@@ -26,38 +26,38 @@ import com.google.common.base.Preconditions;
  * @since 1.2.1
  */
 public class CreateDDL extends AbstractGeoGigOp<List<String>> {
-	private Environment environment;
+    private Environment environment;
 
-	private URI baseURI;
+    private URI baseURI;
 
-	protected @Override List<String> _call() {
-		Environment env = resolveEnvironment();
-		Version dbVersion = PGStorage.getServerVersion(env);
-		PGStorageTableManager tableManager = PGStorageTableManager.forVersion(dbVersion);
-		List<String> ddl = tableManager.createDDL(env);
-		return ddl;
-	}
+    protected @Override List<String> _call() {
+        Environment env = resolveEnvironment();
+        Version dbVersion = PGStorage.getServerVersion(env);
+        PGStorageTableManager tableManager = PGStorageTableManager.forVersion(dbVersion);
+        List<String> ddl = tableManager.createDDL(env);
+        return ddl;
+    }
 
-	private Environment resolveEnvironment() {
-		Preconditions.checkArgument(environment != null || baseURI != null,
-				"Environment or base URI argument not provided");
-		if (environment != null) {
-			return environment;
-		}
-		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
-		Environment env = environmentBuilder.build();
-		return env;
-	}
+    private Environment resolveEnvironment() {
+        Preconditions.checkArgument(environment != null || baseURI != null,
+                "Environment or base URI argument not provided");
+        if (environment != null) {
+            return environment;
+        }
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
+        Environment env = environmentBuilder.build();
+        return env;
+    }
 
-	public CreateDDL setEnvironment(Environment env) {
-		this.environment = env;
-		this.baseURI = null;
-		return this;
-	}
+    public CreateDDL setEnvironment(Environment env) {
+        this.environment = env;
+        this.baseURI = null;
+        return this;
+    }
 
-	public CreateDDL setBaseURI(URI baseURI) {
-		this.environment = null;
-		this.baseURI = baseURI;
-		return this;
-	}
+    public CreateDDL setBaseURI(URI baseURI) {
+        this.environment = null;
+        this.baseURI = baseURI;
+        return this;
+    }
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/CreateDDL.java
@@ -1,0 +1,63 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.postgresql.commands;
+
+import java.net.URI;
+import java.util.List;
+
+import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.storage.postgresql.config.Environment;
+import org.locationtech.geogig.storage.postgresql.config.EnvironmentBuilder;
+import org.locationtech.geogig.storage.postgresql.config.PGStorage;
+import org.locationtech.geogig.storage.postgresql.config.PGStorageTableManager;
+import org.locationtech.geogig.storage.postgresql.config.Version;
+
+import com.google.common.base.Preconditions;
+
+/**
+ * 
+ * @since 1.2.1
+ */
+public class CreateDDL extends AbstractGeoGigOp<List<String>> {
+	private Environment environment;
+
+	private URI baseURI;
+
+	protected @Override List<String> _call() {
+		Environment env = resolveEnvironment();
+		Version dbVersion = PGStorage.getServerVersion(env);
+		PGStorageTableManager tableManager = PGStorageTableManager.forVersion(dbVersion);
+		List<String> ddl = tableManager.createDDL(env);
+		return ddl;
+	}
+
+	private Environment resolveEnvironment() {
+		Preconditions.checkArgument(environment != null || baseURI != null,
+				"Environment or base URI argument not provided");
+		if (environment != null) {
+			return environment;
+		}
+		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI);
+		Environment env = environmentBuilder.build();
+		return env;
+	}
+
+	public CreateDDL setEnvironment(Environment env) {
+		this.environment = env;
+		this.baseURI = null;
+		return this;
+	}
+
+	public CreateDDL setBaseURI(URI baseURI) {
+		this.environment = null;
+		this.baseURI = baseURI;
+		return this;
+	}
+}

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/PGDatabaseUpgrade.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/PGDatabaseUpgrade.java
@@ -1,0 +1,127 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.postgresql.commands;
+
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.sql.DataSource;
+
+import org.locationtech.geogig.repository.AbstractGeoGigOp;
+import org.locationtech.geogig.storage.postgresql.config.Environment;
+import org.locationtech.geogig.storage.postgresql.config.EnvironmentBuilder;
+import org.locationtech.geogig.storage.postgresql.config.PGStorage;
+import org.locationtech.geogig.storage.postgresql.config.PGStorageTableManager;
+import org.locationtech.geogig.storage.postgresql.config.TableNames;
+import org.locationtech.geogig.storage.postgresql.config.Version;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+
+/**
+ * Given a geogig database, performs any necessary database schema upgrade
+ */
+public class PGDatabaseUpgrade extends AbstractGeoGigOp<Void> {
+
+	private Environment environment;
+
+	private URI baseURI;
+
+	protected @Override Void _call() {
+		Environment env = resolveEnvironment();
+		Version serverVersion = PGStorage.getServerVersion(env);
+		PGStorageTableManager tableManager = PGStorageTableManager.forVersion(serverVersion);
+		TableNames tables = env.getTables();
+		DataSource dataSource = PGStorage.newDataSource(env);
+
+		// DDL to tell the user to run if we don't have priviledges to
+		List<String> DDL = new ArrayList<>();
+		try (Connection cx = dataSource.getConnection()) {
+			final int currentSchemaVersion = tableManager.getSchemaVersion(cx, tables);
+			final boolean createMetadataTable = currentSchemaVersion == 0;
+			if (createMetadataTable) {
+				tableManager.createMetadata(DDL, tables);
+			}
+			final SchemaUpgrade0To1 upgrade = new SchemaUpgrade0To1(env);
+			final boolean runUpgrade = upgrade.shouldRun(cx);
+			if (runUpgrade) {
+				DDL.addAll(upgrade.createDDL());
+			}
+
+			if (DDL.isEmpty()) {
+				getProgressListener().setDescription(
+						"Database schema is up to date, checking for non DDL related upgrade actions...");
+			} else {
+				getProgressListener().setDescription("Running DDL script:");
+				String script = "-- SCRIPT START --\n" + Joiner.on('\n').join(DDL) + "\n-- SCRIPT END --\n";
+				getProgressListener().setDescription(script);
+
+				cx.setAutoCommit(false);
+				if (runScript(cx, DDL, tableManager)) {
+					cx.commit();
+					cx.setAutoCommit(true);
+				} else {
+					cx.rollback();
+					return null;
+				}
+			}
+			if (runUpgrade) {
+				upgrade.run(cx, tableManager, getProgressListener());
+				getProgressListener().setDescription("Finished upgrading the geogig database to the latest version.");
+			} else {
+				getProgressListener().setDescription("Nothing to upgrade. Database schema is up to date");
+			}
+		} catch (SQLException e) {
+			throw new IllegalStateException(e);
+		}
+		return null;
+	}
+
+	private boolean runScript(Connection cx, List<String> ddl, PGStorageTableManager tableManager) {
+		if (ddl.isEmpty()) {
+			return true;
+		}
+		try {
+			tableManager.runScript(cx, ddl);
+			return true;
+		} catch (SQLException e) {
+			getProgressListener().setDescription("Error running DDL script: " + e.getMessage()
+					+ "\n Please run the script above manually and re-run this command.");
+		}
+		return false;
+	}
+
+	private Environment resolveEnvironment() {
+		Preconditions.checkArgument(environment != null || baseURI != null,
+				"Environment or base URI argument not provided");
+		if (environment != null) {
+			return environment;
+		}
+		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
+		Environment env = environmentBuilder.build();
+		return env;
+	}
+
+	public PGDatabaseUpgrade setEnvironment(Environment env) {
+		this.environment = env;
+		this.baseURI = null;
+		return this;
+	}
+
+	public PGDatabaseUpgrade setBaseURI(URI baseURI) {
+		this.environment = null;
+		this.baseURI = baseURI;
+		return this;
+	}
+
+}

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/PGDatabaseUpgrade.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/PGDatabaseUpgrade.java
@@ -33,95 +33,98 @@ import com.google.common.base.Preconditions;
  */
 public class PGDatabaseUpgrade extends AbstractGeoGigOp<Void> {
 
-	private Environment environment;
+    private Environment environment;
 
-	private URI baseURI;
+    private URI baseURI;
 
-	protected @Override Void _call() {
-		Environment env = resolveEnvironment();
-		Version serverVersion = PGStorage.getServerVersion(env);
-		PGStorageTableManager tableManager = PGStorageTableManager.forVersion(serverVersion);
-		TableNames tables = env.getTables();
-		DataSource dataSource = PGStorage.newDataSource(env);
+    protected @Override Void _call() {
+        Environment env = resolveEnvironment();
+        Version serverVersion = PGStorage.getServerVersion(env);
+        PGStorageTableManager tableManager = PGStorageTableManager.forVersion(serverVersion);
+        TableNames tables = env.getTables();
+        DataSource dataSource = PGStorage.newDataSource(env);
 
-		// DDL to tell the user to run if we don't have priviledges to
-		List<String> DDL = new ArrayList<>();
-		try (Connection cx = dataSource.getConnection()) {
-			final int currentSchemaVersion = tableManager.getSchemaVersion(cx, tables);
-			final boolean createMetadataTable = currentSchemaVersion == 0;
-			if (createMetadataTable) {
-				tableManager.createMetadata(DDL, tables);
-			}
-			final SchemaUpgrade0To1 upgrade = new SchemaUpgrade0To1(env);
-			final boolean runUpgrade = upgrade.shouldRun(cx);
-			if (runUpgrade) {
-				DDL.addAll(upgrade.createDDL());
-			}
+        // DDL to tell the user to run if we don't have priviledges to
+        List<String> DDL = new ArrayList<>();
+        try (Connection cx = dataSource.getConnection()) {
+            final int currentSchemaVersion = tableManager.getSchemaVersion(cx, tables);
+            final boolean createMetadataTable = currentSchemaVersion == 0;
+            if (createMetadataTable) {
+                tableManager.createMetadata(DDL, tables);
+            }
+            final SchemaUpgrade0To1 upgrade = new SchemaUpgrade0To1(env);
+            final boolean runUpgrade = upgrade.shouldRun(cx);
+            if (runUpgrade) {
+                DDL.addAll(upgrade.createDDL());
+            }
 
-			if (DDL.isEmpty()) {
-				getProgressListener().setDescription(
-						"Database schema is up to date, checking for non DDL related upgrade actions...");
-			} else {
-				getProgressListener().setDescription("Running DDL script:");
-				String script = "-- SCRIPT START --\n" + Joiner.on('\n').join(DDL) + "\n-- SCRIPT END --\n";
-				getProgressListener().setDescription(script);
+            if (DDL.isEmpty()) {
+                getProgressListener().setDescription(
+                        "Database schema is up to date, checking for non DDL related upgrade actions...");
+            } else {
+                getProgressListener().setDescription("Running DDL script:");
+                String script = "-- SCRIPT START --\n" + Joiner.on('\n').join(DDL)
+                        + "\n-- SCRIPT END --\n";
+                getProgressListener().setDescription(script);
 
-				cx.setAutoCommit(false);
-				if (runScript(cx, DDL, tableManager)) {
-					cx.commit();
-					cx.setAutoCommit(true);
-				} else {
-					cx.rollback();
-					return null;
-				}
-			}
-			if (runUpgrade) {
-				upgrade.run(cx, tableManager, getProgressListener());
-				getProgressListener().setDescription("Finished upgrading the geogig database to the latest version.");
-			} else {
-				getProgressListener().setDescription("Nothing to upgrade. Database schema is up to date");
-			}
-		} catch (SQLException e) {
-			throw new IllegalStateException(e);
-		}
-		return null;
-	}
+                cx.setAutoCommit(false);
+                if (runScript(cx, DDL, tableManager)) {
+                    cx.commit();
+                    cx.setAutoCommit(true);
+                } else {
+                    cx.rollback();
+                    return null;
+                }
+            }
+            if (runUpgrade) {
+                upgrade.run(cx, tableManager, getProgressListener());
+                getProgressListener().setDescription(
+                        "Finished upgrading the geogig database to the latest version.");
+            } else {
+                getProgressListener()
+                        .setDescription("Nothing to upgrade. Database schema is up to date");
+            }
+        } catch (SQLException e) {
+            throw new IllegalStateException(e);
+        }
+        return null;
+    }
 
-	private boolean runScript(Connection cx, List<String> ddl, PGStorageTableManager tableManager) {
-		if (ddl.isEmpty()) {
-			return true;
-		}
-		try {
-			tableManager.runScript(cx, ddl);
-			return true;
-		} catch (SQLException e) {
-			getProgressListener().setDescription("Error running DDL script: " + e.getMessage()
-					+ "\n Please run the script above manually and re-run this command.");
-		}
-		return false;
-	}
+    private boolean runScript(Connection cx, List<String> ddl, PGStorageTableManager tableManager) {
+        if (ddl.isEmpty()) {
+            return true;
+        }
+        try {
+            tableManager.runScript(cx, ddl);
+            return true;
+        } catch (SQLException e) {
+            getProgressListener().setDescription("Error running DDL script: " + e.getMessage()
+                    + "\n Please run the script above manually and re-run this command.");
+        }
+        return false;
+    }
 
-	private Environment resolveEnvironment() {
-		Preconditions.checkArgument(environment != null || baseURI != null,
-				"Environment or base URI argument not provided");
-		if (environment != null) {
-			return environment;
-		}
-		EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
-		Environment env = environmentBuilder.build();
-		return env;
-	}
+    private Environment resolveEnvironment() {
+        Preconditions.checkArgument(environment != null || baseURI != null,
+                "Environment or base URI argument not provided");
+        if (environment != null) {
+            return environment;
+        }
+        EnvironmentBuilder environmentBuilder = new EnvironmentBuilder(baseURI, true);
+        Environment env = environmentBuilder.build();
+        return env;
+    }
 
-	public PGDatabaseUpgrade setEnvironment(Environment env) {
-		this.environment = env;
-		this.baseURI = null;
-		return this;
-	}
+    public PGDatabaseUpgrade setEnvironment(Environment env) {
+        this.environment = env;
+        this.baseURI = null;
+        return this;
+    }
 
-	public PGDatabaseUpgrade setBaseURI(URI baseURI) {
-		this.environment = null;
-		this.baseURI = baseURI;
-		return this;
-	}
+    public PGDatabaseUpgrade setBaseURI(URI baseURI) {
+        this.environment = null;
+        this.baseURI = baseURI;
+        return this;
+    }
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/SchemaUpgrade0To1.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/SchemaUpgrade0To1.java
@@ -1,0 +1,95 @@
+/* Copyright (c) 2018 Boundless and others.
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Distribution License v1.0
+ * which accompanies this distribution, and is available at
+ * https://www.eclipse.org/org/documents/edl-v10.html
+ *
+ * Contributors:
+ * Gabriel Roldan (Boundless) - initial implementation
+ */
+package org.locationtech.geogig.storage.postgresql.commands;
+
+import java.net.URI;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.locationtech.geogig.plumbing.RebuildGraphOp;
+import org.locationtech.geogig.repository.ProgressListener;
+import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.repository.RepositoryConnectionException;
+import org.locationtech.geogig.repository.RepositoryResolver;
+import org.locationtech.geogig.storage.postgresql.config.Environment;
+import org.locationtech.geogig.storage.postgresql.config.PGStorage;
+import org.locationtech.geogig.storage.postgresql.config.PGStorageTableManager;
+
+/**
+ * Upgrades a geogig database from the schema used for Postgres 9/geogig <
+ * 1.2.1, to Postgres 10/geogig 1.2.1
+ * <p>
+ * For instance, adds the columns {@code srcindex} and {@code dstindex} to the
+ * {@code geogig_graph_edge} table, and runs {@link RebuildGraphOp} on each
+ * repository in the database.
+ * 
+ * @since 1.2.1
+ */
+public class SchemaUpgrade0To1 {
+
+	private Environment env;
+
+	public SchemaUpgrade0To1(Environment env) {
+		this.env = env;
+	}
+
+	public boolean shouldRun(Connection cx) throws SQLException {
+		DatabaseMetaData md = cx.getMetaData();
+
+		final String tableName = env.getTables().graphEdges();
+		final String schema = PGStorageTableManager.schema(tableName);
+		final String table = PGStorageTableManager.stripSchema(tableName);
+
+		try (ResultSet columns = md.getColumns(null, schema, table, "dstindex")) {
+			return !columns.next();
+		}
+	}
+
+	public List<String> createDDL() {
+		List<String> ddl = new ArrayList<>();
+		String edges = env.getTables().graphEdges();
+		ddl.add(String.format("TRUNCATE %s;", edges));
+		ddl.add(String.format("ALTER TABLE %s ADD COLUMN dstindex INT NOT NULL;", edges));
+		return ddl;
+	}
+
+	public void run(Connection cx, PGStorageTableManager tableManager, ProgressListener progress) throws SQLException {
+		List<String> repoNames = PGStorage.listRepos(cx, env.getTables());
+		progress.setDescription(String.format("Upgrading commit graph for all %,d repositories...", repoNames.size()));
+		Collections.sort(repoNames);
+		int i = 0;
+		for (String repoName : repoNames) {
+			progress.setProgressIndicator(p -> String.format("Upgrading graph for repository %s", repoName));
+			URI repoURI = env.connectionConfig.toURI(repoName);
+			Repository repo;
+			try {
+				repo = RepositoryResolver.load(repoURI);
+			} catch (RepositoryConnectionException e) {
+				throw new IllegalStateException("Unable to connnect to repo " + repoName, e);
+			}
+			try {
+				progress.setProgress(++i);
+				rebuildGraph(repo);
+			} finally {
+				repo.close();
+			}
+		}
+		progress.setProgressIndicator(ProgressListener.DEFAULT_PROGRES_INDICATOR);
+	}
+
+	private void rebuildGraph(Repository repo) {
+		repo.command(RebuildGraphOp.class).call();
+	}
+}

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/SchemaUpgrade0To1.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/commands/SchemaUpgrade0To1.java
@@ -28,68 +28,71 @@ import org.locationtech.geogig.storage.postgresql.config.PGStorage;
 import org.locationtech.geogig.storage.postgresql.config.PGStorageTableManager;
 
 /**
- * Upgrades a geogig database from the schema used for Postgres 9/geogig <
- * 1.2.1, to Postgres 10/geogig 1.2.1
+ * Upgrades a geogig database from the schema used for Postgres 9/geogig < 1.2.1, to Postgres
+ * 10/geogig 1.2.1
  * <p>
  * For instance, adds the columns {@code srcindex} and {@code dstindex} to the
- * {@code geogig_graph_edge} table, and runs {@link RebuildGraphOp} on each
- * repository in the database.
+ * {@code geogig_graph_edge} table, and runs {@link RebuildGraphOp} on each repository in the
+ * database.
  * 
  * @since 1.2.1
  */
 public class SchemaUpgrade0To1 {
 
-	private Environment env;
+    private Environment env;
 
-	public SchemaUpgrade0To1(Environment env) {
-		this.env = env;
-	}
+    public SchemaUpgrade0To1(Environment env) {
+        this.env = env;
+    }
 
-	public boolean shouldRun(Connection cx) throws SQLException {
-		DatabaseMetaData md = cx.getMetaData();
+    public boolean shouldRun(Connection cx) throws SQLException {
+        DatabaseMetaData md = cx.getMetaData();
 
-		final String tableName = env.getTables().graphEdges();
-		final String schema = PGStorageTableManager.schema(tableName);
-		final String table = PGStorageTableManager.stripSchema(tableName);
+        final String tableName = env.getTables().graphEdges();
+        final String schema = PGStorageTableManager.schema(tableName);
+        final String table = PGStorageTableManager.stripSchema(tableName);
 
-		try (ResultSet columns = md.getColumns(null, schema, table, "dstindex")) {
-			return !columns.next();
-		}
-	}
+        try (ResultSet columns = md.getColumns(null, schema, table, "dstindex")) {
+            return !columns.next();
+        }
+    }
 
-	public List<String> createDDL() {
-		List<String> ddl = new ArrayList<>();
-		String edges = env.getTables().graphEdges();
-		ddl.add(String.format("TRUNCATE %s;", edges));
-		ddl.add(String.format("ALTER TABLE %s ADD COLUMN dstindex INT NOT NULL;", edges));
-		return ddl;
-	}
+    public List<String> createDDL() {
+        List<String> ddl = new ArrayList<>();
+        String edges = env.getTables().graphEdges();
+        ddl.add(String.format("TRUNCATE %s;", edges));
+        ddl.add(String.format("ALTER TABLE %s ADD COLUMN dstindex INT NOT NULL;", edges));
+        return ddl;
+    }
 
-	public void run(Connection cx, PGStorageTableManager tableManager, ProgressListener progress) throws SQLException {
-		List<String> repoNames = PGStorage.listRepos(cx, env.getTables());
-		progress.setDescription(String.format("Upgrading commit graph for all %,d repositories...", repoNames.size()));
-		Collections.sort(repoNames);
-		int i = 0;
-		for (String repoName : repoNames) {
-			progress.setProgressIndicator(p -> String.format("Upgrading graph for repository %s", repoName));
-			URI repoURI = env.connectionConfig.toURI(repoName);
-			Repository repo;
-			try {
-				repo = RepositoryResolver.load(repoURI);
-			} catch (RepositoryConnectionException e) {
-				throw new IllegalStateException("Unable to connnect to repo " + repoName, e);
-			}
-			try {
-				progress.setProgress(++i);
-				rebuildGraph(repo);
-			} finally {
-				repo.close();
-			}
-		}
-		progress.setProgressIndicator(ProgressListener.DEFAULT_PROGRES_INDICATOR);
-	}
+    public void run(Connection cx, PGStorageTableManager tableManager, ProgressListener progress)
+            throws SQLException {
+        List<String> repoNames = PGStorage.listRepos(cx, env.getTables());
+        progress.setDescription(String.format("Upgrading commit graph for all %,d repositories...",
+                repoNames.size()));
+        Collections.sort(repoNames);
+        int i = 0;
+        for (String repoName : repoNames) {
+            progress.setProgressIndicator(
+                    p -> String.format("Upgrading graph for repository %s", repoName));
+            URI repoURI = env.connectionConfig.toURI(repoName);
+            Repository repo;
+            try {
+                repo = RepositoryResolver.load(repoURI);
+            } catch (RepositoryConnectionException e) {
+                throw new IllegalStateException("Unable to connnect to repo " + repoName, e);
+            }
+            try {
+                progress.setProgress(++i);
+                rebuildGraph(repo);
+            } finally {
+                repo.close();
+            }
+        }
+        progress.setProgressIndicator(ProgressListener.DEFAULT_PROGRES_INDICATOR);
+    }
 
-	private void rebuildGraph(Repository repo) {
-		repo.command(RebuildGraphOp.class).call();
-	}
+    private void rebuildGraph(Repository repo) {
+        repo.command(RebuildGraphOp.class).call();
+    }
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/DataSourceManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/DataSourceManager.java
@@ -193,7 +193,7 @@ public class DataSourceManager extends ConnectionManager<ConnectionConfig.Key, D
             LOG.debug("Connected to " + jdbcUrl + " as " + connInfo.user);
         } catch (SQLException e) {
             LOG.error("Unable to connect to " + jdbcUrl + " as " + connInfo.user, e);
-            throw new RuntimeException(e);
+            throw new IllegalArgumentException(e);
         }
         return ds;
     }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/DataSourceManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/DataSourceManager.java
@@ -174,8 +174,8 @@ public class DataSourceManager extends ConnectionManager<ConnectionConfig.Key, D
             String[] maxConnections = Environment.KEY_MAX_CONNECTIONS.split("\\.");
             String section = maxConnections[0];
             String key = maxConnections[1];
-            try (PreparedStatement ps = c.prepareStatement(
-                    log(sql, LOG, Environment.GLOBAL_KEY, section, key))) {
+            try (PreparedStatement ps = c
+                    .prepareStatement(log(sql, LOG, Environment.GLOBAL_KEY, section, key))) {
                 ps.setInt(1, Environment.GLOBAL_KEY);
                 ps.setString(2, section);
                 ps.setString(3, key);

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Environment.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Environment.java
@@ -208,4 +208,9 @@ public class Environment implements Cloneable {
         return clone;
     }
 
+	public URI toURI() {
+		// TODO Auto-generated method stub
+		return null;
+	}
+
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Environment.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Environment.java
@@ -208,9 +208,9 @@ public class Environment implements Cloneable {
         return clone;
     }
 
-	public URI toURI() {
-		// TODO Auto-generated method stub
-		return null;
-	}
+    public URI toURI() {
+        // TODO Auto-generated method stub
+        return null;
+    }
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilder.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilder.java
@@ -32,208 +32,213 @@ import com.google.common.base.Strings;
 
 public class EnvironmentBuilder {
 
-    private Environment config;
+	private Environment config;
 
-    public EnvironmentBuilder(Hints hints) throws URISyntaxException {
-        Optional<Serializable> repoUrl = hints.get(Hints.REPOSITORY_URL);
-        checkArgument(repoUrl.isPresent(), "%s was not given", Hints.REPOSITORY_URL);
-        URI url = new URI(String.valueOf(repoUrl.get()));
-        init(url);
-    }
+	public EnvironmentBuilder(Hints hints) throws URISyntaxException {
+		Optional<Serializable> repoUrl = hints.get(Hints.REPOSITORY_URL);
+		checkArgument(repoUrl.isPresent(), "%s was not given", Hints.REPOSITORY_URL);
+		URI url = new URI(String.valueOf(repoUrl.get()));
+		init(url, false);
+	}
 
-    public EnvironmentBuilder(Properties props) {
-        init(props);
-    }
+	public EnvironmentBuilder(Properties props) {
+		init(props);
+	}
 
-    /**
-     * @param repoUrl repository URL of the form
-     *        {@code postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>}
-     */
-    public EnvironmentBuilder(URI repoUrl) {
-        init(repoUrl);
-    }
+	/**
+	 * @param repoUrl repository URL of the form
+	 *                {@code postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>}
+	 */
+	public EnvironmentBuilder(URI repoUrl) {
+		this(repoUrl, false);
+	}
 
-    private static Map<String, String> extractShortKeys(String rawQuery) {
-        Map<String, String> shortKeys = new HashMap<>();
-        for (String pair : Splitter.on('&').split(rawQuery)) {
-            List<String> p = Splitter.on('=').splitToList(pair);
-            // it should be the raw query, URL decode the values
-            try {
-                shortKeys.put(p.get(0), URLDecoder.decode(p.get(1), StandardCharsets.UTF_8.name()));
-            } catch (UnsupportedEncodingException uee) {
-                throw new RuntimeException(uee);
-            }
-        }
-        return shortKeys;
-    }
+	public EnvironmentBuilder(URI repoUrl, boolean isBaseURI) {
+		init(repoUrl, isBaseURI);
+	}
 
-    private void init(URI repoUrl) {
-        // postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>
-        Preconditions.checkNotNull(repoUrl);
-        final String uriScheme = repoUrl.getScheme();
-        Preconditions.checkArgument("postgresql".equals(uriScheme),
-                "Wrong URL protocol. Expected postgresql, got ", uriScheme);
-        final String host = repoUrl.getHost();
-        final String portNumber;
-        final String dbName;
-        final String schema;
-        final String repsitoryId;
-        final String user, password;
-        final String tablePrefix;// mainly used for unit testing
+	private static Map<String, String> extractShortKeys(String rawQuery) {
+		Map<String, String> shortKeys = new HashMap<>();
+		for (String pair : Splitter.on('&').split(rawQuery)) {
+			List<String> p = Splitter.on('=').splitToList(pair);
+			// it should be the raw query, URL decode the values
+			try {
+				shortKeys.put(p.get(0), URLDecoder.decode(p.get(1), StandardCharsets.UTF_8.name()));
+			} catch (UnsupportedEncodingException uee) {
+				throw new RuntimeException(uee);
+			}
+		}
+		return shortKeys;
+	}
 
-        int port = repoUrl.getPort();
-        if (-1 == port) {
-            port = Environment.DEFAULT_DB_PORT;
-        }
-        portNumber = String.valueOf(port);
+	private void init(URI repoUrl, boolean forceBaseURL) {
+		// postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>
+		Preconditions.checkNotNull(repoUrl);
+		final String uriScheme = repoUrl.getScheme();
+		Preconditions.checkArgument("postgresql".equals(uriScheme), "Wrong URL protocol. Expected postgresql, got ",
+				uriScheme);
+		final String host = repoUrl.getHost();
+		final String portNumber;
+		final String dbName;
+		final String schema;
+		final String repositoryId;
+		final String user, password;
+		final String tablePrefix;// mainly used for unit testing
 
-        List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(repoUrl.getPath());
-        Preconditions.checkArgument(path.size() >= 2 && path.size() <= 3,
-                "Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>",
-                repoUrl);
+		int port = repoUrl.getPort();
+		if (-1 == port) {
+			port = Environment.DEFAULT_DB_PORT;
+		}
+		portNumber = String.valueOf(port);
 
-        dbName = path.get(0);
-        schema = path.size() == 2 ? "public" : path.get(1);
-        repsitoryId = path.size() == 2 ? path.get(1) : path.get(2);
-        Map<String, String> shortKeys = extractShortKeys(repoUrl.getRawQuery());
-        user = shortKeys.get("user");
-        password = shortKeys.get("password");
-        tablePrefix = shortKeys.get("tablePrefix");
+		List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(repoUrl.getPath());
+		Preconditions.checkArgument(forceBaseURL || (path.size() >= 1 && path.size() <= 3),
+				"Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>][/<repoid>]?user=<username>&password=<pwd>",
+				repoUrl);
 
-        Properties props = new Properties();
-        props.setProperty(Environment.KEY_DB_SERVER, host);
-        props.setProperty(Environment.KEY_DB_PORT, portNumber);
-        props.setProperty(Environment.KEY_DB_NAME, dbName);
-        props.setProperty(Environment.KEY_DB_SCHEMA, schema);
-        props.setProperty(Environment.KEY_REPOSITORY_ID, repsitoryId);
-        props.setProperty(Environment.KEY_DB_USERNAME, user);
-        props.setProperty(Environment.KEY_DB_PASSWORD, password);
-        if (!Strings.isNullOrEmpty(tablePrefix)) {
-            props.setProperty("tablePrefix", tablePrefix);
-        }
-        init(props);
-    }
+		dbName = path.get(0);
+		if (forceBaseURL) {
+			schema = path.size() == 1 ? "public" : path.get(1);
+		} else {
+			schema = path.size() == 2 ? "public" : path.get(1);
+		}
+		repositoryId = forceBaseURL ? null : (path.size() == 2 ? path.get(1) : path.get(2));
+		Map<String, String> shortKeys = extractShortKeys(repoUrl.getRawQuery());
+		user = shortKeys.get("user");
+		password = shortKeys.get("password");
+		tablePrefix = shortKeys.get("tablePrefix");
 
-    private void init(Properties props) {
-        String server = props.getProperty(Environment.KEY_DB_SERVER);
-        String portNumber = props.getProperty(Environment.KEY_DB_PORT);
-        String databaseName = props.getProperty(Environment.KEY_DB_NAME);
-        String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
-        String userName = props.getProperty(Environment.KEY_DB_USERNAME);
-        String password = props.getProperty(Environment.KEY_DB_PASSWORD);
-        @Nullable
-        String repoId = props.getProperty(Environment.KEY_REPOSITORY_ID);
+		Properties props = new Properties();
+		props.setProperty(Environment.KEY_DB_SERVER, host);
+		props.setProperty(Environment.KEY_DB_PORT, portNumber);
+		props.setProperty(Environment.KEY_DB_NAME, dbName);
+		props.setProperty(Environment.KEY_DB_SCHEMA, schema);
+		if (repositoryId != null) {
+			props.setProperty(Environment.KEY_REPOSITORY_ID, repositoryId);
+		}
+		props.setProperty(Environment.KEY_DB_USERNAME, user);
+		props.setProperty(Environment.KEY_DB_PASSWORD, password);
+		if (!Strings.isNullOrEmpty(tablePrefix)) {
+			props.setProperty("tablePrefix", tablePrefix);
+		}
+		init(props);
+	}
 
-        checkArgument(server != null, "postgres.server config is not set");
-        checkArgument(databaseName != null, "postgres.database config is not set");
-        checkArgument(schema != null, "postgres.schema config is not set");
-        checkArgument(userName != null, "postgres.user config is not set");
-        checkArgument(password != null, "postgres.password config is not set");
-        // checkArgument(repoId != null, "repository.id config is not set");
+	private void init(Properties props) {
+		String server = props.getProperty(Environment.KEY_DB_SERVER);
+		String portNumber = props.getProperty(Environment.KEY_DB_PORT);
+		String databaseName = props.getProperty(Environment.KEY_DB_NAME);
+		String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
+		String userName = props.getProperty(Environment.KEY_DB_USERNAME);
+		String password = props.getProperty(Environment.KEY_DB_PASSWORD);
+		@Nullable
+		String repoId = props.getProperty(Environment.KEY_REPOSITORY_ID);
 
-        int port;
-        try {
-            port = portNumber == null ? 4532 : Integer.parseInt(portNumber);
-        } catch (NumberFormatException nfe) {
-            throw new IllegalArgumentException(
-                    String.format("'%s' can't be parsed as integer for argument %s", portNumber,
-                            Environment.KEY_DB_PORT),
-                    nfe);
-        }
-        String tablePrefix = props.getProperty("tablePrefix");// only used by tests
-        if (tablePrefix != null && tablePrefix.trim().isEmpty()) {
-            tablePrefix = null;
-        }
-        this.config = new Environment(server, port, databaseName, schema, userName, password,
-                repoId, tablePrefix);
-    }
+		checkArgument(server != null, "postgres.server config is not set");
+		checkArgument(databaseName != null, "postgres.database config is not set");
+		checkArgument(schema != null, "postgres.schema config is not set");
+		checkArgument(userName != null, "postgres.user config is not set");
+		checkArgument(password != null, "postgres.password config is not set");
+		// checkArgument(repoId != null, "repository.id config is not set");
 
-    public Environment build() {
-        return config;
-    }
+		int port;
+		try {
+			port = portNumber == null ? 4532 : Integer.parseInt(portNumber);
+		} catch (NumberFormatException nfe) {
+			throw new IllegalArgumentException(String.format("'%s' can't be parsed as integer for argument %s",
+					portNumber, Environment.KEY_DB_PORT), nfe);
+		}
+		String tablePrefix = props.getProperty("tablePrefix");// only used by tests
+		if (tablePrefix != null && tablePrefix.trim().isEmpty()) {
+			tablePrefix = null;
+		}
+		this.config = new Environment(server, port, databaseName, schema, userName, password, repoId, tablePrefix);
+	}
 
-    public static ConnectionConfig parse(URI uri) {
-        EnvironmentBuilder eb = new EnvironmentBuilder(uri);
-        Environment e = eb.build();
-        return e.connectionConfig;
-    }
+	public Environment build() {
+		return config;
+	}
 
-    /**
-     * Extracts all of the {@link Environment} properties from a given root URI.
-     * 
-     * @param rootRepoURI the root URI
-     * @return the extracted properties
-     */
-    public static Properties getRootURIProperties(final URI rootRepoURI) {
-        // postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>
-        Preconditions.checkNotNull(rootRepoURI);
-        final String uriScheme = rootRepoURI.getScheme();
-        Preconditions.checkArgument("postgresql".equals(uriScheme),
-                "Wrong URL protocol. Expected postgresql, got ", uriScheme);
-        final String host = rootRepoURI.getHost();
-        final String portNumber;
-        final String dbName;
-        final String schema;
-        final String user, password;
-        final String tablePrefix;// mainly used for unit testing
+	public static ConnectionConfig parse(URI uri) {
+		EnvironmentBuilder eb = new EnvironmentBuilder(uri);
+		Environment e = eb.build();
+		return e.connectionConfig;
+	}
 
-        int port = rootRepoURI.getPort();
-        if (-1 == port) {
-            port = 5432;
-        }
-        portNumber = String.valueOf(port);
+	/**
+	 * Extracts all of the {@link Environment} properties from a given root URI.
+	 * 
+	 * @param rootRepoURI the root URI
+	 * @return the extracted properties
+	 */
+	public static Properties getRootURIProperties(final URI rootRepoURI) {
+		// postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>
+		Preconditions.checkNotNull(rootRepoURI);
+		final String uriScheme = rootRepoURI.getScheme();
+		Preconditions.checkArgument("postgresql".equals(uriScheme), "Wrong URL protocol. Expected postgresql, got ",
+				uriScheme);
+		final String host = rootRepoURI.getHost();
+		final String portNumber;
+		final String dbName;
+		final String schema;
+		final String user, password;
+		final String tablePrefix;// mainly used for unit testing
 
-        List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(rootRepoURI.getPath());
-        Preconditions.checkArgument(path.size() >= 1 && path.size() <= 2,
-                "Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>",
-                rootRepoURI);
+		int port = rootRepoURI.getPort();
+		if (-1 == port) {
+			port = 5432;
+		}
+		portNumber = String.valueOf(port);
 
-        dbName = path.get(0);
-        schema = path.size() == 1 ? "public" : path.get(1);
-        Map<String, String> shortKeys = extractShortKeys(rootRepoURI.getRawQuery());
-        user = shortKeys.get("user");
-        password = shortKeys.get("password");
-        tablePrefix = shortKeys.get("tablePrefix");
+		List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(rootRepoURI.getPath());
+		Preconditions.checkArgument(path.size() >= 1 && path.size() <= 2,
+				"Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>",
+				rootRepoURI);
 
-        Properties props = new Properties();
-        props.setProperty(Environment.KEY_DB_SERVER, host);
-        props.setProperty(Environment.KEY_DB_PORT, portNumber);
-        props.setProperty(Environment.KEY_DB_NAME, dbName);
-        props.setProperty(Environment.KEY_DB_SCHEMA, schema);
-        props.setProperty(Environment.KEY_DB_USERNAME, user);
-        props.setProperty(Environment.KEY_DB_PASSWORD, password);
-        if (!Strings.isNullOrEmpty(tablePrefix)) {
-            props.setProperty("tablePrefix", tablePrefix);
-        }
+		dbName = path.get(0);
+		schema = path.size() == 1 ? "public" : path.get(1);
+		Map<String, String> shortKeys = extractShortKeys(rootRepoURI.getRawQuery());
+		user = shortKeys.get("user");
+		password = shortKeys.get("password");
+		tablePrefix = shortKeys.get("tablePrefix");
 
-        return props;
-    }
+		Properties props = new Properties();
+		props.setProperty(Environment.KEY_DB_SERVER, host);
+		props.setProperty(Environment.KEY_DB_PORT, portNumber);
+		props.setProperty(Environment.KEY_DB_NAME, dbName);
+		props.setProperty(Environment.KEY_DB_SCHEMA, schema);
+		props.setProperty(Environment.KEY_DB_USERNAME, user);
+		props.setProperty(Environment.KEY_DB_PASSWORD, password);
+		if (!Strings.isNullOrEmpty(tablePrefix)) {
+			props.setProperty("tablePrefix", tablePrefix);
+		}
 
-    /**
-     * Constructs a repository URI from the given {@link Environment} properties and repository
-     * name.
-     * 
-     * @param props the properties
-     * @param repoName the repository name
-     * @return the resolved URI of the repository
-     */
-    public static URI buildRepoURI(Properties props, String repoName) {
-        String server = props.getProperty(Environment.KEY_DB_SERVER);
-        String portNumber = props.getProperty(Environment.KEY_DB_PORT,
-                String.valueOf(Environment.DEFAULT_DB_PORT));
-        String databaseName = props.getProperty(Environment.KEY_DB_NAME);
-        String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
-        String userName = props.getProperty(Environment.KEY_DB_USERNAME);
-        String password = props.getProperty(Environment.KEY_DB_PASSWORD);
-        String tablePrefix = props.getProperty("tablePrefix");
+		return props;
+	}
 
-        final int port = Integer.parseInt(portNumber);
+	/**
+	 * Constructs a repository URI from the given {@link Environment} properties and
+	 * repository name.
+	 * 
+	 * @param props    the properties
+	 * @param repoName the repository name
+	 * @return the resolved URI of the repository
+	 */
+	public static URI buildRepoURI(Properties props, String repoName) {
+		String server = props.getProperty(Environment.KEY_DB_SERVER);
+		String portNumber = props.getProperty(Environment.KEY_DB_PORT, String.valueOf(Environment.DEFAULT_DB_PORT));
+		String databaseName = props.getProperty(Environment.KEY_DB_NAME);
+		String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
+		String userName = props.getProperty(Environment.KEY_DB_USERNAME);
+		String password = props.getProperty(Environment.KEY_DB_PASSWORD);
+		String tablePrefix = props.getProperty("tablePrefix");
 
-        Environment env = new Environment(server, port, databaseName, schema, userName, password,
-                repoName, tablePrefix);
-        final URI repoURI = env.connectionConfig.toURI(repoName);
+		final int port = Integer.parseInt(portNumber);
 
-        return repoURI;
-    }
+		Environment env = new Environment(server, port, databaseName, schema, userName, password, repoName,
+				tablePrefix);
+		final URI repoURI = env.connectionConfig.toURI(repoName);
 
+		return repoURI;
+	}
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilder.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilder.java
@@ -32,213 +32,217 @@ import com.google.common.base.Strings;
 
 public class EnvironmentBuilder {
 
-	private Environment config;
+    private Environment config;
 
-	public EnvironmentBuilder(Hints hints) throws URISyntaxException {
-		Optional<Serializable> repoUrl = hints.get(Hints.REPOSITORY_URL);
-		checkArgument(repoUrl.isPresent(), "%s was not given", Hints.REPOSITORY_URL);
-		URI url = new URI(String.valueOf(repoUrl.get()));
-		init(url, false);
-	}
+    public EnvironmentBuilder(Hints hints) throws URISyntaxException {
+        Optional<Serializable> repoUrl = hints.get(Hints.REPOSITORY_URL);
+        checkArgument(repoUrl.isPresent(), "%s was not given", Hints.REPOSITORY_URL);
+        URI url = new URI(String.valueOf(repoUrl.get()));
+        init(url, false);
+    }
 
-	public EnvironmentBuilder(Properties props) {
-		init(props);
-	}
+    public EnvironmentBuilder(Properties props) {
+        init(props);
+    }
 
-	/**
-	 * @param repoUrl repository URL of the form
-	 *                {@code postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>}
-	 */
-	public EnvironmentBuilder(URI repoUrl) {
-		this(repoUrl, false);
-	}
+    /**
+     * @param repoUrl repository URL of the form
+     *        {@code postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>}
+     */
+    public EnvironmentBuilder(URI repoUrl) {
+        this(repoUrl, false);
+    }
 
-	public EnvironmentBuilder(URI repoUrl, boolean isBaseURI) {
-		init(repoUrl, isBaseURI);
-	}
+    public EnvironmentBuilder(URI repoUrl, boolean isBaseURI) {
+        init(repoUrl, isBaseURI);
+    }
 
-	private static Map<String, String> extractShortKeys(String rawQuery) {
-		Map<String, String> shortKeys = new HashMap<>();
-		for (String pair : Splitter.on('&').split(rawQuery)) {
-			List<String> p = Splitter.on('=').splitToList(pair);
-			// it should be the raw query, URL decode the values
-			try {
-				shortKeys.put(p.get(0), URLDecoder.decode(p.get(1), StandardCharsets.UTF_8.name()));
-			} catch (UnsupportedEncodingException uee) {
-				throw new RuntimeException(uee);
-			}
-		}
-		return shortKeys;
-	}
+    private static Map<String, String> extractShortKeys(String rawQuery) {
+        Map<String, String> shortKeys = new HashMap<>();
+        for (String pair : Splitter.on('&').split(rawQuery)) {
+            List<String> p = Splitter.on('=').splitToList(pair);
+            // it should be the raw query, URL decode the values
+            try {
+                shortKeys.put(p.get(0), URLDecoder.decode(p.get(1), StandardCharsets.UTF_8.name()));
+            } catch (UnsupportedEncodingException uee) {
+                throw new RuntimeException(uee);
+            }
+        }
+        return shortKeys;
+    }
 
-	private void init(URI repoUrl, boolean forceBaseURL) {
-		// postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>
-		Preconditions.checkNotNull(repoUrl);
-		final String uriScheme = repoUrl.getScheme();
-		Preconditions.checkArgument("postgresql".equals(uriScheme), "Wrong URL protocol. Expected postgresql, got ",
-				uriScheme);
-		final String host = repoUrl.getHost();
-		final String portNumber;
-		final String dbName;
-		final String schema;
-		final String repositoryId;
-		final String user, password;
-		final String tablePrefix;// mainly used for unit testing
+    private void init(URI repoUrl, boolean forceBaseURL) {
+        // postgresql://<server>[:<port>]/database[/<schema>]/<repoid>?user=<username>&password=<pwd>
+        Preconditions.checkNotNull(repoUrl);
+        final String uriScheme = repoUrl.getScheme();
+        Preconditions.checkArgument("postgresql".equals(uriScheme),
+                "Wrong URL protocol. Expected postgresql, got ", uriScheme);
+        final String host = repoUrl.getHost();
+        final String portNumber;
+        final String dbName;
+        final String schema;
+        final String repositoryId;
+        final String user, password;
+        final String tablePrefix;// mainly used for unit testing
 
-		int port = repoUrl.getPort();
-		if (-1 == port) {
-			port = Environment.DEFAULT_DB_PORT;
-		}
-		portNumber = String.valueOf(port);
+        int port = repoUrl.getPort();
+        if (-1 == port) {
+            port = Environment.DEFAULT_DB_PORT;
+        }
+        portNumber = String.valueOf(port);
 
-		List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(repoUrl.getPath());
-		Preconditions.checkArgument(forceBaseURL || (path.size() >= 1 && path.size() <= 3),
-				"Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>][/<repoid>]?user=<username>&password=<pwd>",
-				repoUrl);
+        List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(repoUrl.getPath());
+        Preconditions.checkArgument(forceBaseURL || (path.size() >= 1 && path.size() <= 3),
+                "Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>][/<repoid>]?user=<username>&password=<pwd>",
+                repoUrl);
 
-		dbName = path.get(0);
-		if (forceBaseURL) {
-			schema = path.size() == 1 ? "public" : path.get(1);
-		} else {
-			schema = path.size() == 2 ? "public" : path.get(1);
-		}
-		repositoryId = forceBaseURL ? null : (path.size() == 2 ? path.get(1) : path.get(2));
-		Map<String, String> shortKeys = extractShortKeys(repoUrl.getRawQuery());
-		user = shortKeys.get("user");
-		password = shortKeys.get("password");
-		tablePrefix = shortKeys.get("tablePrefix");
+        dbName = path.get(0);
+        if (forceBaseURL) {
+            schema = path.size() == 1 ? "public" : path.get(1);
+        } else {
+            schema = path.size() == 2 ? "public" : path.get(1);
+        }
+        repositoryId = forceBaseURL ? null : (path.size() == 2 ? path.get(1) : path.get(2));
+        Map<String, String> shortKeys = extractShortKeys(repoUrl.getRawQuery());
+        user = shortKeys.get("user");
+        password = shortKeys.get("password");
+        tablePrefix = shortKeys.get("tablePrefix");
 
-		Properties props = new Properties();
-		props.setProperty(Environment.KEY_DB_SERVER, host);
-		props.setProperty(Environment.KEY_DB_PORT, portNumber);
-		props.setProperty(Environment.KEY_DB_NAME, dbName);
-		props.setProperty(Environment.KEY_DB_SCHEMA, schema);
-		if (repositoryId != null) {
-			props.setProperty(Environment.KEY_REPOSITORY_ID, repositoryId);
-		}
-		props.setProperty(Environment.KEY_DB_USERNAME, user);
-		props.setProperty(Environment.KEY_DB_PASSWORD, password);
-		if (!Strings.isNullOrEmpty(tablePrefix)) {
-			props.setProperty("tablePrefix", tablePrefix);
-		}
-		init(props);
-	}
+        Properties props = new Properties();
+        props.setProperty(Environment.KEY_DB_SERVER, host);
+        props.setProperty(Environment.KEY_DB_PORT, portNumber);
+        props.setProperty(Environment.KEY_DB_NAME, dbName);
+        props.setProperty(Environment.KEY_DB_SCHEMA, schema);
+        if (repositoryId != null) {
+            props.setProperty(Environment.KEY_REPOSITORY_ID, repositoryId);
+        }
+        props.setProperty(Environment.KEY_DB_USERNAME, user);
+        props.setProperty(Environment.KEY_DB_PASSWORD, password);
+        if (!Strings.isNullOrEmpty(tablePrefix)) {
+            props.setProperty("tablePrefix", tablePrefix);
+        }
+        init(props);
+    }
 
-	private void init(Properties props) {
-		String server = props.getProperty(Environment.KEY_DB_SERVER);
-		String portNumber = props.getProperty(Environment.KEY_DB_PORT);
-		String databaseName = props.getProperty(Environment.KEY_DB_NAME);
-		String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
-		String userName = props.getProperty(Environment.KEY_DB_USERNAME);
-		String password = props.getProperty(Environment.KEY_DB_PASSWORD);
-		@Nullable
-		String repoId = props.getProperty(Environment.KEY_REPOSITORY_ID);
+    private void init(Properties props) {
+        String server = props.getProperty(Environment.KEY_DB_SERVER);
+        String portNumber = props.getProperty(Environment.KEY_DB_PORT);
+        String databaseName = props.getProperty(Environment.KEY_DB_NAME);
+        String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
+        String userName = props.getProperty(Environment.KEY_DB_USERNAME);
+        String password = props.getProperty(Environment.KEY_DB_PASSWORD);
+        @Nullable
+        String repoId = props.getProperty(Environment.KEY_REPOSITORY_ID);
 
-		checkArgument(server != null, "postgres.server config is not set");
-		checkArgument(databaseName != null, "postgres.database config is not set");
-		checkArgument(schema != null, "postgres.schema config is not set");
-		checkArgument(userName != null, "postgres.user config is not set");
-		checkArgument(password != null, "postgres.password config is not set");
-		// checkArgument(repoId != null, "repository.id config is not set");
+        checkArgument(server != null, "postgres.server config is not set");
+        checkArgument(databaseName != null, "postgres.database config is not set");
+        checkArgument(schema != null, "postgres.schema config is not set");
+        checkArgument(userName != null, "postgres.user config is not set");
+        checkArgument(password != null, "postgres.password config is not set");
+        // checkArgument(repoId != null, "repository.id config is not set");
 
-		int port;
-		try {
-			port = portNumber == null ? 4532 : Integer.parseInt(portNumber);
-		} catch (NumberFormatException nfe) {
-			throw new IllegalArgumentException(String.format("'%s' can't be parsed as integer for argument %s",
-					portNumber, Environment.KEY_DB_PORT), nfe);
-		}
-		String tablePrefix = props.getProperty("tablePrefix");// only used by tests
-		if (tablePrefix != null && tablePrefix.trim().isEmpty()) {
-			tablePrefix = null;
-		}
-		this.config = new Environment(server, port, databaseName, schema, userName, password, repoId, tablePrefix);
-	}
+        int port;
+        try {
+            port = portNumber == null ? 4532 : Integer.parseInt(portNumber);
+        } catch (NumberFormatException nfe) {
+            throw new IllegalArgumentException(
+                    String.format("'%s' can't be parsed as integer for argument %s", portNumber,
+                            Environment.KEY_DB_PORT),
+                    nfe);
+        }
+        String tablePrefix = props.getProperty("tablePrefix");// only used by tests
+        if (tablePrefix != null && tablePrefix.trim().isEmpty()) {
+            tablePrefix = null;
+        }
+        this.config = new Environment(server, port, databaseName, schema, userName, password,
+                repoId, tablePrefix);
+    }
 
-	public Environment build() {
-		return config;
-	}
+    public Environment build() {
+        return config;
+    }
 
-	public static ConnectionConfig parse(URI uri) {
-		EnvironmentBuilder eb = new EnvironmentBuilder(uri);
-		Environment e = eb.build();
-		return e.connectionConfig;
-	}
+    public static ConnectionConfig parse(URI uri) {
+        EnvironmentBuilder eb = new EnvironmentBuilder(uri);
+        Environment e = eb.build();
+        return e.connectionConfig;
+    }
 
-	/**
-	 * Extracts all of the {@link Environment} properties from a given root URI.
-	 * 
-	 * @param rootRepoURI the root URI
-	 * @return the extracted properties
-	 */
-	public static Properties getRootURIProperties(final URI rootRepoURI) {
-		// postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>
-		Preconditions.checkNotNull(rootRepoURI);
-		final String uriScheme = rootRepoURI.getScheme();
-		Preconditions.checkArgument("postgresql".equals(uriScheme), "Wrong URL protocol. Expected postgresql, got ",
-				uriScheme);
-		final String host = rootRepoURI.getHost();
-		final String portNumber;
-		final String dbName;
-		final String schema;
-		final String user, password;
-		final String tablePrefix;// mainly used for unit testing
+    /**
+     * Extracts all of the {@link Environment} properties from a given root URI.
+     * 
+     * @param rootRepoURI the root URI
+     * @return the extracted properties
+     */
+    public static Properties getRootURIProperties(final URI rootRepoURI) {
+        // postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>
+        Preconditions.checkNotNull(rootRepoURI);
+        final String uriScheme = rootRepoURI.getScheme();
+        Preconditions.checkArgument("postgresql".equals(uriScheme),
+                "Wrong URL protocol. Expected postgresql, got ", uriScheme);
+        final String host = rootRepoURI.getHost();
+        final String portNumber;
+        final String dbName;
+        final String schema;
+        final String user, password;
+        final String tablePrefix;// mainly used for unit testing
 
-		int port = rootRepoURI.getPort();
-		if (-1 == port) {
-			port = 5432;
-		}
-		portNumber = String.valueOf(port);
+        int port = rootRepoURI.getPort();
+        if (-1 == port) {
+            port = 5432;
+        }
+        portNumber = String.valueOf(port);
 
-		List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(rootRepoURI.getPath());
-		Preconditions.checkArgument(path.size() >= 1 && path.size() <= 2,
-				"Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>",
-				rootRepoURI);
+        List<String> path = Splitter.on('/').omitEmptyStrings().splitToList(rootRepoURI.getPath());
+        Preconditions.checkArgument(path.size() >= 1 && path.size() <= 2,
+                "Path in URI must be like postgresql://<server>[:<port>]/database[/<schema>]?user=<username>&password=<pwd>",
+                rootRepoURI);
 
-		dbName = path.get(0);
-		schema = path.size() == 1 ? "public" : path.get(1);
-		Map<String, String> shortKeys = extractShortKeys(rootRepoURI.getRawQuery());
-		user = shortKeys.get("user");
-		password = shortKeys.get("password");
-		tablePrefix = shortKeys.get("tablePrefix");
+        dbName = path.get(0);
+        schema = path.size() == 1 ? "public" : path.get(1);
+        Map<String, String> shortKeys = extractShortKeys(rootRepoURI.getRawQuery());
+        user = shortKeys.get("user");
+        password = shortKeys.get("password");
+        tablePrefix = shortKeys.get("tablePrefix");
 
-		Properties props = new Properties();
-		props.setProperty(Environment.KEY_DB_SERVER, host);
-		props.setProperty(Environment.KEY_DB_PORT, portNumber);
-		props.setProperty(Environment.KEY_DB_NAME, dbName);
-		props.setProperty(Environment.KEY_DB_SCHEMA, schema);
-		props.setProperty(Environment.KEY_DB_USERNAME, user);
-		props.setProperty(Environment.KEY_DB_PASSWORD, password);
-		if (!Strings.isNullOrEmpty(tablePrefix)) {
-			props.setProperty("tablePrefix", tablePrefix);
-		}
+        Properties props = new Properties();
+        props.setProperty(Environment.KEY_DB_SERVER, host);
+        props.setProperty(Environment.KEY_DB_PORT, portNumber);
+        props.setProperty(Environment.KEY_DB_NAME, dbName);
+        props.setProperty(Environment.KEY_DB_SCHEMA, schema);
+        props.setProperty(Environment.KEY_DB_USERNAME, user);
+        props.setProperty(Environment.KEY_DB_PASSWORD, password);
+        if (!Strings.isNullOrEmpty(tablePrefix)) {
+            props.setProperty("tablePrefix", tablePrefix);
+        }
 
-		return props;
-	}
+        return props;
+    }
 
-	/**
-	 * Constructs a repository URI from the given {@link Environment} properties and
-	 * repository name.
-	 * 
-	 * @param props    the properties
-	 * @param repoName the repository name
-	 * @return the resolved URI of the repository
-	 */
-	public static URI buildRepoURI(Properties props, String repoName) {
-		String server = props.getProperty(Environment.KEY_DB_SERVER);
-		String portNumber = props.getProperty(Environment.KEY_DB_PORT, String.valueOf(Environment.DEFAULT_DB_PORT));
-		String databaseName = props.getProperty(Environment.KEY_DB_NAME);
-		String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
-		String userName = props.getProperty(Environment.KEY_DB_USERNAME);
-		String password = props.getProperty(Environment.KEY_DB_PASSWORD);
-		String tablePrefix = props.getProperty("tablePrefix");
+    /**
+     * Constructs a repository URI from the given {@link Environment} properties and repository
+     * name.
+     * 
+     * @param props the properties
+     * @param repoName the repository name
+     * @return the resolved URI of the repository
+     */
+    public static URI buildRepoURI(Properties props, String repoName) {
+        String server = props.getProperty(Environment.KEY_DB_SERVER);
+        String portNumber = props.getProperty(Environment.KEY_DB_PORT,
+                String.valueOf(Environment.DEFAULT_DB_PORT));
+        String databaseName = props.getProperty(Environment.KEY_DB_NAME);
+        String schema = props.getProperty(Environment.KEY_DB_SCHEMA);
+        String userName = props.getProperty(Environment.KEY_DB_USERNAME);
+        String password = props.getProperty(Environment.KEY_DB_PASSWORD);
+        String tablePrefix = props.getProperty("tablePrefix");
 
-		final int port = Integer.parseInt(portNumber);
+        final int port = Integer.parseInt(portNumber);
 
-		Environment env = new Environment(server, port, databaseName, schema, userName, password, repoName,
-				tablePrefix);
-		final URI repoURI = env.connectionConfig.toURI(repoName);
+        Environment env = new Environment(server, port, databaseName, schema, userName, password,
+                repoName, tablePrefix);
+        final URI repoURI = env.connectionConfig.toURI(repoName);
 
-		return repoURI;
-	}
+        return repoURI;
+    }
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorage.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorage.java
@@ -39,315 +39,318 @@ import com.google.common.base.Preconditions;
  */
 public class PGStorage {
 
-	static final Logger LOG = LoggerFactory.getLogger(PGStorage.class);
+    static final Logger LOG = LoggerFactory.getLogger(PGStorage.class);
 
-	private static final DataSourceManager DATASOURCE_POOL = new DataSourceManager();
+    private static final DataSourceManager DATASOURCE_POOL = new DataSourceManager();
 
-	/**
-	 * Logs a (prepared) sql statement.
-	 * 
-	 * @param sql  Base sql to log.
-	 * @param log  The logger object.
-	 * @param args Optional arguments to the statement.
-	 * 
-	 * @return The original statement.
-	 */
-	public static String log(String sql, Logger log, Object... args) {
-		if (log.isDebugEnabled()) {
-			StringBuilder sb = new StringBuilder(sql);
-			if (args.length > 0) {
-				sb.append(";");
-				for (int i = 0; i < args.length; i++) {
-					sb.append(i).append("=").append(args[i]).append(", ");
-				}
-				sb.setLength(sb.length() - 2);
-			}
-			String statement = sb.toString();
-			if (!statement.trim().endsWith(";")) {
-				statement += ";";
-			}
-			log.debug(statement);
-		}
-		return sql;
-	}
+    /**
+     * Logs a (prepared) sql statement.
+     * 
+     * @param sql Base sql to log.
+     * @param log The logger object.
+     * @param args Optional arguments to the statement.
+     * 
+     * @return The original statement.
+     */
+    public static String log(String sql, Logger log, Object... args) {
+        if (log.isDebugEnabled()) {
+            StringBuilder sb = new StringBuilder(sql);
+            if (args.length > 0) {
+                sb.append(";");
+                for (int i = 0; i < args.length; i++) {
+                    sb.append(i).append("=").append(args[i]).append(", ");
+                }
+                sb.setLength(sb.length() - 2);
+            }
+            String statement = sb.toString();
+            if (!statement.trim().endsWith(";")) {
+                statement += ";";
+            }
+            log.debug(statement);
+        }
+        return sql;
+    }
 
-	public synchronized static DataSource newDataSource(Environment config) {
-		return newDataSource(config.connectionConfig);
-	}
+    public synchronized static DataSource newDataSource(Environment config) {
+        return newDataSource(config.connectionConfig);
+    }
 
-	public synchronized static DataSource newDataSource(ConnectionConfig config) {
-		DataSource dataSource = DATASOURCE_POOL.acquire(config.getKey());
-		return dataSource;
-	}
+    public synchronized static DataSource newDataSource(ConnectionConfig config) {
+        DataSource dataSource = DATASOURCE_POOL.acquire(config.getKey());
+        return dataSource;
+    }
 
-	public static void closeDataSource(DataSource ds) {
-		if (ds != null) {
-			DATASOURCE_POOL.release(ds);
-		}
-	}
+    public static void closeDataSource(DataSource ds) {
+        if (ds != null) {
+            DATASOURCE_POOL.release(ds);
+        }
+    }
 
-	public static Connection newConnection(DataSource ds) {
-		try {
-			Connection connection = ds.getConnection();
-			return connection;
-		} catch (SQLTransientConnectionException e) {
-			throw new RepositoryBusyException("No available connections to the repository.", e);
-		} catch (SQLException e) {
-			throw new RuntimeException("Unable to obatain connection: " + e.getMessage(), e);
-		}
-	}
+    public static Connection newConnection(DataSource ds) {
+        try {
+            Connection connection = ds.getConnection();
+            return connection;
+        } catch (SQLTransientConnectionException e) {
+            throw new RepositoryBusyException("No available connections to the repository.", e);
+        } catch (SQLException e) {
+            throw new RuntimeException("Unable to obatain connection: " + e.getMessage(), e);
+        }
+    }
 
-	public static SQLException rollbackAndRethrow(Connection c, Exception e) throws SQLException {
-		c.rollback();
-		if (e instanceof SQLException) {
-			throw (SQLException) e;
-		}
-		throw new RuntimeException(e);
-	}
+    public static SQLException rollbackAndRethrow(Connection c, Exception e) throws SQLException {
+        c.rollback();
+        if (e instanceof SQLException) {
+            throw (SQLException) e;
+        }
+        throw new RuntimeException(e);
+    }
 
-	public static boolean repoExists(final Environment config) throws IllegalArgumentException {
-		checkNotNull(config);
-		checkArgument(config.getRepositoryName() != null, "no repository name provided");
+    public static boolean repoExists(final Environment config) throws IllegalArgumentException {
+        checkNotNull(config);
+        checkArgument(config.getRepositoryName() != null, "no repository name provided");
 
-		Optional<Integer> repoPK;
-		try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
-			if (config.isRepositorySet()) {
-				String configuredName = configdb.get("repo.name").orNull();
-				Preconditions.checkState(config.getRepositoryName().equals(configuredName));
-				return true;
-			} else {
-				repoPK = configdb.resolveRepositoryPK(config.getRepositoryName());
-				if (repoPK.isPresent()) {
-					if (config.isRepositorySet()) {
-						if (repoPK.get() != config.getRepositoryId()) {
-							String msg = format("The provided primary key for the repository '%s' "
-									+ "does not match the one in the database. Provided: %d, returned: %d. "
-									+ "Check the consistency of the repo.name config property for those repository ids");
-							throw new IllegalStateException(msg);
-						}
-					} else {
-						config.setRepositoryId(repoPK.get());
-					}
-				}
-				return repoPK.isPresent();
-			}
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		}
-	}
+        Optional<Integer> repoPK;
+        try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
+            if (config.isRepositorySet()) {
+                String configuredName = configdb.get("repo.name").orNull();
+                Preconditions.checkState(config.getRepositoryName().equals(configuredName));
+                return true;
+            } else {
+                repoPK = configdb.resolveRepositoryPK(config.getRepositoryName());
+                if (repoPK.isPresent()) {
+                    if (config.isRepositorySet()) {
+                        if (repoPK.get() != config.getRepositoryId()) {
+                            String msg = format("The provided primary key for the repository '%s' "
+                                    + "does not match the one in the database. Provided: %d, returned: %d. "
+                                    + "Check the consistency of the repo.name config property for those repository ids");
+                            throw new IllegalStateException(msg);
+                        }
+                    } else {
+                        config.setRepositoryId(repoPK.get());
+                    }
+                }
+                return repoPK.isPresent();
+            }
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        }
+    }
 
-	public static Version getServerVersion(final Environment env) {
-		DataSource ds = newDataSource(env);
-		try (Connection cx = newConnection(ds)) {
-			return getServerVersion(cx);
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		} finally {
-			closeDataSource(ds);
-		}
-	}
+    public static Version getServerVersion(final Environment env) {
+        DataSource ds = newDataSource(env);
+        try (Connection cx = newConnection(ds)) {
+            return getServerVersion(cx);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            closeDataSource(ds);
+        }
+    }
 
-	public static Version getServerVersion(Connection cx) throws SQLException {
-		try (Statement st = cx.createStatement()) {
-			try (ResultSet rs = st.executeQuery("SHOW server_version")) {
-				Preconditions.checkState(rs.next(), "Query 'SHOW server_version' did not produce a result");
-				final String v = rs.getString(1);
-				return getVersionFromQueryResult(v);
-			}
-		}
-	}
+    public static Version getServerVersion(Connection cx) throws SQLException {
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet rs = st.executeQuery("SHOW server_version")) {
+                Preconditions.checkState(rs.next(),
+                        "Query 'SHOW server_version' did not produce a result");
+                final String v = rs.getString(1);
+                return getVersionFromQueryResult(v);
+            }
+        }
+    }
 
-	static Version getVersionFromQueryResult(final String versionQueryResult) {
-		return Version.valueOf(versionQueryResult);
-	}
+    static Version getVersionFromQueryResult(final String versionQueryResult) {
+        return Version.valueOf(versionQueryResult);
+    }
 
-	/**
-	 * List the names of all repositories in the given {@link Environment}.
-	 * 
-	 * @param config the environment
-	 * @return the list of repository names
-	 */
-	public static List<String> listRepos(final Environment config) {
-		checkNotNull(config);
-		final DataSource dataSource = PGStorage.newDataSource(config);
-		TableNames tables = config.getTables();
+    /**
+     * List the names of all repositories in the given {@link Environment}.
+     * 
+     * @param config the environment
+     * @return the list of repository names
+     */
+    public static List<String> listRepos(final Environment config) {
+        checkNotNull(config);
+        final DataSource dataSource = PGStorage.newDataSource(config);
+        TableNames tables = config.getTables();
 
-		try (Connection cx = PGStorage.newConnection(dataSource)) {
-			return listRepos(cx, tables);
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		} finally {
-			PGStorage.closeDataSource(dataSource);
-		}
-	}
+        try (Connection cx = PGStorage.newConnection(dataSource)) {
+            return listRepos(cx, tables);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            PGStorage.closeDataSource(dataSource);
+        }
+    }
 
-	public static List<String> listRepos(final Connection cx, TableNames tables) throws SQLException {
-		checkNotNull(cx);
-		checkNotNull(tables);
-		List<String> repoNames = new ArrayList<>();
-		final String repoNamesView = tables.repositoryNamesView();
-		if (!tableExists(cx, repoNamesView)) {
-			return repoNames;
-		}
-		String sql = format("SELECT name FROM %s", repoNamesView);
-		try (Statement st = cx.createStatement()) {
-			try (ResultSet repos = st.executeQuery(sql)) {
-				while (repos.next()) {
-					repoNames.add(repos.getString(1));
-				}
-			}
-		}
-		return repoNames;
-	}
+    public static List<String> listRepos(final Connection cx, TableNames tables)
+            throws SQLException {
+        checkNotNull(cx);
+        checkNotNull(tables);
+        List<String> repoNames = new ArrayList<>();
+        final String repoNamesView = tables.repositoryNamesView();
+        if (!tableExists(cx, repoNamesView)) {
+            return repoNames;
+        }
+        String sql = format("SELECT name FROM %s", repoNamesView);
+        try (Statement st = cx.createStatement()) {
+            try (ResultSet repos = st.executeQuery(sql)) {
+                while (repos.next()) {
+                    repoNames.add(repos.getString(1));
+                }
+            }
+        }
+        return repoNames;
+    }
 
-	/**
-	 * Initializes all the tables as given by the names in
-	 * {@link Environment#getTables() config.getTables()} if need be, and creates an
-	 * entry in the {@link TableNames#repositories() repsitories} table with the
-	 * repository id given by {@link Environment#repositoryId config.repositoryId},
-	 * returning true if the entry was created and false if it already existed.
-	 * 
-	 * @return {@code true} if the repository was created, {@code false} if it
-	 *         already exists
-	 */
-	public static boolean createNewRepo(final Environment config) throws IllegalArgumentException {
-		checkNotNull(config);
-		checkArgument(config.getRepositoryName() != null, "no repository name provided");
-		createTables(config);
+    /**
+     * Initializes all the tables as given by the names in {@link Environment#getTables()
+     * config.getTables()} if need be, and creates an entry in the {@link TableNames#repositories()
+     * repsitories} table with the repository id given by {@link Environment#repositoryId
+     * config.repositoryId}, returning true if the entry was created and false if it already
+     * existed.
+     * 
+     * @return {@code true} if the repository was created, {@code false} if it already exists
+     */
+    public static boolean createNewRepo(final Environment config) throws IllegalArgumentException {
+        checkNotNull(config);
+        checkArgument(config.getRepositoryName() != null, "no repository name provided");
+        createTables(config);
 
-		final String argRepoName = config.getRepositoryName();
-		if (config.isRepositorySet()) {
-			return false;
-		}
+        final String argRepoName = config.getRepositoryName();
+        if (config.isRepositorySet()) {
+            return false;
+        }
 
-		final DataSource dataSource = PGStorage.newDataSource(config);
+        final DataSource dataSource = PGStorage.newDataSource(config);
 
-		try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
-			final Optional<Integer> repositoryPK = configdb.resolveRepositoryPK(argRepoName);
-			if (repositoryPK.isPresent()) {
-				return false;
-			}
-			final int pk;
-			try (Connection cx = PGStorage.newConnection(dataSource)) {
-				final String reposTable = config.getTables().repositories();
-				cx.setAutoCommit(false);
-				try {
-					String sql = format("INSERT INTO %s (created) VALUES (NOW())", reposTable);
-					try (Statement st = cx.createStatement()) {
-						int updCnt = st.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
-						checkState(updCnt == 1);
-						try (ResultSet generatedKeys = st.getGeneratedKeys()) {
-							checkState(generatedKeys.next());
-							pk = generatedKeys.getInt(1);
-						}
-						config.setRepositoryId(pk);
-					}
-					cx.commit();
-				} catch (SQLException | RuntimeException e) {
-					throw rollbackAndRethrow(cx, e);
-				} finally {
-					cx.setAutoCommit(true);
-				}
-			}
-			// set the config option outside the try-with-resources block to avoid acquiring
-			// 2
-			// connections
-			configdb.put("repo.name", argRepoName);
-			checkState(pk == configdb.resolveRepositoryPK(argRepoName).or(Environment.REPOSITORY_ID_UNSET));
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		} finally {
-			PGStorage.closeDataSource(dataSource);
-		}
+        try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
+            final Optional<Integer> repositoryPK = configdb.resolveRepositoryPK(argRepoName);
+            if (repositoryPK.isPresent()) {
+                return false;
+            }
+            final int pk;
+            try (Connection cx = PGStorage.newConnection(dataSource)) {
+                final String reposTable = config.getTables().repositories();
+                cx.setAutoCommit(false);
+                try {
+                    String sql = format("INSERT INTO %s (created) VALUES (NOW())", reposTable);
+                    try (Statement st = cx.createStatement()) {
+                        int updCnt = st.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
+                        checkState(updCnt == 1);
+                        try (ResultSet generatedKeys = st.getGeneratedKeys()) {
+                            checkState(generatedKeys.next());
+                            pk = generatedKeys.getInt(1);
+                        }
+                        config.setRepositoryId(pk);
+                    }
+                    cx.commit();
+                } catch (SQLException | RuntimeException e) {
+                    throw rollbackAndRethrow(cx, e);
+                } finally {
+                    cx.setAutoCommit(true);
+                }
+            }
+            // set the config option outside the try-with-resources block to avoid acquiring
+            // 2
+            // connections
+            configdb.put("repo.name", argRepoName);
+            checkState(pk == configdb.resolveRepositoryPK(argRepoName)
+                    .or(Environment.REPOSITORY_ID_UNSET));
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            PGStorage.closeDataSource(dataSource);
+        }
 
-		checkState(config.isRepositorySet());
-		return true;
-	}
+        checkState(config.isRepositorySet());
+        return true;
+    }
 
-	public static boolean tableExists(final DataSource dataSource, final String tableName) {
-		boolean tableExists = false;
-		if (dataSource != null) {
-			try (Connection cx = PGStorage.newConnection(dataSource)) {
-				tableExists = tableExists(cx, tableName);
-			} catch (SQLException e) {
-				throw new RuntimeException(e);
-			}
-		}
-		return tableExists;
-	}
+    public static boolean tableExists(final DataSource dataSource, final String tableName) {
+        boolean tableExists = false;
+        if (dataSource != null) {
+            try (Connection cx = PGStorage.newConnection(dataSource)) {
+                tableExists = tableExists(cx, tableName);
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        return tableExists;
+    }
 
-	public static boolean tableExists(final Connection cx, final String tableName) throws SQLException {
-		boolean tableExists = false;
-		DatabaseMetaData md = cx.getMetaData();
-		final String schema = PGStorageTableManager.schema(tableName);
-		final String table = PGStorageTableManager.stripSchema(tableName);
-		try (ResultSet tables = md.getTables(null, schema, table, null)) {
-			tableExists = tables.next();
-		}
-		return tableExists;
-	}
+    public static boolean tableExists(final Connection cx, final String tableName)
+            throws SQLException {
+        boolean tableExists = false;
+        DatabaseMetaData md = cx.getMetaData();
+        final String schema = PGStorageTableManager.schema(tableName);
+        final String table = PGStorageTableManager.stripSchema(tableName);
+        try (ResultSet tables = md.getTables(null, schema, table, null)) {
+            tableExists = tables.next();
+        }
+        return tableExists;
+    }
 
-	public static synchronized void createTables(final Environment config) {
-		final DataSource dataSource = PGStorage.newDataSource(config);
-		try (Connection cx = PGStorage.newConnection(dataSource)) {
-			final Version serverVersion = getServerVersion(cx);
-			final PGStorageTableManager tableManager;
-			tableManager = PGStorageTableManager.forVersion(serverVersion);
-			tableManager.createTables(cx, config);
-		} catch (SQLException e) {
-			throw new RuntimeException(e);
-		} finally {
-			PGStorage.closeDataSource(dataSource);
-		}
+    public static synchronized void createTables(final Environment config) {
+        final DataSource dataSource = PGStorage.newDataSource(config);
+        try (Connection cx = PGStorage.newConnection(dataSource)) {
+            final Version serverVersion = getServerVersion(cx);
+            final PGStorageTableManager tableManager;
+            tableManager = PGStorageTableManager.forVersion(serverVersion);
+            tableManager.createTables(cx, config);
+        } catch (SQLException e) {
+            throw new RuntimeException(e);
+        } finally {
+            PGStorage.closeDataSource(dataSource);
+        }
 
-	}
+    }
 
-	public static boolean deleteRepository(final Environment env) {
-		checkArgument(env.getRepositoryName() != null, "No repository name provided");
+    public static boolean deleteRepository(final Environment env) {
+        checkArgument(env.getRepositoryName() != null, "No repository name provided");
 
-		final String repositoryName = env.getRepositoryName();
-		final int repositoryPK;
+        final String repositoryName = env.getRepositoryName();
+        final int repositoryPK;
 
-		if (env.isRepositorySet()) {
-			repositoryPK = env.getRepositoryId();
-		} else {
-			try (PGConfigDatabase configdb = new PGConfigDatabase(env)) {
-				Optional<Integer> pk = configdb.resolveRepositoryPK(repositoryName);
-				if (pk.isPresent()) {
-					repositoryPK = pk.get();
-				} else {
-					return false;
-				}
-			} catch (SQLException e) {
-				throw new RuntimeException(e);
-			}
-		}
-		final TableNames tables = env.getTables();
-		final String reposTable = tables.repositories();
-		boolean deleted = false;
+        if (env.isRepositorySet()) {
+            repositoryPK = env.getRepositoryId();
+        } else {
+            try (PGConfigDatabase configdb = new PGConfigDatabase(env)) {
+                Optional<Integer> pk = configdb.resolveRepositoryPK(repositoryName);
+                if (pk.isPresent()) {
+                    repositoryPK = pk.get();
+                } else {
+                    return false;
+                }
+            } catch (SQLException e) {
+                throw new RuntimeException(e);
+            }
+        }
+        final TableNames tables = env.getTables();
+        final String reposTable = tables.repositories();
+        boolean deleted = false;
 
-		final String sql = String.format("DELETE FROM %s WHERE repository = ?", reposTable);
-		final DataSource ds = PGStorage.newDataSource(env);
+        final String sql = String.format("DELETE FROM %s WHERE repository = ?", reposTable);
+        final DataSource ds = PGStorage.newDataSource(env);
 
-		try (Connection cx = PGStorage.newConnection(ds)) {
-			cx.setAutoCommit(false);
-			try (PreparedStatement st = cx.prepareStatement(log(sql, LOG, repositoryName))) {
-				st.setInt(1, repositoryPK);
-				int rowCount = st.executeUpdate();
-				deleted = rowCount > 0;
-				cx.commit();
-			} catch (SQLException e) {
-				cx.rollback();
-				throw e;
-			} finally {
-				cx.setAutoCommit(true);
-			}
-		} catch (Exception e) {
-			throw new RuntimeException(e);
-		} finally {
-			PGStorage.closeDataSource(ds);
-		}
+        try (Connection cx = PGStorage.newConnection(ds)) {
+            cx.setAutoCommit(false);
+            try (PreparedStatement st = cx.prepareStatement(log(sql, LOG, repositoryName))) {
+                st.setInt(1, repositoryPK);
+                int rowCount = st.executeUpdate();
+                deleted = rowCount > 0;
+                cx.commit();
+            } catch (SQLException e) {
+                cx.rollback();
+                throw e;
+            } finally {
+                cx.setAutoCommit(true);
+            }
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        } finally {
+            PGStorage.closeDataSource(ds);
+        }
 
-		return Boolean.valueOf(deleted);
-	}
+        return Boolean.valueOf(deleted);
+    }
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorage.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorage.java
@@ -21,6 +21,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.SQLTransientConnectionException;
 import java.sql.Statement;
+import java.util.ArrayList;
 import java.util.List;
 
 import javax.sql.DataSource;
@@ -32,336 +33,321 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Splitter;
-import com.google.common.collect.Lists;
 
 /**
  * Utility class for PostgreSQL storage.
  */
 public class PGStorage {
 
-    static final Logger LOG = LoggerFactory.getLogger(PGStorage.class);
+	static final Logger LOG = LoggerFactory.getLogger(PGStorage.class);
 
-    private static final DataSourceManager DATASOURCE_POOL = new DataSourceManager();
+	private static final DataSourceManager DATASOURCE_POOL = new DataSourceManager();
 
-    /**
-     * Logs a (prepared) sql statement.
-     * 
-     * @param sql Base sql to log.
-     * @param log The logger object.
-     * @param args Optional arguments to the statement.
-     * 
-     * @return The original statement.
-     */
-    public static String log(String sql, Logger log, Object... args) {
-        if (log.isDebugEnabled()) {
-            StringBuilder sb = new StringBuilder(sql);
-            if (args.length > 0) {
-                sb.append(";");
-                for (int i = 0; i < args.length; i++) {
-                    sb.append(i).append("=").append(args[i]).append(", ");
-                }
-                sb.setLength(sb.length() - 2);
-            }
-            String statement = sb.toString();
-            if (!statement.trim().endsWith(";")) {
-                statement += ";";
-            }
-            log.debug(statement);
-        }
-        return sql;
-    }
+	/**
+	 * Logs a (prepared) sql statement.
+	 * 
+	 * @param sql  Base sql to log.
+	 * @param log  The logger object.
+	 * @param args Optional arguments to the statement.
+	 * 
+	 * @return The original statement.
+	 */
+	public static String log(String sql, Logger log, Object... args) {
+		if (log.isDebugEnabled()) {
+			StringBuilder sb = new StringBuilder(sql);
+			if (args.length > 0) {
+				sb.append(";");
+				for (int i = 0; i < args.length; i++) {
+					sb.append(i).append("=").append(args[i]).append(", ");
+				}
+				sb.setLength(sb.length() - 2);
+			}
+			String statement = sb.toString();
+			if (!statement.trim().endsWith(";")) {
+				statement += ";";
+			}
+			log.debug(statement);
+		}
+		return sql;
+	}
 
-    public synchronized static DataSource newDataSource(Environment config) {
-        return newDataSource(config.connectionConfig);
-    }
+	public synchronized static DataSource newDataSource(Environment config) {
+		return newDataSource(config.connectionConfig);
+	}
 
-    public synchronized static DataSource newDataSource(ConnectionConfig config) {
-        DataSource dataSource = DATASOURCE_POOL.acquire(config.getKey());
-        return dataSource;
-    }
+	public synchronized static DataSource newDataSource(ConnectionConfig config) {
+		DataSource dataSource = DATASOURCE_POOL.acquire(config.getKey());
+		return dataSource;
+	}
 
-    public static void closeDataSource(DataSource ds) {
-        if (ds != null) {
-            DATASOURCE_POOL.release(ds);
-        }
-    }
+	public static void closeDataSource(DataSource ds) {
+		if (ds != null) {
+			DATASOURCE_POOL.release(ds);
+		}
+	}
 
-    public static Connection newConnection(DataSource ds) {
-        try {
-            Connection connection = ds.getConnection();
-            return connection;
-        } catch (SQLTransientConnectionException e) {
-            throw new RepositoryBusyException("No available connections to the repository.", e);
-        } catch (SQLException e) {
-            throw new RuntimeException("Unable to obatain connection: " + e.getMessage(), e);
-        }
-    }
+	public static Connection newConnection(DataSource ds) {
+		try {
+			Connection connection = ds.getConnection();
+			return connection;
+		} catch (SQLTransientConnectionException e) {
+			throw new RepositoryBusyException("No available connections to the repository.", e);
+		} catch (SQLException e) {
+			throw new RuntimeException("Unable to obatain connection: " + e.getMessage(), e);
+		}
+	}
 
-    public static SQLException rollbackAndRethrow(Connection c, Exception e) throws SQLException {
-        c.rollback();
-        if (e instanceof SQLException) {
-            throw (SQLException) e;
-        }
-        throw new RuntimeException(e);
-    }
+	public static SQLException rollbackAndRethrow(Connection c, Exception e) throws SQLException {
+		c.rollback();
+		if (e instanceof SQLException) {
+			throw (SQLException) e;
+		}
+		throw new RuntimeException(e);
+	}
 
-    public static boolean repoExists(final Environment config) throws IllegalArgumentException {
-        checkNotNull(config);
-        checkArgument(config.getRepositoryName() != null, "no repository name provided");
+	public static boolean repoExists(final Environment config) throws IllegalArgumentException {
+		checkNotNull(config);
+		checkArgument(config.getRepositoryName() != null, "no repository name provided");
 
-        Optional<Integer> repoPK;
-        try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
-            if (config.isRepositorySet()) {
-                String configuredName = configdb.get("repo.name").orNull();
-                Preconditions.checkState(config.getRepositoryName().equals(configuredName));
-                return true;
-            } else {
-                repoPK = configdb.resolveRepositoryPK(config.getRepositoryName());
-                if (repoPK.isPresent()) {
-                    if (config.isRepositorySet()) {
-                        if (repoPK.get() != config.getRepositoryId()) {
-                            String msg = format("The provided primary key for the repository '%s' "
-                                    + "does not match the one in the database. Provided: %d, returned: %d. "
-                                    + "Check the consistency of the repo.name config property for those repository ids");
-                            throw new IllegalStateException(msg);
-                        }
-                    } else {
-                        config.setRepositoryId(repoPK.get());
-                    }
-                }
-                return repoPK.isPresent();
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        }
-    }
+		Optional<Integer> repoPK;
+		try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
+			if (config.isRepositorySet()) {
+				String configuredName = configdb.get("repo.name").orNull();
+				Preconditions.checkState(config.getRepositoryName().equals(configuredName));
+				return true;
+			} else {
+				repoPK = configdb.resolveRepositoryPK(config.getRepositoryName());
+				if (repoPK.isPresent()) {
+					if (config.isRepositorySet()) {
+						if (repoPK.get() != config.getRepositoryId()) {
+							String msg = format("The provided primary key for the repository '%s' "
+									+ "does not match the one in the database. Provided: %d, returned: %d. "
+									+ "Check the consistency of the repo.name config property for those repository ids");
+							throw new IllegalStateException(msg);
+						}
+					} else {
+						config.setRepositoryId(repoPK.get());
+					}
+				}
+				return repoPK.isPresent();
+			}
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		}
+	}
 
-    public static Version getServerVersion(final Environment env) {
-        DataSource ds = newDataSource(env);
-        try (Connection cx = newConnection(ds)) {
-            return getServerVersion(cx);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        } finally {
-            closeDataSource(ds);
-        }
-    }
+	public static Version getServerVersion(final Environment env) {
+		DataSource ds = newDataSource(env);
+		try (Connection cx = newConnection(ds)) {
+			return getServerVersion(cx);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		} finally {
+			closeDataSource(ds);
+		}
+	}
 
-    public static Version getServerVersion(Connection cx) throws SQLException {
-        try (Statement st = cx.createStatement()) {
-            try (ResultSet rs = st.executeQuery("SHOW server_version")) {
-                Preconditions.checkState(rs.next(),
-                        "Query 'SHOW server_version' did not produce a result");
-                final String v = rs.getString(1);
-                return getVersionFromQueryResult(v);
-            }
-        }
-    }
+	public static Version getServerVersion(Connection cx) throws SQLException {
+		try (Statement st = cx.createStatement()) {
+			try (ResultSet rs = st.executeQuery("SHOW server_version")) {
+				Preconditions.checkState(rs.next(), "Query 'SHOW server_version' did not produce a result");
+				final String v = rs.getString(1);
+				return getVersionFromQueryResult(v);
+			}
+		}
+	}
 
-    static Version getVersionFromQueryResult(final String versionQueryResult) {
-        // version string may not be a simple x.y.x value. Let's just take it from the front and
-        // stop at the first
-        // non-digit, non-decimal-point character
-        final String regex = "[^0-9.]";
-        // replace first non-digit, non-decimal point with XXX
-        String marked = versionQueryResult.replaceFirst(regex, "XXX");
-        if (marked.contains("XXX")) {
-            // no throw away everything starting with XXX
-            marked = marked.substring(0, marked.indexOf("XXX"));
-        }
-        final List<Integer> versions = Lists.transform(Splitter.on('.').splitToList(marked),
-                (s) -> Integer.parseInt(s));
-        // version string can be either
-        // {major}.{minor}.{patch}
-        // or (since PostgreSQL 10)
-        // {major}.{minor}
-        Preconditions.checkState(versions.size() == 3 || versions.size() == 2,
-                "Expected version format x.y.z or x.y, got " + versionQueryResult);
-        int major = versions.get(0).intValue();
-        int minor = versions.get(1).intValue();
-        // patch may not be present. If not, just use 0
-        int patch = (versions.size() == 3) ? versions.get(2).intValue() : 0;
-        return new Version(major, minor, patch);
-    }
+	static Version getVersionFromQueryResult(final String versionQueryResult) {
+		return Version.valueOf(versionQueryResult);
+	}
 
-    /**
-     * List the names of all repositories in the given {@link Environment}.
-     * 
-     * @param config the environment
-     * @return the list of repository names
-     */
-    public static List<String> listRepos(final Environment config) {
-        checkNotNull(config);
+	/**
+	 * List the names of all repositories in the given {@link Environment}.
+	 * 
+	 * @param config the environment
+	 * @return the list of repository names
+	 */
+	public static List<String> listRepos(final Environment config) {
+		checkNotNull(config);
+		final DataSource dataSource = PGStorage.newDataSource(config);
+		TableNames tables = config.getTables();
 
-        List<String> repoNames = Lists.newLinkedList();
-        final DataSource dataSource = PGStorage.newDataSource(config);
+		try (Connection cx = PGStorage.newConnection(dataSource)) {
+			return listRepos(cx, tables);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		} finally {
+			PGStorage.closeDataSource(dataSource);
+		}
+	}
 
-        final String repoNamesView = config.getTables().repositoryNamesView();
-        if (!tableExists(dataSource, repoNamesView)) {
-            PGStorage.closeDataSource(dataSource);
-            return repoNames;
-        }
+	public static List<String> listRepos(final Connection cx, TableNames tables) throws SQLException {
+		checkNotNull(cx);
+		checkNotNull(tables);
+		List<String> repoNames = new ArrayList<>();
+		final String repoNamesView = tables.repositoryNamesView();
+		if (!tableExists(cx, repoNamesView)) {
+			return repoNames;
+		}
+		String sql = format("SELECT name FROM %s", repoNamesView);
+		try (Statement st = cx.createStatement()) {
+			try (ResultSet repos = st.executeQuery(sql)) {
+				while (repos.next()) {
+					repoNames.add(repos.getString(1));
+				}
+			}
+		}
+		return repoNames;
+	}
 
-        try (Connection cx = PGStorage.newConnection(dataSource)) {
-            String sql = format("SELECT name FROM %s", repoNamesView);
-            try (Statement st = cx.createStatement()) {
-                try (ResultSet repos = st.executeQuery(sql)) {
-                    while (repos.next()) {
-                        repoNames.add(repos.getString(1));
-                    }
-                }
-            }
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        } finally {
-            PGStorage.closeDataSource(dataSource);
-        }
+	/**
+	 * Initializes all the tables as given by the names in
+	 * {@link Environment#getTables() config.getTables()} if need be, and creates an
+	 * entry in the {@link TableNames#repositories() repsitories} table with the
+	 * repository id given by {@link Environment#repositoryId config.repositoryId},
+	 * returning true if the entry was created and false if it already existed.
+	 * 
+	 * @return {@code true} if the repository was created, {@code false} if it
+	 *         already exists
+	 */
+	public static boolean createNewRepo(final Environment config) throws IllegalArgumentException {
+		checkNotNull(config);
+		checkArgument(config.getRepositoryName() != null, "no repository name provided");
+		createTables(config);
 
-        return repoNames;
-    }
+		final String argRepoName = config.getRepositoryName();
+		if (config.isRepositorySet()) {
+			return false;
+		}
 
-    /**
-     * Initializes all the tables as given by the names in {@link Environment#getTables()
-     * config.getTables()} if need be, and creates an entry in the {@link TableNames#repositories()
-     * repsitories} table with the repository id given by {@link Environment#repositoryId
-     * config.repositoryId}, returning true if the entry was created and false if it already
-     * existed.
-     * 
-     * @return {@code true} if the repository was created, {@code false} if it already exists
-     */
-    public static boolean createNewRepo(final Environment config) throws IllegalArgumentException {
-        checkNotNull(config);
-        checkArgument(config.getRepositoryName() != null, "no repository name provided");
-        createTables(config);
+		final DataSource dataSource = PGStorage.newDataSource(config);
 
-        final String argRepoName = config.getRepositoryName();
-        if (config.isRepositorySet()) {
-            return false;
-        }
+		try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
+			final Optional<Integer> repositoryPK = configdb.resolveRepositoryPK(argRepoName);
+			if (repositoryPK.isPresent()) {
+				return false;
+			}
+			final int pk;
+			try (Connection cx = PGStorage.newConnection(dataSource)) {
+				final String reposTable = config.getTables().repositories();
+				cx.setAutoCommit(false);
+				try {
+					String sql = format("INSERT INTO %s (created) VALUES (NOW())", reposTable);
+					try (Statement st = cx.createStatement()) {
+						int updCnt = st.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
+						checkState(updCnt == 1);
+						try (ResultSet generatedKeys = st.getGeneratedKeys()) {
+							checkState(generatedKeys.next());
+							pk = generatedKeys.getInt(1);
+						}
+						config.setRepositoryId(pk);
+					}
+					cx.commit();
+				} catch (SQLException | RuntimeException e) {
+					throw rollbackAndRethrow(cx, e);
+				} finally {
+					cx.setAutoCommit(true);
+				}
+			}
+			// set the config option outside the try-with-resources block to avoid acquiring
+			// 2
+			// connections
+			configdb.put("repo.name", argRepoName);
+			checkState(pk == configdb.resolveRepositoryPK(argRepoName).or(Environment.REPOSITORY_ID_UNSET));
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		} finally {
+			PGStorage.closeDataSource(dataSource);
+		}
 
-        final DataSource dataSource = PGStorage.newDataSource(config);
+		checkState(config.isRepositorySet());
+		return true;
+	}
 
-        try (PGConfigDatabase configdb = new PGConfigDatabase(config)) {
-            final Optional<Integer> repositoryPK = configdb.resolveRepositoryPK(argRepoName);
-            if (repositoryPK.isPresent()) {
-                return false;
-            }
-            final int pk;
-            try (Connection cx = PGStorage.newConnection(dataSource)) {
-                final String reposTable = config.getTables().repositories();
-                cx.setAutoCommit(false);
-                try {
-                    String sql = format("INSERT INTO %s (created) VALUES (NOW())", reposTable);
-                    try (Statement st = cx.createStatement()) {
-                        int updCnt = st.executeUpdate(sql, Statement.RETURN_GENERATED_KEYS);
-                        checkState(updCnt == 1);
-                        try (ResultSet generatedKeys = st.getGeneratedKeys()) {
-                            checkState(generatedKeys.next());
-                            pk = generatedKeys.getInt(1);
-                        }
-                        config.setRepositoryId(pk);
-                    }
-                    cx.commit();
-                } catch (SQLException | RuntimeException e) {
-                    throw rollbackAndRethrow(cx, e);
-                } finally {
-                    cx.setAutoCommit(true);
-                }
-            }
-            // set the config option outside the try-with-resources block to avoid acquiring 2
-            // connections
-            configdb.put("repo.name", argRepoName);
-            checkState(pk == configdb.resolveRepositoryPK(argRepoName)
-                    .or(Environment.REPOSITORY_ID_UNSET));
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        } finally {
-            PGStorage.closeDataSource(dataSource);
-        }
+	public static boolean tableExists(final DataSource dataSource, final String tableName) {
+		boolean tableExists = false;
+		if (dataSource != null) {
+			try (Connection cx = PGStorage.newConnection(dataSource)) {
+				tableExists = tableExists(cx, tableName);
+			} catch (SQLException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		return tableExists;
+	}
 
-        checkState(config.isRepositorySet());
-        return true;
-    }
+	public static boolean tableExists(final Connection cx, final String tableName) throws SQLException {
+		boolean tableExists = false;
+		DatabaseMetaData md = cx.getMetaData();
+		final String schema = PGStorageTableManager.schema(tableName);
+		final String table = PGStorageTableManager.stripSchema(tableName);
+		try (ResultSet tables = md.getTables(null, schema, table, null)) {
+			tableExists = tables.next();
+		}
+		return tableExists;
+	}
 
-    public static boolean tableExists(final DataSource dataSource, final String tableName) {
-        boolean tableExists = false;
-        if (dataSource != null) {
-            try (Connection cx = PGStorage.newConnection(dataSource)) {
-                DatabaseMetaData md = cx.getMetaData();
-                final String schema = PGStorageTableManager.schema(tableName);
-                final String table = PGStorageTableManager.stripSchema(tableName);
-                try (ResultSet tables = md.getTables(null, schema, table, null)) {
-                    tableExists = tables.next();
-                }
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        return tableExists;
-    }
+	public static synchronized void createTables(final Environment config) {
+		final DataSource dataSource = PGStorage.newDataSource(config);
+		try (Connection cx = PGStorage.newConnection(dataSource)) {
+			final Version serverVersion = getServerVersion(cx);
+			final PGStorageTableManager tableManager;
+			tableManager = PGStorageTableManager.forVersion(serverVersion);
+			tableManager.createTables(cx, config);
+		} catch (SQLException e) {
+			throw new RuntimeException(e);
+		} finally {
+			PGStorage.closeDataSource(dataSource);
+		}
 
-    public static synchronized void createTables(final Environment config) {
-        final DataSource dataSource = PGStorage.newDataSource(config);
-        try (Connection cx = PGStorage.newConnection(dataSource)) {
-            final Version serverVersion = getServerVersion(cx);
-            final PGStorageTableManager tableManager;
-            tableManager = PGStorageTableManager.forVersion(serverVersion);
-            tableManager.createTables(cx, config);
-        } catch (SQLException e) {
-            throw new RuntimeException(e);
-        } finally {
-            PGStorage.closeDataSource(dataSource);
-        }
+	}
 
-    }
+	public static boolean deleteRepository(final Environment env) {
+		checkArgument(env.getRepositoryName() != null, "No repository name provided");
 
-    public static boolean deleteRepository(final Environment env) {
-        checkArgument(env.getRepositoryName() != null, "No repository name provided");
+		final String repositoryName = env.getRepositoryName();
+		final int repositoryPK;
 
-        final String repositoryName = env.getRepositoryName();
-        final int repositoryPK;
+		if (env.isRepositorySet()) {
+			repositoryPK = env.getRepositoryId();
+		} else {
+			try (PGConfigDatabase configdb = new PGConfigDatabase(env)) {
+				Optional<Integer> pk = configdb.resolveRepositoryPK(repositoryName);
+				if (pk.isPresent()) {
+					repositoryPK = pk.get();
+				} else {
+					return false;
+				}
+			} catch (SQLException e) {
+				throw new RuntimeException(e);
+			}
+		}
+		final TableNames tables = env.getTables();
+		final String reposTable = tables.repositories();
+		boolean deleted = false;
 
-        if (env.isRepositorySet()) {
-            repositoryPK = env.getRepositoryId();
-        } else {
-            try (PGConfigDatabase configdb = new PGConfigDatabase(env)) {
-                Optional<Integer> pk = configdb.resolveRepositoryPK(repositoryName);
-                if (pk.isPresent()) {
-                    repositoryPK = pk.get();
-                } else {
-                    return false;
-                }
-            } catch (SQLException e) {
-                throw new RuntimeException(e);
-            }
-        }
-        final TableNames tables = env.getTables();
-        final String reposTable = tables.repositories();
-        boolean deleted = false;
+		final String sql = String.format("DELETE FROM %s WHERE repository = ?", reposTable);
+		final DataSource ds = PGStorage.newDataSource(env);
 
-        final String sql = String.format("DELETE FROM %s WHERE repository = ?", reposTable);
-        final DataSource ds = PGStorage.newDataSource(env);
+		try (Connection cx = PGStorage.newConnection(ds)) {
+			cx.setAutoCommit(false);
+			try (PreparedStatement st = cx.prepareStatement(log(sql, LOG, repositoryName))) {
+				st.setInt(1, repositoryPK);
+				int rowCount = st.executeUpdate();
+				deleted = rowCount > 0;
+				cx.commit();
+			} catch (SQLException e) {
+				cx.rollback();
+				throw e;
+			} finally {
+				cx.setAutoCommit(true);
+			}
+		} catch (Exception e) {
+			throw new RuntimeException(e);
+		} finally {
+			PGStorage.closeDataSource(ds);
+		}
 
-        try (Connection cx = PGStorage.newConnection(ds)) {
-            cx.setAutoCommit(false);
-            try (PreparedStatement st = cx.prepareStatement(log(sql, LOG, repositoryName))) {
-                st.setInt(1, repositoryPK);
-                int rowCount = st.executeUpdate();
-                deleted = rowCount > 0;
-                cx.commit();
-            } catch (SQLException e) {
-                cx.rollback();
-                throw e;
-            } finally {
-                cx.setAutoCommit(true);
-            }
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        } finally {
-            PGStorage.closeDataSource(ds);
-        }
-
-        return Boolean.valueOf(deleted);
-    }
+		return Boolean.valueOf(deleted);
+	}
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
@@ -19,73 +19,73 @@ import com.google.common.base.Throwables;
 
 public abstract class PGStorageTableManager {
 
-	static final Logger LOG = LoggerFactory.getLogger(PGStorageTableManager.class);
+    static final Logger LOG = LoggerFactory.getLogger(PGStorageTableManager.class);
 
-	/**
-	 * @see PGStorage#createObjectsTables
-	 */
-	static final String OBJECT_TABLE_STMT = "CREATE TABLE %s (id OBJECTID, object BYTEA) WITHOUT OIDS;";
+    /**
+     * @see PGStorage#createObjectsTables
+     */
+    static final String OBJECT_TABLE_STMT = "CREATE TABLE %s (id OBJECTID, object BYTEA) WITHOUT OIDS;";
 
-	/**
-	 * @see PGStorageTableManager#createObjectChildTable
-	 */
-	static final String CHILD_TABLE_STMT = "CREATE TABLE %s ( ) INHERITS(%s)";
+    /**
+     * @see PGStorageTableManager#createObjectChildTable
+     */
+    static final String CHILD_TABLE_STMT = "CREATE TABLE %s ( ) INHERITS(%s)";
 
-	/**
-	 * @see PGStorage#partitionedObjectTableDDL
-	 */
-	static final String PARTITIONED_CHILD_TABLE_STMT = "CREATE TABLE %s"
-			+ " (id OBJECTID, object BYTEA, CHECK ( ((id).h1) >= %d AND ((id).h1) < %d) ) INHERITS (%s)";
+    /**
+     * @see PGStorage#partitionedObjectTableDDL
+     */
+    static final String PARTITIONED_CHILD_TABLE_STMT = "CREATE TABLE %s"
+            + " (id OBJECTID, object BYTEA, CHECK ( ((id).h1) >= %d AND ((id).h1) < %d) ) INHERITS (%s)";
 
-	public static PGStorageTableManager forVersion(Version serverVersion) {
-		if (serverVersion.major < 10) {
-			return new PrePg10TableManager();
-		}
-		return new Pg10TableManager();
-	}
+    public static PGStorageTableManager forVersion(Version serverVersion) {
+        if (serverVersion.major < 10) {
+            return new PrePg10TableManager();
+        }
+        return new Pg10TableManager();
+    }
 
-	private static class PrePg10TableManager extends PGStorageTableManager {
+    private static class PrePg10TableManager extends PGStorageTableManager {
 
-	}
+    }
 
-	/**
-	 * <ul>
-	 * <li>Table partitioning: can't do with inheritance
-	 * <li>Hash indexes
-	 * <li>Parallel workers
-	 * </ul>
-	 */
-	private static class Pg10TableManager extends PGStorageTableManager {
+    /**
+     * <ul>
+     * <li>Table partitioning: can't do with inheritance
+     * <li>Hash indexes
+     * <li>Parallel workers
+     * </ul>
+     */
+    private static class Pg10TableManager extends PGStorageTableManager {
 
-		// protected @Override void createObjectsTables(List<String> ddl, TableNames
-		// tables) {
-		// // tables.setFeaturesPartitions(0);
-		// createObjectsTables(ddl, tables.objects(), tables.commits(),
-		// tables.featureTypes(),
-		// tables.tags(), tables.trees(), tables.features());
-		// }
+        // protected @Override void createObjectsTables(List<String> ddl, TableNames
+        // tables) {
+        // // tables.setFeaturesPartitions(0);
+        // createObjectsTables(ddl, tables.objects(), tables.commits(),
+        // tables.featureTypes(),
+        // tables.tags(), tables.trees(), tables.features());
+        // }
 
-		protected @Override void createObjectTableIndex(List<String> ddl, String tableName) {
-			String index = format("CREATE INDEX %s_objectid_h1_hash ON %s USING HASH (((id).h1))",
-					stripSchema(tableName), tableName);
-			ddl.add(index);
-		}
+        protected @Override void createObjectTableIndex(List<String> ddl, String tableName) {
+            String index = format("CREATE INDEX %s_objectid_h1_hash ON %s USING HASH (((id).h1))",
+                    stripSchema(tableName), tableName);
+            ddl.add(index);
+        }
 
-		// protected @Override void createPartitionedObjectsTable(List<String> ddl,
-		// String
-		// parentTable,
-		// TableNames tables) {
-		// if (true) {
-		// throw new UnsupportedOperationException();
-		// }
-		// // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) PARTITION BY
-		// RANGE (
-		// // ((id).h1) )";
-		// final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) ";
-		// String sql = format(tableDDL, parentTable, tables.objects());
-		// ddl.add(sql);
-		// createObjectTableIndex(ddl, parentTable);
-		//
+        // protected @Override void createPartitionedObjectsTable(List<String> ddl,
+        // String
+        // parentTable,
+        // TableNames tables) {
+        // if (true) {
+        // throw new UnsupportedOperationException();
+        // }
+        // // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) PARTITION BY
+        // RANGE (
+        // // ((id).h1) )";
+        // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) ";
+        // String sql = format(tableDDL, parentTable, tables.objects());
+        // ddl.add(sql);
+        // createObjectTableIndex(ddl, parentTable);
+        //
 //            //@formatter:off
 //            /*
 //            final int min = Integer.MIN_VALUE;
@@ -108,379 +108,394 @@ public abstract class PGStorageTableManager {
 //            }
 //            */
 //            //@formatter:on
-		// }
-	}
+        // }
+    }
 
-	public static String schema(String tableName) {
-		int idx = tableName.indexOf('.');
-		String schema = "public";
-		if (idx > -1) {
-			schema = tableName.substring(0, idx);
-		}
-		return schema;
-	}
+    public static String schema(String tableName) {
+        int idx = tableName.indexOf('.');
+        String schema = "public";
+        if (idx > -1) {
+            schema = tableName.substring(0, idx);
+        }
+        return schema;
+    }
 
-	public static String stripSchema(String tableName) {
-		int idx = tableName.indexOf('.');
-		String prefixStripped = tableName;
-		if (idx > -1) {
-			prefixStripped = tableName.substring(idx + 1);
-		}
-		return prefixStripped;
-	}
+    public static String stripSchema(String tableName) {
+        int idx = tableName.indexOf('.');
+        String prefixStripped = tableName;
+        if (idx > -1) {
+            prefixStripped = tableName.substring(idx + 1);
+        }
+        return prefixStripped;
+    }
 
-	public List<String> createDDL(Environment config) {
-		final TableNames tables = config.getTables();
-		final String databaseName = config.getDatabaseName();
-		return createDDL(databaseName, tables);
-	}
+    public List<String> createDDL(Environment config) {
+        final TableNames tables = config.getTables();
+        final String databaseName = config.getDatabaseName();
+        return createDDL(databaseName, tables);
+    }
 
-	public List<String> createDDL(final String databaseName, final TableNames tables) {
-		List<String> ddl = new ArrayList<>();
+    public List<String> createDDL(final String databaseName, final TableNames tables) {
+        List<String> ddl = new ArrayList<>();
 
-		ddl.add("-- tell postgres to send bytea fields in a more compact format than hex encoding");
-		ddl.add("SELECT pg_advisory_lock(-1);");
-		String sql = format("do language plpgsql\n"//
-				+ "$$\n"//
-				+ "begin\n"//
-				+ " alter database %s SET bytea_output = 'escape'; \n"//
-				+ " exception when others then raise notice 'Unable to set bytea_output to escape';\n"//
-				+ "end;\n"//
-				+ "$$;", //
+        ddl.add("-- tell postgres to send bytea fields in a more compact format than hex encoding");
+        ddl.add("SELECT pg_advisory_lock(-1);");
+        String sql = format("do language plpgsql\n"//
+                + "$$\n"//
+                + "begin\n"//
+                + " alter database %s SET bytea_output = 'escape'; \n"//
+                + " exception when others then raise notice 'Unable to set bytea_output to escape';\n"//
+                + "end;\n"//
+                + "$$;", //
 
-				databaseName);
-		ddl.add(sql);
-		ddl.add("SELECT pg_advisory_unlock(-1);");
-		ddl.add("SET constraint_exclusion=ON;");
+                databaseName);
+        ddl.add(sql);
+        ddl.add("SELECT pg_advisory_unlock(-1);");
+        ddl.add("SET constraint_exclusion=ON;");
 
-		createMetadata(ddl, tables);
-		createObjectIdCompositeType(ddl);
-		createRepositoriesTable(ddl, tables);
-		createConfigTable(ddl, tables);
+        createMetadata(ddl, tables);
+        createObjectIdCompositeType(ddl);
+        createRepositoriesTable(ddl, tables);
+        createConfigTable(ddl, tables);
 
-		createRefsTable(ddl, tables);
-		createConflictsTable(ddl, tables);
-		createBlobsTable(ddl, tables);
-		createIndexTables(ddl, tables);
-		createObjectsTables(ddl, tables);
-		createGraphTables(ddl, tables);
-		return ddl;
-	}
+        createRefsTable(ddl, tables);
+        createConflictsTable(ddl, tables);
+        createBlobsTable(ddl, tables);
+        createIndexTables(ddl, tables);
+        createObjectsTables(ddl, tables);
+        createGraphTables(ddl, tables);
+        return ddl;
+    }
 
-	public void createMetadata(List<String> ddl, TableNames tables) {
-		VersionInfo productVersion = VersionOp.get();
+    public void createMetadata(List<String> ddl, TableNames tables) {
+        VersionInfo productVersion = VersionOp.get();
 
-		final String table = tables.metadata();
-		int latestVersion = getLatestSchemaVersion();
-		ddl.add(format("CREATE TABLE %s (key TEXT PRIMARY KEY, value TEXT, description TEXT);", table));
-		ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.version', '%s');", table,
-				productVersion.getProjectVersion()));
-		ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.commit-id', '%s');", table,
-				productVersion.getCommitId()));
-		ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.version', '%s');", table, latestVersion));
-		ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.features.partitions', '16');", table));
-		// ddl.add(format(
-		// "insert into %s (key, value) values ('schema.databse-version', '10');",
-		// table));
-	}
+        final String table = tables.metadata();
+        int latestVersion = getLatestSchemaVersion();
+        ddl.add(format("CREATE TABLE %s (key TEXT PRIMARY KEY, value TEXT, description TEXT);",
+                table));
+        ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.version', '%s');", table,
+                productVersion.getProjectVersion()));
+        ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.commit-id', '%s');", table,
+                productVersion.getCommitId()));
+        ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.version', '%s');", table,
+                latestVersion));
+        ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.features.partitions', '16');",
+                table));
+        // ddl.add(format(
+        // "insert into %s (key, value) values ('schema.databse-version', '10');",
+        // table));
+    }
 
-	public int getLatestSchemaVersion() {
-		return 1;
-	}
+    public int getLatestSchemaVersion() {
+        return 1;
+    }
 
-	public int getSchemaVersion(Connection cx, TableNames tables) throws SQLException {
-		String tableName = tables.metadata();
-		if (!PGStorage.tableExists(cx, tableName)) {
-			return 0;
-		} else {
-			try (Statement st = cx.createStatement()) {
-				String sql = format("select value from %s where key = 'schema.version'", tableName);
-				try (ResultSet rs = st.executeQuery(sql)) {
-					if (rs.next()) {
-						String sv = rs.getString(1);
-						return Integer.parseInt(sv);
-					}
-				}
-			}
-		}
-		throw new IllegalStateException("Table " + tableName + " exists but has no schema.version entry");
-	}
+    public int getSchemaVersion(Connection cx, TableNames tables) throws SQLException {
+        String tableName = tables.metadata();
+        if (!PGStorage.tableExists(cx, tableName)) {
+            return 0;
+        } else {
+            try (Statement st = cx.createStatement()) {
+                String sql = format("select value from %s where key = 'schema.version'", tableName);
+                try (ResultSet rs = st.executeQuery(sql)) {
+                    if (rs.next()) {
+                        String sv = rs.getString(1);
+                        return Integer.parseInt(sv);
+                    }
+                }
+            }
+        }
+        throw new IllegalStateException(
+                "Table " + tableName + " exists but has no schema.version entry");
+    }
 
+    public void createTables(Connection cx, Environment config) throws SQLException {
+        final TableNames tables = config.getTables();
+        final String reposTable = tables.repositories();
+        final String schema = PGStorageTableManager.schema(reposTable);
+        final String table = PGStorageTableManager.stripSchema(reposTable);
 
-	public void createTables(Connection cx, Environment config) throws SQLException {
-		final TableNames tables = config.getTables();
-		final String reposTable = tables.repositories();
-		final String schema = PGStorageTableManager.schema(reposTable);
-		final String table = PGStorageTableManager.stripSchema(reposTable);
+        DatabaseMetaData md = cx.getMetaData();
+        try (ResultSet rs = md.getTables(null, schema, table, null)) {
+            if (rs.next()) {
+                return;
+            }
+        }
+        final List<String> ddl = createDDL(config);
+        try {
+            cx.setAutoCommit(false);
+            runScript(cx, ddl);
+            cx.commit();
+        } catch (SQLException | RuntimeException e) {
+            cx.rollback();
+            Throwables.propagateIfInstanceOf(e, SQLException.class);
+            throw e;
+        } finally {
+            cx.setAutoCommit(true);
+        }
+    }
 
-		DatabaseMetaData md = cx.getMetaData();
-		try (ResultSet rs = md.getTables(null, schema, table, null)) {
-			if (rs.next()) {
-				return;
-			}
-		}
-		final List<String> ddl = createDDL(config);
-		try {
-			cx.setAutoCommit(false);
-			runScript(cx, ddl);
-			cx.commit();
-		} catch (SQLException | RuntimeException e) {
-			cx.rollback();
-			Throwables.propagateIfInstanceOf(e, SQLException.class);
-			throw e;
-		} finally {
-			cx.setAutoCommit(true);
-		}
-	}
+    public void runScript(Connection cx, final List<String> ddl) throws SQLException {
+        for (String ddlStatement : ddl) {
+            if (ddlStatement.trim().startsWith("--")) {
+                continue;
+            }
+            run(cx, ddlStatement);
+        }
+    }
 
-	public void runScript(Connection cx, final List<String> ddl) throws SQLException {
-		for (String ddlStatement : ddl) {
-			if (ddlStatement.trim().startsWith("--")) {
-				continue;
-			}
-			run(cx, ddlStatement);
-		}
-	}
+    protected void createGraphTables(List<String> ddl, TableNames tables) {
 
-	protected void createGraphTables(List<String> ddl, TableNames tables) {
+        final String edges = tables.graphEdges();
+        final String properties = tables.graphProperties();
+        final String mappings = tables.graphMappings();
 
-		final String edges = tables.graphEdges();
-		final String properties = tables.graphProperties();
-		final String mappings = tables.graphMappings();
+        String sql;
 
-		String sql;
+        sql = format(
+                "CREATE TABLE %s (src OBJECTID, dst OBJECTID, dstindex int NOT NULL, PRIMARY KEY (src,dst));",
+                edges);
+        ddl.add(sql);
 
-		sql = format("CREATE TABLE %s (src OBJECTID, dst OBJECTID, dstindex int NOT NULL, PRIMARY KEY (src,dst));",
-				edges);
-		ddl.add(sql);
+        sql = format("CREATE INDEX %s_src_index ON %s(src);", stripSchema(edges), edges);
+        ddl.add(sql);
 
-		sql = format("CREATE INDEX %s_src_index ON %s(src);", stripSchema(edges), edges);
-		ddl.add(sql);
+        sql = format("CREATE INDEX %s_dst_index ON %s(dst);", stripSchema(edges), edges);
+        ddl.add(sql);
 
-		sql = format("CREATE INDEX %s_dst_index ON %s(dst);", stripSchema(edges), edges);
-		ddl.add(sql);
+        sql = format("CREATE TABLE %s (nid OBJECTID, key VARCHAR, val VARCHAR,"
+                + " PRIMARY KEY(nid,key));", properties);
+        ddl.add(sql);
 
-		sql = format("CREATE TABLE %s (nid OBJECTID, key VARCHAR, val VARCHAR," + " PRIMARY KEY(nid,key));",
-				properties);
-		ddl.add(sql);
+        sql = format("CREATE TABLE %s (alias OBJECTID PRIMARY KEY, nid OBJECTID);", mappings);
+        ddl.add(sql);
 
-		sql = format("CREATE TABLE %s (alias OBJECTID PRIMARY KEY, nid OBJECTID);", mappings);
-		ddl.add(sql);
+        sql = format("CREATE INDEX %s_nid_index ON %s(nid);", stripSchema(mappings), mappings);
+        ddl.add(sql);
+    }
 
-		sql = format("CREATE INDEX %s_nid_index ON %s(nid);", stripSchema(mappings), mappings);
-		ddl.add(sql);
-	}
+    protected void createPartitionedObjectsTable(List<String> ddl, final String parentTable,
+            TableNames tables) {
+        final int min = Integer.MIN_VALUE;
+        final long max = (long) Integer.MAX_VALUE + 1;
+        final int numTables = 16;
+        final int step = (int) (((long) max - (long) min) / numTables);
 
-	protected void createPartitionedObjectsTable(List<String> ddl, final String parentTable, TableNames tables) {
-		final int min = Integer.MIN_VALUE;
-		final long max = (long) Integer.MAX_VALUE + 1;
-		final int numTables = 16;
-		final int step = (int) (((long) max - (long) min) / numTables);
+        createObjectChildTable(ddl, parentTable, tables.objects());
 
-		createObjectChildTable(ddl, parentTable, tables.objects());
+        final String triggerFunction = stripSchema(
+                format("%s_partitioning_insert_trigger", parentTable));
+        StringBuilder funcSql = new StringBuilder(
+                format("CREATE OR REPLACE FUNCTION %s()\n", triggerFunction));
+        funcSql.append("RETURNS TRIGGER AS $$\n");
+        funcSql.append("DECLARE\n\n");
+        funcSql.append("id objectid;\n");
+        funcSql.append("h1 integer;\n");
+        funcSql.append("\nBEGIN\n\n");
 
-		final String triggerFunction = stripSchema(format("%s_partitioning_insert_trigger", parentTable));
-		StringBuilder funcSql = new StringBuilder(format("CREATE OR REPLACE FUNCTION %s()\n", triggerFunction));
-		funcSql.append("RETURNS TRIGGER AS $$\n");
-		funcSql.append("DECLARE\n\n");
-		funcSql.append("id objectid;\n");
-		funcSql.append("h1 integer;\n");
-		funcSql.append("\nBEGIN\n\n");
+        funcSql.append("id = NEW.id;\n");
+        funcSql.append("-- raise notice 'id : %', id;\n");
+        funcSql.append("h1 = id.h1;\n");
+        funcSql.append("-- raise notice 'h1 : %', h1;\n");
 
-		funcSql.append("id = NEW.id;\n");
-		funcSql.append("-- raise notice 'id : %', id;\n");
-		funcSql.append("h1 = id.h1;\n");
-		funcSql.append("-- raise notice 'h1 : %', h1;\n");
+        long curr = min;
+        for (long i = 0; i < numTables; i++) {
+            long next = curr + step;
+            String tableName = format("%s_%d", parentTable, i);
+            String sql = partitionedObjectTableDDL(tableName, parentTable, curr, next);
 
-		long curr = min;
-		for (long i = 0; i < numTables; i++) {
-			long next = curr + step;
-			String tableName = format("%s_%d", parentTable, i);
-			String sql = partitionedObjectTableDDL(tableName, parentTable, curr, next);
+            ddl.add(sql);
 
-			ddl.add(sql);
+            createIgnoreDuplicatesRule(ddl, tableName);
+            createObjectTableIndex(ddl, tableName);
 
-			createIgnoreDuplicatesRule(ddl, tableName);
-			createObjectTableIndex(ddl, tableName);
+            funcSql.append(i == 0 ? "IF" : "ELSIF");
+            funcSql.append(" ( h1 >= ").append(curr);
+            if (i < numTables - 1) {
+                funcSql.append(" AND h1 < ").append(next);
+            }
+            funcSql.append(" ) THEN\n");
+            funcSql.append(format("  INSERT INTO %s_%d VALUES (NEW.*);\n", parentTable, i));
+            curr = next;
+        }
+        funcSql.append("END IF;\n");
+        funcSql.append("RETURN NULL;\n");
+        funcSql.append("END;\n");
+        funcSql.append("$$\n");
+        funcSql.append("LANGUAGE plpgsql;\n");
 
-			funcSql.append(i == 0 ? "IF" : "ELSIF");
-			funcSql.append(" ( h1 >= ").append(curr);
-			if (i < numTables - 1) {
-				funcSql.append(" AND h1 < ").append(next);
-			}
-			funcSql.append(" ) THEN\n");
-			funcSql.append(format("  INSERT INTO %s_%d VALUES (NEW.*);\n", parentTable, i));
-			curr = next;
-		}
-		funcSql.append("END IF;\n");
-		funcSql.append("RETURN NULL;\n");
-		funcSql.append("END;\n");
-		funcSql.append("$$\n");
-		funcSql.append("LANGUAGE plpgsql;\n");
+        String sql = funcSql.toString();
+        ddl.add(sql);
 
-		String sql = funcSql.toString();
-		ddl.add(sql);
+        sql = format(
+                "CREATE TRIGGER %s BEFORE INSERT ON " + "%s FOR EACH ROW EXECUTE PROCEDURE %s();",
+                triggerFunction, parentTable, triggerFunction);
+        ddl.add(sql);
+    }
 
-		sql = format("CREATE TRIGGER %s BEFORE INSERT ON " + "%s FOR EACH ROW EXECUTE PROCEDURE %s();", triggerFunction,
-				parentTable, triggerFunction);
-		ddl.add(sql);
-	}
+    protected void createObjectTableIndex(List<String> ddl, String tableName) {
+        String index = format("CREATE INDEX %s_objectid_h1_hash ON %s (((id).h1));",
+                stripSchema(tableName), tableName);
+        ddl.add(index);
+    }
 
-	protected void createObjectTableIndex(List<String> ddl, String tableName) {
-		String index = format("CREATE INDEX %s_objectid_h1_hash ON %s (((id).h1));", stripSchema(tableName), tableName);
-		ddl.add(index);
-	}
+    protected void createIgnoreDuplicatesRule(List<String> ddl, String tableName) {
+        String rulePrefix = stripSchema(tableName);
 
-	protected void createIgnoreDuplicatesRule(List<String> ddl, String tableName) {
-		String rulePrefix = stripSchema(tableName);
+        String rule = "CREATE OR REPLACE RULE " + rulePrefix
+                + "_ignore_duplicate_inserts AS ON INSERT TO " + tableName
+                + " WHERE (EXISTS ( SELECT 1 FROM " + tableName
+                + " WHERE ((id).h1) = (NEW.id).h1 AND id = NEW.id))" + " DO INSTEAD NOTHING;";
+        ddl.add(rule);
+    }
 
-		String rule = "CREATE OR REPLACE RULE " + rulePrefix + "_ignore_duplicate_inserts AS ON INSERT TO " + tableName
-				+ " WHERE (EXISTS ( SELECT 1 FROM " + tableName + " WHERE ((id).h1) = (NEW.id).h1 AND id = NEW.id))"
-				+ " DO INSTEAD NOTHING;";
-		ddl.add(rule);
-	}
+    protected String partitionedObjectTableDDL(String tableName, final String parentTable,
+            long checkMinValue, long checkMaxValue) {
+        return format(PARTITIONED_CHILD_TABLE_STMT, tableName, checkMinValue, checkMaxValue,
+                parentTable);
+    }
 
-	protected String partitionedObjectTableDDL(String tableName, final String parentTable, long checkMinValue,
-			long checkMaxValue) {
-		return format(PARTITIONED_CHILD_TABLE_STMT, tableName, checkMinValue, checkMaxValue, parentTable);
-	}
+    protected void createObjectChildTable(List<String> ddl, String tableName, String parentTable) {
 
-	protected void createObjectChildTable(List<String> ddl, String tableName, String parentTable) {
+        String sql = format(CHILD_TABLE_STMT, tableName, parentTable);
+        ddl.add(sql);
+    }
 
-		String sql = format(CHILD_TABLE_STMT, tableName, parentTable);
-		ddl.add(sql);
-	}
+    /**
+     * TODO: compare performance in case we also created indexes for the "abstract" tables (object
+     * and object_feature), have read somewhere that otherwise you'll get sequential scans from the
+     * query planner that can be avoided.
+     */
+    protected void createObjectsTables(List<String> ddl, TableNames tables) {
+        createObjectsTables(ddl, tables.objects(), tables.commits(), tables.featureTypes(),
+                tables.tags(), tables.trees());
+        createPartitionedObjectsTable(ddl, tables.features(), tables);
+    }
 
-	/**
-	 * TODO: compare performance in case we also created indexes for the "abstract"
-	 * tables (object and object_feature), have read somewhere that otherwise you'll
-	 * get sequential scans from the query planner that can be avoided.
-	 */
-	protected void createObjectsTables(List<String> ddl, TableNames tables) {
-		createObjectsTables(ddl, tables.objects(), tables.commits(), tables.featureTypes(), tables.tags(),
-				tables.trees());
-		createPartitionedObjectsTable(ddl, tables.features(), tables);
-	}
+    protected void createObjectsTables(List<String> ddl, String objectsTable,
+            String... childTables) {
 
-	protected void createObjectsTables(List<String> ddl, String objectsTable, String... childTables) {
+        String sql = format(OBJECT_TABLE_STMT, objectsTable);
+        ddl.add(sql);
 
-		String sql = format(OBJECT_TABLE_STMT, objectsTable);
-		ddl.add(sql);
+        for (String tableName : childTables) {
+            createObjectChildTable(ddl, tableName, objectsTable);
+            createIgnoreDuplicatesRule(ddl, tableName);
+            createObjectTableIndex(ddl, tableName);
+        }
+    }
 
-		for (String tableName : childTables) {
-			createObjectChildTable(ddl, tableName, objectsTable);
-			createIgnoreDuplicatesRule(ddl, tableName);
-			createObjectTableIndex(ddl, tableName);
-		}
-	}
+    protected void createIndexTables(List<String> ddl, TableNames tables) {
+        String indexTable = tables.index();
+        String sql = format(
+                "CREATE TABLE %s (repository INTEGER, treeName TEXT, attributeName TEXT, strategy TEXT, metadata BYTEA"
+                        + ", PRIMARY KEY(repository, treeName, attributeName)"
+                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                indexTable, tables.repositories());
+        ddl.add(sql);
+        String indexMappings = tables.indexMappings();
+        sql = format(
+                "CREATE TABLE %s (repository INTEGER, indexId OBJECTID, treeId OBJECTID, indexTreeId OBJECTID"
+                        + ", PRIMARY KEY(repository, indexId, treeId)"
+                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                indexMappings, tables.repositories());
+        ddl.add(sql);
+        String indexObjects = tables.indexObjects();
+        sql = format(PGStorageTableManager.OBJECT_TABLE_STMT, indexObjects);
+        ddl.add(sql);
+        createIgnoreDuplicatesRule(ddl, indexObjects);
+        createObjectTableIndex(ddl, indexObjects);
+    }
 
-	protected void createIndexTables(List<String> ddl, TableNames tables) {
-		String indexTable = tables.index();
-		String sql = format(
-				"CREATE TABLE %s (repository INTEGER, treeName TEXT, attributeName TEXT, strategy TEXT, metadata BYTEA"
-						+ ", PRIMARY KEY(repository, treeName, attributeName)"
-						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				indexTable, tables.repositories());
-		ddl.add(sql);
-		String indexMappings = tables.indexMappings();
-		sql = format(
-				"CREATE TABLE %s (repository INTEGER, indexId OBJECTID, treeId OBJECTID, indexTreeId OBJECTID"
-						+ ", PRIMARY KEY(repository, indexId, treeId)"
-						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				indexMappings, tables.repositories());
-		ddl.add(sql);
-		String indexObjects = tables.indexObjects();
-		sql = format(PGStorageTableManager.OBJECT_TABLE_STMT, indexObjects);
-		ddl.add(sql);
-		createIgnoreDuplicatesRule(ddl, indexObjects);
-		createObjectTableIndex(ddl, indexObjects);
-	}
+    protected void createBlobsTable(List<String> ddl, TableNames tables) {
+        String blobsTable = tables.blobs();
+        String sql = format(
+                "CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, blob BYTEA"
+                        + ", PRIMARY KEY(repository,namespace,path)"
+                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                blobsTable, tables.repositories());
+        ddl.add(sql);
+    }
 
-	protected void createBlobsTable(List<String> ddl, TableNames tables) {
-		String blobsTable = tables.blobs();
-		String sql = format(
-				"CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, blob BYTEA"
-						+ ", PRIMARY KEY(repository,namespace,path)"
-						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				blobsTable, tables.repositories());
-		ddl.add(sql);
-	}
+    protected void createConflictsTable(List<String> ddl, TableNames tables) {
+        String conflictsTable = tables.conflicts();
+        String sql = format(
+                "CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, ancestor bytea, ours bytea NOT NULL, theirs bytea NOT NULL"
+                        + ", PRIMARY KEY(repository, namespace, path)"
+                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                conflictsTable, tables.repositories());
+        ddl.add(sql);
+    }
 
-	protected void createConflictsTable(List<String> ddl, TableNames tables) {
-		String conflictsTable = tables.conflicts();
-		String sql = format(
-				"CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, ancestor bytea, ours bytea NOT NULL, theirs bytea NOT NULL"
-						+ ", PRIMARY KEY(repository, namespace, path)"
-						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				conflictsTable, tables.repositories());
-		ddl.add(sql);
-	}
+    protected void createRefsTable(List<String> ddl, TableNames tables) {
+        final String TABLE_STMT = format(
+                "CREATE TABLE %s (" + "repository INTEGER, path TEXT, name TEXT, value TEXT, "
+                        + "PRIMARY KEY(repository, path, name), "
+                        + "FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                tables.refs(), tables.repositories());
+        ddl.add(TABLE_STMT);
+    }
 
-	protected void createRefsTable(List<String> ddl, TableNames tables) {
-		final String TABLE_STMT = format(
-				"CREATE TABLE %s (" + "repository INTEGER, path TEXT, name TEXT, value TEXT, "
-						+ "PRIMARY KEY(repository, path, name), "
-						+ "FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				tables.refs(), tables.repositories());
-		ddl.add(TABLE_STMT);
-	}
+    protected void createConfigTable(List<String> ddl, TableNames tables) {
+        final String viewName = tables.repositoryNamesView();
+        final String repositories = tables.repositories();
+        String configTable = tables.config();
+        String sql = format(
+                "CREATE TABLE IF NOT EXISTS %s (repository INTEGER, section TEXT, key TEXT, value TEXT,"
+                        + " PRIMARY KEY (repository, section, key)"
+                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+                configTable, tables.repositories());
+        ddl.add(sql);
+        sql = format("CREATE INDEX %s_section_idx ON %s (repository, section);",
+                stripSchema(configTable), configTable);
+        ddl.add(sql);
+        sql = format("CREATE VIEW %s " + "AS SELECT r.*, c.value AS name FROM "
+                + "%s r INNER JOIN %s c ON r.repository = c.repository WHERE c.section = 'repo' AND c.key = 'name';",
+                viewName, repositories, configTable);
+        ddl.add(sql);
+    }
 
-	protected void createConfigTable(List<String> ddl, TableNames tables) {
-		final String viewName = tables.repositoryNamesView();
-		final String repositories = tables.repositories();
-		String configTable = tables.config();
-		String sql = format(
-				"CREATE TABLE IF NOT EXISTS %s (repository INTEGER, section TEXT, key TEXT, value TEXT,"
-						+ " PRIMARY KEY (repository, section, key)"
-						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-				configTable, tables.repositories());
-		ddl.add(sql);
-		sql = format("CREATE INDEX %s_section_idx ON %s (repository, section);", stripSchema(configTable), configTable);
-		ddl.add(sql);
-		sql = format("CREATE VIEW %s " + "AS SELECT r.*, c.value AS name FROM "
-				+ "%s r INNER JOIN %s c ON r.repository = c.repository WHERE c.section = 'repo' AND c.key = 'name';",
-				viewName, repositories, configTable);
-		ddl.add(sql);
-	}
+    protected void createRepositoriesTable(List<String> ddl, TableNames tables) {
+        final String repositories = tables.repositories();
 
-	protected void createRepositoriesTable(List<String> ddl, TableNames tables) {
-		final String repositories = tables.repositories();
+        String sql = format("CREATE TABLE %s (repository serial PRIMARY KEY, created TIMESTAMP);",
+                repositories);
+        ddl.add(sql);
+        ddl.add("-- create an entry for global config to have a matching entry in repositories");
+        sql = format("INSERT INTO %s (repository, created) VALUES (%d, NOW());", repositories,
+                Environment.GLOBAL_KEY);
+        ddl.add(sql);
+    }
 
-		String sql = format("CREATE TABLE %s (repository serial PRIMARY KEY, created TIMESTAMP);", repositories);
-		ddl.add(sql);
-		ddl.add("-- create an entry for global config to have a matching entry in repositories");
-		sql = format("INSERT INTO %s (repository, created) VALUES (%d, NOW());", repositories, Environment.GLOBAL_KEY);
-		ddl.add(sql);
-	}
+    protected void createObjectIdCompositeType(List<String> ddl) {
 
-	protected void createObjectIdCompositeType(List<String> ddl) {
+        ddl.add("-- There's no CREATE TYPE IF NOT EXIST, so use this trick");
+        ddl.add("-- This function is to create a type if it does not exist since there's no support for IF NOT EXISTS for CREATE TYPE\n");
 
-		ddl.add("-- There's no CREATE TYPE IF NOT EXIST, so use this trick");
-		ddl.add("-- This function is to create a type if it does not exist since there's no support for IF NOT EXISTS for CREATE TYPE\n");
+        final String func = "CREATE OR REPLACE FUNCTION create_objectid_type() RETURNS integer AS $$\n"//
+                + "DECLARE v_exists INTEGER;\n"//
+                + "BEGIN\n"//
+                + "    SELECT into v_exists (SELECT 1 FROM pg_type WHERE typname = 'objectid');\n"//
+                + "    IF v_exists IS NULL THEN\n"//
+                + "        CREATE TYPE OBJECTID AS(h1 INTEGER, h2 BIGINT, h3 BIGINT);\n"//
+                + "    END IF;\n"//
+                + "    RETURN v_exists;\n"//
+                + "END;\n"//
+                + "$$ LANGUAGE plpgsql;";
 
-		final String func = "CREATE OR REPLACE FUNCTION create_objectid_type() RETURNS integer AS $$\n"//
-				+ "DECLARE v_exists INTEGER;\n"//
-				+ "BEGIN\n"//
-				+ "    SELECT into v_exists (SELECT 1 FROM pg_type WHERE typname = 'objectid');\n"//
-				+ "    IF v_exists IS NULL THEN\n"//
-				+ "        CREATE TYPE OBJECTID AS(h1 INTEGER, h2 BIGINT, h3 BIGINT);\n"//
-				+ "    END IF;\n"//
-				+ "    RETURN v_exists;\n"//
-				+ "END;\n"//
-				+ "$$ LANGUAGE plpgsql;";
+        ddl.add(func);
+        ddl.add("SELECT create_objectid_type();");
+        ddl.add("DROP FUNCTION IF EXISTS create_objectid_type();");
+    }
 
-		ddl.add(func);
-		ddl.add("SELECT create_objectid_type();");
-		ddl.add("DROP FUNCTION IF EXISTS create_objectid_type();");
-	}
-
-	static void run(final Connection cx, final String sql) throws SQLException {
-		try (Statement st = cx.createStatement()) {
-			st.execute(PGStorage.log(sql, PGStorage.LOG));
-		} catch (SQLException e) {
-			LOG.error("Error running SQL: {}", sql, e);
-			throw e;
-		}
-	}
+    static void run(final Connection cx, final String sql) throws SQLException {
+        try (Statement st = cx.createStatement()) {
+            st.execute(PGStorage.log(sql, PGStorage.LOG));
+        } catch (SQLException e) {
+            LOG.error("Error running SQL: {}", sql, e);
+            throw e;
+        }
+    }
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
@@ -498,4 +498,16 @@ public abstract class PGStorageTableManager {
         }
     }
 
+    public void checkCompatibility(Connection cx, Environment env)
+            throws IllegalArgumentException, SQLException {
+        final int latestSchemaVersion = getLatestSchemaVersion();
+        final int currentSchemaVersion = getSchemaVersion(cx, env.getTables());
+        if (currentSchemaVersion < latestSchemaVersion) {
+            String msg = String.format(
+                    "ERROR: Database %s is running an outdated geogig schema. You need to run `geogig postgres-upgrade` from the command line before continuing.",
+                    env.getDatabaseName());
+            throw new IllegalArgumentException(msg);
+        }
+    }
+
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/PGStorageTableManager.java
@@ -19,69 +19,73 @@ import com.google.common.base.Throwables;
 
 public abstract class PGStorageTableManager {
 
-    static final Logger LOG = LoggerFactory.getLogger(PGStorageTableManager.class);
+	static final Logger LOG = LoggerFactory.getLogger(PGStorageTableManager.class);
 
-    /**
-     * @see PGStorage#createObjectsTables
-     */
-    static final String OBJECT_TABLE_STMT = "CREATE TABLE %s (id OBJECTID, object BYTEA) WITHOUT OIDS;";
+	/**
+	 * @see PGStorage#createObjectsTables
+	 */
+	static final String OBJECT_TABLE_STMT = "CREATE TABLE %s (id OBJECTID, object BYTEA) WITHOUT OIDS;";
 
-    /**
-     * @see PGStorageTableManager#createObjectChildTable
-     */
-    static final String CHILD_TABLE_STMT = "CREATE TABLE %s ( ) INHERITS(%s)";
+	/**
+	 * @see PGStorageTableManager#createObjectChildTable
+	 */
+	static final String CHILD_TABLE_STMT = "CREATE TABLE %s ( ) INHERITS(%s)";
 
-    /**
-     * @see PGStorage#partitionedObjectTableDDL
-     */
-    static final String PARTITIONED_CHILD_TABLE_STMT = "CREATE TABLE %s"
-            + " (id OBJECTID, object BYTEA, CHECK ( ((id).h1) >= %d AND ((id).h1) < %d) ) INHERITS (%s)";
+	/**
+	 * @see PGStorage#partitionedObjectTableDDL
+	 */
+	static final String PARTITIONED_CHILD_TABLE_STMT = "CREATE TABLE %s"
+			+ " (id OBJECTID, object BYTEA, CHECK ( ((id).h1) >= %d AND ((id).h1) < %d) ) INHERITS (%s)";
 
-    public static PGStorageTableManager forVersion(Version serverVersion) {
-        if (serverVersion.major < 10) {
-            return new PrePg10TableManager();
-        }
-        return new Pg10TableManager();
-    }
+	public static PGStorageTableManager forVersion(Version serverVersion) {
+		if (serverVersion.major < 10) {
+			return new PrePg10TableManager();
+		}
+		return new Pg10TableManager();
+	}
 
-    private static class PrePg10TableManager extends PGStorageTableManager {
+	private static class PrePg10TableManager extends PGStorageTableManager {
 
-    }
+	}
 
-    /**
-     * <ul>
-     * <li>Table partitioning: can't do with inheritance
-     * <li>Hash indexes
-     * <li>Parallel workers
-     * </ul>
-     */
-    private static class Pg10TableManager extends PGStorageTableManager {
+	/**
+	 * <ul>
+	 * <li>Table partitioning: can't do with inheritance
+	 * <li>Hash indexes
+	 * <li>Parallel workers
+	 * </ul>
+	 */
+	private static class Pg10TableManager extends PGStorageTableManager {
 
-        // protected @Override void createObjectsTables(List<String> ddl, TableNames tables) {
-        // // tables.setFeaturesPartitions(0);
-        // createObjectsTables(ddl, tables.objects(), tables.commits(), tables.featureTypes(),
-        // tables.tags(), tables.trees(), tables.features());
-        // }
+		// protected @Override void createObjectsTables(List<String> ddl, TableNames
+		// tables) {
+		// // tables.setFeaturesPartitions(0);
+		// createObjectsTables(ddl, tables.objects(), tables.commits(),
+		// tables.featureTypes(),
+		// tables.tags(), tables.trees(), tables.features());
+		// }
 
-        protected @Override void createObjectTableIndex(List<String> ddl, String tableName) {
-            String index = format("CREATE INDEX %s_objectid_h1_hash ON %s USING HASH (((id).h1))",
-                    stripSchema(tableName), tableName);
-            ddl.add(index);
-        }
+		protected @Override void createObjectTableIndex(List<String> ddl, String tableName) {
+			String index = format("CREATE INDEX %s_objectid_h1_hash ON %s USING HASH (((id).h1))",
+					stripSchema(tableName), tableName);
+			ddl.add(index);
+		}
 
-        // protected @Override void createPartitionedObjectsTable(List<String> ddl, String
-        // parentTable,
-        // TableNames tables) {
-        // if (true) {
-        // throw new UnsupportedOperationException();
-        // }
-        // // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) PARTITION BY RANGE (
-        // // ((id).h1) )";
-        // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) ";
-        // String sql = format(tableDDL, parentTable, tables.objects());
-        // ddl.add(sql);
-        // createObjectTableIndex(ddl, parentTable);
-        //
+		// protected @Override void createPartitionedObjectsTable(List<String> ddl,
+		// String
+		// parentTable,
+		// TableNames tables) {
+		// if (true) {
+		// throw new UnsupportedOperationException();
+		// }
+		// // final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) PARTITION BY
+		// RANGE (
+		// // ((id).h1) )";
+		// final String tableDDL = "CREATE TABLE %s ( ) INHERITS(%s) ";
+		// String sql = format(tableDDL, parentTable, tables.objects());
+		// ddl.add(sql);
+		// createObjectTableIndex(ddl, parentTable);
+		//
 //            //@formatter:off
 //            /*
 //            final int min = Integer.MIN_VALUE;
@@ -104,359 +108,379 @@ public abstract class PGStorageTableManager {
 //            }
 //            */
 //            //@formatter:on
-        // }
-    }
+		// }
+	}
 
-    public static String schema(String tableName) {
-        int idx = tableName.indexOf('.');
-        String schema = "public";
-        if (idx > -1) {
-            schema = tableName.substring(0, idx);
-        }
-        return schema;
-    }
+	public static String schema(String tableName) {
+		int idx = tableName.indexOf('.');
+		String schema = "public";
+		if (idx > -1) {
+			schema = tableName.substring(0, idx);
+		}
+		return schema;
+	}
 
-    public static String stripSchema(String tableName) {
-        int idx = tableName.indexOf('.');
-        String prefixStripped = tableName;
-        if (idx > -1) {
-            prefixStripped = tableName.substring(idx + 1);
-        }
-        return prefixStripped;
-    }
+	public static String stripSchema(String tableName) {
+		int idx = tableName.indexOf('.');
+		String prefixStripped = tableName;
+		if (idx > -1) {
+			prefixStripped = tableName.substring(idx + 1);
+		}
+		return prefixStripped;
+	}
 
-    public List<String> createDDL(Environment config) {
-        final TableNames tables = config.getTables();
-        List<String> ddl = new ArrayList<>();
+	public List<String> createDDL(Environment config) {
+		final TableNames tables = config.getTables();
+		final String databaseName = config.getDatabaseName();
+		return createDDL(databaseName, tables);
+	}
 
-        ddl.add("-- tell postgres to send bytea fields in a more compact format than hex encoding");
-        ddl.add("SELECT pg_advisory_lock(-1);");
-        String sql = format("do language plpgsql\n"//
-                + "$$\n"//
-                + "begin\n"//
-                + " alter database %s SET bytea_output = 'escape'; \n"//
-                + " exception when others then raise notice 'Unable to set bytea_output to escape';\n"//
-                + "end;\n"//
-                + "$$;", //
+	public List<String> createDDL(final String databaseName, final TableNames tables) {
+		List<String> ddl = new ArrayList<>();
 
-                config.getDatabaseName());
-        ddl.add(sql);
-        ddl.add("SELECT pg_advisory_unlock(-1);");
-        ddl.add("SET constraint_exclusion=ON;");
+		ddl.add("-- tell postgres to send bytea fields in a more compact format than hex encoding");
+		ddl.add("SELECT pg_advisory_lock(-1);");
+		String sql = format("do language plpgsql\n"//
+				+ "$$\n"//
+				+ "begin\n"//
+				+ " alter database %s SET bytea_output = 'escape'; \n"//
+				+ " exception when others then raise notice 'Unable to set bytea_output to escape';\n"//
+				+ "end;\n"//
+				+ "$$;", //
 
-        createMetadata(ddl, tables);
-        createObjectIdCompositeType(ddl);
-        createRepositoriesTable(ddl, tables);
-        createConfigTable(ddl, tables);
+				databaseName);
+		ddl.add(sql);
+		ddl.add("SELECT pg_advisory_unlock(-1);");
+		ddl.add("SET constraint_exclusion=ON;");
 
-        createRefsTable(ddl, tables);
-        createConflictsTable(ddl, tables);
-        createBlobsTable(ddl, tables);
-        createIndexTables(ddl, tables);
-        createObjectsTables(ddl, tables);
-        createGraphTables(ddl, tables);
-        return ddl;
-    }
+		createMetadata(ddl, tables);
+		createObjectIdCompositeType(ddl);
+		createRepositoriesTable(ddl, tables);
+		createConfigTable(ddl, tables);
 
-    private void createMetadata(List<String> ddl, TableNames tables) {
-        VersionInfo productVersion = VersionOp.get();
+		createRefsTable(ddl, tables);
+		createConflictsTable(ddl, tables);
+		createBlobsTable(ddl, tables);
+		createIndexTables(ddl, tables);
+		createObjectsTables(ddl, tables);
+		createGraphTables(ddl, tables);
+		return ddl;
+	}
 
-        final String table = tables.metadata();
-        ddl.add(format("create table %s (key text primary key, value text, description text);",
-                table));
-        ddl.add(format("insert into %s (key, value) values ('geogig.version', '%s');", table,
-                productVersion.getProjectVersion()));
-        ddl.add(format("insert into %s (key, value) values ('geogig.commit-id', '%s');", table,
-                productVersion.getCommitId()));
-        ddl.add(format("insert into %s (key, value) values ('schema.version', '1');", table));
-        ddl.add(format("insert into %s (key, value) values ('schema.features.partitions', '16');",
-                table));
-        // ddl.add(format(
-        // "insert into %s (key, value) values ('schema.databse-version', '10');", table));
-    }
+	public void createMetadata(List<String> ddl, TableNames tables) {
+		VersionInfo productVersion = VersionOp.get();
 
-    public void createTables(Connection cx, Environment config) throws SQLException {
-        final TableNames tables = config.getTables();
-        final String reposTable = tables.repositories();
-        final String schema = PGStorageTableManager.schema(reposTable);
-        final String table = PGStorageTableManager.stripSchema(reposTable);
+		final String table = tables.metadata();
+		int latestVersion = getLatestSchemaVersion();
+		ddl.add(format("CREATE TABLE %s (key TEXT PRIMARY KEY, value TEXT, description TEXT);", table));
+		ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.version', '%s');", table,
+				productVersion.getProjectVersion()));
+		ddl.add(format("INSERT INTO %s (key, value) VALUES ('geogig.commit-id', '%s');", table,
+				productVersion.getCommitId()));
+		ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.version', '%s');", table, latestVersion));
+		ddl.add(format("INSERT INTO %s (key, value) VALUES ('schema.features.partitions', '16');", table));
+		// ddl.add(format(
+		// "insert into %s (key, value) values ('schema.databse-version', '10');",
+		// table));
+	}
 
-        DatabaseMetaData md = cx.getMetaData();
-        try (ResultSet rs = md.getTables(null, schema, table, null)) {
-            if (rs.next()) {
-                return;
-            }
-        }
-        final List<String> ddl = createDDL(config);
-        try {
-            cx.setAutoCommit(false);
-            for (String ddlStatement : ddl) {
-                if (ddlStatement.trim().startsWith("--")) {
-                    continue;
-                }
-                run(cx, ddlStatement);
-            }
-            cx.commit();
-        } catch (SQLException | RuntimeException e) {
-            cx.rollback();
-            Throwables.throwIfInstanceOf(e, SQLException.class);
-            throw e;
-        } finally {
-            cx.setAutoCommit(true);
-        }
-    }
+	public int getLatestSchemaVersion() {
+		return 1;
+	}
 
-    protected void createGraphTables(List<String> ddl, TableNames tables) {
+	public int getSchemaVersion(Connection cx, TableNames tables) throws SQLException {
+		String tableName = tables.metadata();
+		if (!PGStorage.tableExists(cx, tableName)) {
+			return 0;
+		} else {
+			try (Statement st = cx.createStatement()) {
+				String sql = format("select value from %s where key = 'schema.version'", tableName);
+				try (ResultSet rs = st.executeQuery(sql)) {
+					if (rs.next()) {
+						String sv = rs.getString(1);
+						return Integer.parseInt(sv);
+					}
+				}
+			}
+		}
+		throw new IllegalStateException("Table " + tableName + " exists but has no schema.version entry");
+	}
 
-        final String edges = tables.graphEdges();
-        final String properties = tables.graphProperties();
-        final String mappings = tables.graphMappings();
 
-        String sql;
+	public void createTables(Connection cx, Environment config) throws SQLException {
+		final TableNames tables = config.getTables();
+		final String reposTable = tables.repositories();
+		final String schema = PGStorageTableManager.schema(reposTable);
+		final String table = PGStorageTableManager.stripSchema(reposTable);
 
-        sql = format(
-                "CREATE TABLE %s (src OBJECTID, dst OBJECTID, dstindex int NOT NULL, PRIMARY KEY (src,dst));",
-                edges);
-        ddl.add(sql);
+		DatabaseMetaData md = cx.getMetaData();
+		try (ResultSet rs = md.getTables(null, schema, table, null)) {
+			if (rs.next()) {
+				return;
+			}
+		}
+		final List<String> ddl = createDDL(config);
+		try {
+			cx.setAutoCommit(false);
+			runScript(cx, ddl);
+			cx.commit();
+		} catch (SQLException | RuntimeException e) {
+			cx.rollback();
+			Throwables.propagateIfInstanceOf(e, SQLException.class);
+			throw e;
+		} finally {
+			cx.setAutoCommit(true);
+		}
+	}
 
-        sql = format("CREATE INDEX %s_src_index ON %s(src);", stripSchema(edges), edges);
-        ddl.add(sql);
+	public void runScript(Connection cx, final List<String> ddl) throws SQLException {
+		for (String ddlStatement : ddl) {
+			if (ddlStatement.trim().startsWith("--")) {
+				continue;
+			}
+			run(cx, ddlStatement);
+		}
+	}
 
-        sql = format("CREATE INDEX %s_dst_index ON %s(dst);", stripSchema(edges), edges);
-        ddl.add(sql);
+	protected void createGraphTables(List<String> ddl, TableNames tables) {
 
-        sql = format("CREATE TABLE %s (nid OBJECTID, key VARCHAR, val VARCHAR,"
-                + " PRIMARY KEY(nid,key));", properties);
-        ddl.add(sql);
+		final String edges = tables.graphEdges();
+		final String properties = tables.graphProperties();
+		final String mappings = tables.graphMappings();
 
-        sql = format("CREATE TABLE %s (alias OBJECTID PRIMARY KEY, nid OBJECTID);", mappings);
-        ddl.add(sql);
+		String sql;
 
-        sql = format("CREATE INDEX %s_nid_index ON %s(nid);", stripSchema(mappings), mappings);
-        ddl.add(sql);
-    }
+		sql = format("CREATE TABLE %s (src OBJECTID, dst OBJECTID, dstindex int NOT NULL, PRIMARY KEY (src,dst));",
+				edges);
+		ddl.add(sql);
 
-    protected void createPartitionedObjectsTable(List<String> ddl, final String parentTable,
-            TableNames tables) {
-        final int min = Integer.MIN_VALUE;
-        final long max = (long) Integer.MAX_VALUE + 1;
-        final int numTables = 16;
-        final int step = (int) (((long) max - (long) min) / numTables);
+		sql = format("CREATE INDEX %s_src_index ON %s(src);", stripSchema(edges), edges);
+		ddl.add(sql);
 
-        createObjectChildTable(ddl, parentTable, tables.objects());
+		sql = format("CREATE INDEX %s_dst_index ON %s(dst);", stripSchema(edges), edges);
+		ddl.add(sql);
 
-        final String triggerFunction = stripSchema(
-                format("%s_partitioning_insert_trigger", parentTable));
-        StringBuilder funcSql = new StringBuilder(
-                format("CREATE OR REPLACE FUNCTION %s()\n", triggerFunction));
-        funcSql.append("RETURNS TRIGGER AS $$\n");
-        funcSql.append("DECLARE\n\n");
-        funcSql.append("id objectid;\n");
-        funcSql.append("h1 integer;\n");
-        funcSql.append("\nBEGIN\n\n");
+		sql = format("CREATE TABLE %s (nid OBJECTID, key VARCHAR, val VARCHAR," + " PRIMARY KEY(nid,key));",
+				properties);
+		ddl.add(sql);
 
-        funcSql.append("id = NEW.id;\n");
-        funcSql.append("-- raise notice 'id : %', id;\n");
-        funcSql.append("h1 = id.h1;\n");
-        funcSql.append("-- raise notice 'h1 : %', h1;\n");
+		sql = format("CREATE TABLE %s (alias OBJECTID PRIMARY KEY, nid OBJECTID);", mappings);
+		ddl.add(sql);
 
-        long curr = min;
-        for (long i = 0; i < numTables; i++) {
-            long next = curr + step;
-            String tableName = format("%s_%d", parentTable, i);
-            String sql = partitionedObjectTableDDL(tableName, parentTable, curr, next);
+		sql = format("CREATE INDEX %s_nid_index ON %s(nid);", stripSchema(mappings), mappings);
+		ddl.add(sql);
+	}
 
-            ddl.add(sql);
+	protected void createPartitionedObjectsTable(List<String> ddl, final String parentTable, TableNames tables) {
+		final int min = Integer.MIN_VALUE;
+		final long max = (long) Integer.MAX_VALUE + 1;
+		final int numTables = 16;
+		final int step = (int) (((long) max - (long) min) / numTables);
 
-            createIgnoreDuplicatesRule(ddl, tableName);
-            createObjectTableIndex(ddl, tableName);
+		createObjectChildTable(ddl, parentTable, tables.objects());
 
-            funcSql.append(i == 0 ? "IF" : "ELSIF");
-            funcSql.append(" ( h1 >= ").append(curr);
-            if (i < numTables - 1) {
-                funcSql.append(" AND h1 < ").append(next);
-            }
-            funcSql.append(" ) THEN\n");
-            funcSql.append(format("  INSERT INTO %s_%d VALUES (NEW.*);\n", parentTable, i));
-            curr = next;
-        }
-        funcSql.append("END IF;\n");
-        funcSql.append("RETURN NULL;\n");
-        funcSql.append("END;\n");
-        funcSql.append("$$\n");
-        funcSql.append("LANGUAGE plpgsql;\n");
+		final String triggerFunction = stripSchema(format("%s_partitioning_insert_trigger", parentTable));
+		StringBuilder funcSql = new StringBuilder(format("CREATE OR REPLACE FUNCTION %s()\n", triggerFunction));
+		funcSql.append("RETURNS TRIGGER AS $$\n");
+		funcSql.append("DECLARE\n\n");
+		funcSql.append("id objectid;\n");
+		funcSql.append("h1 integer;\n");
+		funcSql.append("\nBEGIN\n\n");
 
-        String sql = funcSql.toString();
-        ddl.add(sql);
+		funcSql.append("id = NEW.id;\n");
+		funcSql.append("-- raise notice 'id : %', id;\n");
+		funcSql.append("h1 = id.h1;\n");
+		funcSql.append("-- raise notice 'h1 : %', h1;\n");
 
-        sql = format(
-                "CREATE TRIGGER %s BEFORE INSERT ON " + "%s FOR EACH ROW EXECUTE PROCEDURE %s();",
-                triggerFunction, parentTable, triggerFunction);
-        ddl.add(sql);
-    }
+		long curr = min;
+		for (long i = 0; i < numTables; i++) {
+			long next = curr + step;
+			String tableName = format("%s_%d", parentTable, i);
+			String sql = partitionedObjectTableDDL(tableName, parentTable, curr, next);
 
-    protected void createObjectTableIndex(List<String> ddl, String tableName) {
-        String index = format("CREATE INDEX %s_objectid_h1_hash ON %s (((id).h1));",
-                stripSchema(tableName), tableName);
-        ddl.add(index);
-    }
+			ddl.add(sql);
 
-    protected void createIgnoreDuplicatesRule(List<String> ddl, String tableName) {
-        String rulePrefix = stripSchema(tableName);
+			createIgnoreDuplicatesRule(ddl, tableName);
+			createObjectTableIndex(ddl, tableName);
 
-        String rule = "CREATE OR REPLACE RULE " + rulePrefix
-                + "_ignore_duplicate_inserts AS ON INSERT TO " + tableName
-                + " WHERE (EXISTS ( SELECT 1 FROM " + tableName
-                + " WHERE ((id).h1) = (NEW.id).h1 AND id = NEW.id))" + " DO INSTEAD NOTHING;";
-        ddl.add(rule);
-    }
+			funcSql.append(i == 0 ? "IF" : "ELSIF");
+			funcSql.append(" ( h1 >= ").append(curr);
+			if (i < numTables - 1) {
+				funcSql.append(" AND h1 < ").append(next);
+			}
+			funcSql.append(" ) THEN\n");
+			funcSql.append(format("  INSERT INTO %s_%d VALUES (NEW.*);\n", parentTable, i));
+			curr = next;
+		}
+		funcSql.append("END IF;\n");
+		funcSql.append("RETURN NULL;\n");
+		funcSql.append("END;\n");
+		funcSql.append("$$\n");
+		funcSql.append("LANGUAGE plpgsql;\n");
 
-    protected String partitionedObjectTableDDL(String tableName, final String parentTable,
-            long checkMinValue, long checkMaxValue) {
-        return format(PARTITIONED_CHILD_TABLE_STMT, tableName, checkMinValue, checkMaxValue,
-                parentTable);
-    }
+		String sql = funcSql.toString();
+		ddl.add(sql);
 
-    protected void createObjectChildTable(List<String> ddl, String tableName, String parentTable) {
+		sql = format("CREATE TRIGGER %s BEFORE INSERT ON " + "%s FOR EACH ROW EXECUTE PROCEDURE %s();", triggerFunction,
+				parentTable, triggerFunction);
+		ddl.add(sql);
+	}
 
-        String sql = format(CHILD_TABLE_STMT, tableName, parentTable);
-        ddl.add(sql);
-    }
+	protected void createObjectTableIndex(List<String> ddl, String tableName) {
+		String index = format("CREATE INDEX %s_objectid_h1_hash ON %s (((id).h1));", stripSchema(tableName), tableName);
+		ddl.add(index);
+	}
 
-    /**
-     * TODO: compare performance in case we also created indexes for the "abstract" tables (object
-     * and object_feature), have read somewhere that otherwise you'll get sequential scans from the
-     * query planner that can be avoided.
-     */
-    protected void createObjectsTables(List<String> ddl, TableNames tables) {
-        createObjectsTables(ddl, tables.objects(), tables.commits(), tables.featureTypes(),
-                tables.tags(), tables.trees());
-        createPartitionedObjectsTable(ddl, tables.features(), tables);
-    }
+	protected void createIgnoreDuplicatesRule(List<String> ddl, String tableName) {
+		String rulePrefix = stripSchema(tableName);
 
-    protected void createObjectsTables(List<String> ddl, String objectsTable,
-            String... childTables) {
+		String rule = "CREATE OR REPLACE RULE " + rulePrefix + "_ignore_duplicate_inserts AS ON INSERT TO " + tableName
+				+ " WHERE (EXISTS ( SELECT 1 FROM " + tableName + " WHERE ((id).h1) = (NEW.id).h1 AND id = NEW.id))"
+				+ " DO INSTEAD NOTHING;";
+		ddl.add(rule);
+	}
 
-        String sql = format(OBJECT_TABLE_STMT, objectsTable);
-        ddl.add(sql);
+	protected String partitionedObjectTableDDL(String tableName, final String parentTable, long checkMinValue,
+			long checkMaxValue) {
+		return format(PARTITIONED_CHILD_TABLE_STMT, tableName, checkMinValue, checkMaxValue, parentTable);
+	}
 
-        for (String tableName : childTables) {
-            createObjectChildTable(ddl, tableName, objectsTable);
-            createIgnoreDuplicatesRule(ddl, tableName);
-            createObjectTableIndex(ddl, tableName);
-        }
-    }
+	protected void createObjectChildTable(List<String> ddl, String tableName, String parentTable) {
 
-    protected void createIndexTables(List<String> ddl, TableNames tables) {
-        String indexTable = tables.index();
-        String sql = format(
-                "CREATE TABLE %s (repository INTEGER, treeName TEXT, attributeName TEXT, strategy TEXT, metadata BYTEA"
-                        + ", PRIMARY KEY(repository, treeName, attributeName)"
-                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                indexTable, tables.repositories());
-        ddl.add(sql);
-        String indexMappings = tables.indexMappings();
-        sql = format(
-                "CREATE TABLE %s (repository INTEGER, indexId OBJECTID, treeId OBJECTID, indexTreeId OBJECTID"
-                        + ", PRIMARY KEY(repository, indexId, treeId)"
-                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                indexMappings, tables.repositories());
-        ddl.add(sql);
-        String indexObjects = tables.indexObjects();
-        sql = format(PGStorageTableManager.OBJECT_TABLE_STMT, indexObjects);
-        ddl.add(sql);
-        createIgnoreDuplicatesRule(ddl, indexObjects);
-        createObjectTableIndex(ddl, indexObjects);
-    }
+		String sql = format(CHILD_TABLE_STMT, tableName, parentTable);
+		ddl.add(sql);
+	}
 
-    protected void createBlobsTable(List<String> ddl, TableNames tables) {
-        String blobsTable = tables.blobs();
-        String sql = format(
-                "CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, blob BYTEA"
-                        + ", PRIMARY KEY(repository,namespace,path)"
-                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                blobsTable, tables.repositories());
-        ddl.add(sql);
-    }
+	/**
+	 * TODO: compare performance in case we also created indexes for the "abstract"
+	 * tables (object and object_feature), have read somewhere that otherwise you'll
+	 * get sequential scans from the query planner that can be avoided.
+	 */
+	protected void createObjectsTables(List<String> ddl, TableNames tables) {
+		createObjectsTables(ddl, tables.objects(), tables.commits(), tables.featureTypes(), tables.tags(),
+				tables.trees());
+		createPartitionedObjectsTable(ddl, tables.features(), tables);
+	}
 
-    protected void createConflictsTable(List<String> ddl, TableNames tables) {
-        String conflictsTable = tables.conflicts();
-        String sql = format(
-                "CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, ancestor bytea, ours bytea NOT NULL, theirs bytea NOT NULL"
-                        + ", PRIMARY KEY(repository, namespace, path)"
-                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                conflictsTable, tables.repositories());
-        ddl.add(sql);
-    }
+	protected void createObjectsTables(List<String> ddl, String objectsTable, String... childTables) {
 
-    protected void createRefsTable(List<String> ddl, TableNames tables) {
-        final String TABLE_STMT = format(
-                "CREATE TABLE %s (" + "repository INTEGER, path TEXT, name TEXT, value TEXT, "
-                        + "PRIMARY KEY(repository, path, name), "
-                        + "FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                tables.refs(), tables.repositories());
-        ddl.add(TABLE_STMT);
-    }
+		String sql = format(OBJECT_TABLE_STMT, objectsTable);
+		ddl.add(sql);
 
-    protected void createConfigTable(List<String> ddl, TableNames tables) {
-        final String viewName = tables.repositoryNamesView();
-        final String repositories = tables.repositories();
-        String configTable = tables.config();
-        String sql = format(
-                "CREATE TABLE IF NOT EXISTS %s (repository INTEGER, section TEXT, key TEXT, value TEXT,"
-                        + " PRIMARY KEY (repository, section, key)"
-                        + ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
-                configTable, tables.repositories());
-        ddl.add(sql);
-        sql = format("CREATE INDEX %s_section_idx ON %s (repository, section);",
-                stripSchema(configTable), configTable);
-        ddl.add(sql);
-        sql = format("CREATE VIEW %s " + "AS SELECT r.*, c.value AS name FROM "
-                + "%s r INNER JOIN %s c ON r.repository = c.repository WHERE c.section = 'repo' AND c.key = 'name';",
-                viewName, repositories, configTable);
-        ddl.add(sql);
-    }
+		for (String tableName : childTables) {
+			createObjectChildTable(ddl, tableName, objectsTable);
+			createIgnoreDuplicatesRule(ddl, tableName);
+			createObjectTableIndex(ddl, tableName);
+		}
+	}
 
-    protected void createRepositoriesTable(List<String> ddl, TableNames tables) {
-        final String repositories = tables.repositories();
+	protected void createIndexTables(List<String> ddl, TableNames tables) {
+		String indexTable = tables.index();
+		String sql = format(
+				"CREATE TABLE %s (repository INTEGER, treeName TEXT, attributeName TEXT, strategy TEXT, metadata BYTEA"
+						+ ", PRIMARY KEY(repository, treeName, attributeName)"
+						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				indexTable, tables.repositories());
+		ddl.add(sql);
+		String indexMappings = tables.indexMappings();
+		sql = format(
+				"CREATE TABLE %s (repository INTEGER, indexId OBJECTID, treeId OBJECTID, indexTreeId OBJECTID"
+						+ ", PRIMARY KEY(repository, indexId, treeId)"
+						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				indexMappings, tables.repositories());
+		ddl.add(sql);
+		String indexObjects = tables.indexObjects();
+		sql = format(PGStorageTableManager.OBJECT_TABLE_STMT, indexObjects);
+		ddl.add(sql);
+		createIgnoreDuplicatesRule(ddl, indexObjects);
+		createObjectTableIndex(ddl, indexObjects);
+	}
 
-        String sql = format("CREATE TABLE %s (repository serial PRIMARY KEY, created TIMESTAMP);",
-                repositories);
-        ddl.add(sql);
-        ddl.add("-- create an entry for global config to have a matching entry in repositories");
-        sql = format("INSERT INTO %s (repository, created) VALUES (%d, NOW());", repositories,
-                Environment.GLOBAL_KEY);
-        ddl.add(sql);
-    }
+	protected void createBlobsTable(List<String> ddl, TableNames tables) {
+		String blobsTable = tables.blobs();
+		String sql = format(
+				"CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, blob BYTEA"
+						+ ", PRIMARY KEY(repository,namespace,path)"
+						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				blobsTable, tables.repositories());
+		ddl.add(sql);
+	}
 
-    protected void createObjectIdCompositeType(List<String> ddl) {
+	protected void createConflictsTable(List<String> ddl, TableNames tables) {
+		String conflictsTable = tables.conflicts();
+		String sql = format(
+				"CREATE TABLE %s (repository INTEGER, namespace TEXT, path TEXT, ancestor bytea, ours bytea NOT NULL, theirs bytea NOT NULL"
+						+ ", PRIMARY KEY(repository, namespace, path)"
+						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				conflictsTable, tables.repositories());
+		ddl.add(sql);
+	}
 
-        ddl.add("-- There's no CREATE TYPE IF NOT EXIST, so use this trick");
-        ddl.add("-- This function is to create a type if it does not exist since there's no support for IF NOT EXISTS for CREATE TYPE\n");
+	protected void createRefsTable(List<String> ddl, TableNames tables) {
+		final String TABLE_STMT = format(
+				"CREATE TABLE %s (" + "repository INTEGER, path TEXT, name TEXT, value TEXT, "
+						+ "PRIMARY KEY(repository, path, name), "
+						+ "FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				tables.refs(), tables.repositories());
+		ddl.add(TABLE_STMT);
+	}
 
-        final String func = "CREATE OR REPLACE FUNCTION create_objectid_type() RETURNS integer AS $$\n"//
-                + "DECLARE v_exists INTEGER;\n"//
-                + "BEGIN\n"//
-                + "    SELECT into v_exists (SELECT 1 FROM pg_type WHERE typname = 'objectid');\n"//
-                + "    IF v_exists IS NULL THEN\n"//
-                + "        CREATE TYPE OBJECTID AS(h1 INTEGER, h2 BIGINT, h3 BIGINT);\n"//
-                + "    END IF;\n"//
-                + "    RETURN v_exists;\n"//
-                + "END;\n"//
-                + "$$ LANGUAGE plpgsql;";
+	protected void createConfigTable(List<String> ddl, TableNames tables) {
+		final String viewName = tables.repositoryNamesView();
+		final String repositories = tables.repositories();
+		String configTable = tables.config();
+		String sql = format(
+				"CREATE TABLE IF NOT EXISTS %s (repository INTEGER, section TEXT, key TEXT, value TEXT,"
+						+ " PRIMARY KEY (repository, section, key)"
+						+ ", FOREIGN KEY (repository) REFERENCES %s(repository) ON DELETE CASCADE);",
+				configTable, tables.repositories());
+		ddl.add(sql);
+		sql = format("CREATE INDEX %s_section_idx ON %s (repository, section);", stripSchema(configTable), configTable);
+		ddl.add(sql);
+		sql = format("CREATE VIEW %s " + "AS SELECT r.*, c.value AS name FROM "
+				+ "%s r INNER JOIN %s c ON r.repository = c.repository WHERE c.section = 'repo' AND c.key = 'name';",
+				viewName, repositories, configTable);
+		ddl.add(sql);
+	}
 
-        ddl.add(func);
-        ddl.add("SELECT create_objectid_type();");
-        ddl.add("DROP FUNCTION IF EXISTS create_objectid_type();");
-    }
+	protected void createRepositoriesTable(List<String> ddl, TableNames tables) {
+		final String repositories = tables.repositories();
 
-    static void run(final Connection cx, final String sql) throws SQLException {
-        try (Statement st = cx.createStatement()) {
-            st.execute(PGStorage.log(sql, PGStorage.LOG));
-        } catch (SQLException e) {
-            LOG.error("Error running SQL: {}", sql, e);
-            throw e;
-        }
-    }
+		String sql = format("CREATE TABLE %s (repository serial PRIMARY KEY, created TIMESTAMP);", repositories);
+		ddl.add(sql);
+		ddl.add("-- create an entry for global config to have a matching entry in repositories");
+		sql = format("INSERT INTO %s (repository, created) VALUES (%d, NOW());", repositories, Environment.GLOBAL_KEY);
+		ddl.add(sql);
+	}
+
+	protected void createObjectIdCompositeType(List<String> ddl) {
+
+		ddl.add("-- There's no CREATE TYPE IF NOT EXIST, so use this trick");
+		ddl.add("-- This function is to create a type if it does not exist since there's no support for IF NOT EXISTS for CREATE TYPE\n");
+
+		final String func = "CREATE OR REPLACE FUNCTION create_objectid_type() RETURNS integer AS $$\n"//
+				+ "DECLARE v_exists INTEGER;\n"//
+				+ "BEGIN\n"//
+				+ "    SELECT into v_exists (SELECT 1 FROM pg_type WHERE typname = 'objectid');\n"//
+				+ "    IF v_exists IS NULL THEN\n"//
+				+ "        CREATE TYPE OBJECTID AS(h1 INTEGER, h2 BIGINT, h3 BIGINT);\n"//
+				+ "    END IF;\n"//
+				+ "    RETURN v_exists;\n"//
+				+ "END;\n"//
+				+ "$$ LANGUAGE plpgsql;";
+
+		ddl.add(func);
+		ddl.add("SELECT create_objectid_type();");
+		ddl.add("DROP FUNCTION IF EXISTS create_objectid_type();");
+	}
+
+	static void run(final Connection cx, final String sql) throws SQLException {
+		try (Statement st = cx.createStatement()) {
+			st.execute(PGStorage.log(sql, PGStorage.LOG));
+		} catch (SQLException e) {
+			LOG.error("Error running SQL: {}", sql, e);
+			throw e;
+		}
+	}
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/TableNames.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/TableNames.java
@@ -14,145 +14,148 @@ import java.util.List;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 
-public class TableNames  implements Cloneable{
+public class TableNames implements Cloneable {
 
-    public static final String DEFAULT_SCHEMA = "public";
+	public static final String DEFAULT_SCHEMA = "public";
 
-    public static final String DEFAULT_TABLE_PREFIX = "geogig_";
+	public static final String DEFAULT_TABLE_PREFIX = "geogig_";
 
-    private final String schema;
+	private final String schema;
 
-    private final String prefix;
+	private final String prefix;
 
-    TableNames() {
-        this(DEFAULT_SCHEMA, DEFAULT_TABLE_PREFIX);
-    }
+	public TableNames() {
+		this(DEFAULT_SCHEMA);
+	}
 
-    public TableNames(String schema, String prefix) {
-        Preconditions.checkNotNull(schema);
-        Preconditions.checkNotNull(prefix);
-        this.schema = schema;
-        this.prefix = prefix;
-    }
+	public TableNames(String schema) {
+		this(schema, DEFAULT_TABLE_PREFIX);
+	}
 
-    public String getPrefix() {
-        return prefix;
-    }
+	public TableNames(String schema, String prefix) {
+		Preconditions.checkNotNull(schema);
+		Preconditions.checkNotNull(prefix);
+		this.schema = schema;
+		this.prefix = prefix;
+	}
 
-    public String metadata() {
-        return name("medatada");
-    }
+	public String getPrefix() {
+		return prefix;
+	}
 
-    public String repositories() {
-        return name("repository");
-    }
+	public String metadata() {
+		return name("medatada");
+	}
 
-    public String repositoryNamesView() {
-        return repositories() + "_name";
-    }
+	public String repositories() {
+		return name("repository");
+	}
 
-    private String name(String name) {
-        return new StringBuilder(schema).append('.').append(prefix).append(name).toString();
-    }
+	public String repositoryNamesView() {
+		return repositories() + "_name";
+	}
 
-    public String refs() {
-        return name("ref");
-    }
+	private String name(String name) {
+		return new StringBuilder(schema).append('.').append(prefix).append(name).toString();
+	}
 
-    public String objects() {
-        return name("object");
-    }
+	public String refs() {
+		return name("ref");
+	}
 
-    public String index() {
-        return name("index");
-    }
+	public String objects() {
+		return name("object");
+	}
 
-    public String indexMappings() {
-        return name("index_mappings");
-    }
+	public String index() {
+		return name("index");
+	}
 
-    public String indexObjects() {
-        return name("index_object");
-    }
+	public String indexMappings() {
+		return name("index_mappings");
+	}
 
-    private int featuresTablePartitionCount = 16;
+	public String indexObjects() {
+		return name("index_object");
+	}
 
-    void setFeaturesPartitions(int featuresTablePartitionCount) {
-        Preconditions.checkArgument(
-                featuresTablePartitionCount >= 0 && featuresTablePartitionCount <= 256);
-        this.featuresTablePartitionCount = featuresTablePartitionCount;
-    }
+	private int featuresTablePartitionCount = 16;
 
-    public String features(final int hash) {
-        if (0 == featuresTablePartitionCount) {
-            return features();
-        }
-        final int min = Integer.MIN_VALUE;
-        final long max = (long) Integer.MAX_VALUE + 1;
-        final int numTables = featuresTablePartitionCount;
-        final int step = (int) (((long) max - (long) min) / numTables);
+	void setFeaturesPartitions(int featuresTablePartitionCount) {
+		Preconditions.checkArgument(featuresTablePartitionCount >= 0 && featuresTablePartitionCount <= 256);
+		this.featuresTablePartitionCount = featuresTablePartitionCount;
+	}
 
-        int index = 0;
-        long curr = min;
-        for (int i = 0; i < numTables; i++) {
-            long next = curr + step;
-            if (hash >= curr && hash < next) {
-                index = i;
-                break;
-            }
-            curr = next;
-        }
-        return String.format("%s_%d", features(), index);
-    }
+	public String features(final int hash) {
+		if (0 == featuresTablePartitionCount) {
+			return features();
+		}
+		final int min = Integer.MIN_VALUE;
+		final long max = (long) Integer.MAX_VALUE + 1;
+		final int numTables = featuresTablePartitionCount;
+		final int step = (int) (((long) max - (long) min) / numTables);
 
-    public String features() {
-        return name("object_feature");
-    }
+		int index = 0;
+		long curr = min;
+		for (int i = 0; i < numTables; i++) {
+			long next = curr + step;
+			if (hash >= curr && hash < next) {
+				index = i;
+				break;
+			}
+			curr = next;
+		}
+		return String.format("%s_%d", features(), index);
+	}
 
-    public String featureTypes() {
-        return name("object_featuretype");
-    }
+	public String features() {
+		return name("object_feature");
+	}
 
-    public String tags() {
-        return name("object_tag");
-    }
+	public String featureTypes() {
+		return name("object_featuretype");
+	}
 
-    public String trees() {
-        return name("object_tree");
-    }
+	public String tags() {
+		return name("object_tag");
+	}
 
-    public String commits() {
-        return name("object_commit");
-    }
+	public String trees() {
+		return name("object_tree");
+	}
 
-    public String config() {
-        return name("config");
-    }
+	public String commits() {
+		return name("object_commit");
+	}
 
-    public String conflicts() {
-        return name("conflict");
-    }
+	public String config() {
+		return name("config");
+	}
 
-    public String graphEdges() {
-        return name("graph_edge");
-    }
+	public String conflicts() {
+		return name("conflict");
+	}
 
-    public String graphProperties() {
-        return name("graph_property");
-    }
+	public String graphEdges() {
+		return name("graph_edge");
+	}
 
-    public String graphMappings() {
-        return name("graph_mapping");
-    }
+	public String graphProperties() {
+		return name("graph_property");
+	}
 
-    public String blobs() {
-        return name("blob");
-    }
+	public String graphMappings() {
+		return name("graph_mapping");
+	}
 
-    public List<String> all() {
-        return ImmutableList.of(metadata(), repositories(), config(), refs(), conflicts(),
-                objects(), index(), indexMappings(), indexObjects(), commits(), features(),
-                featureTypes(), trees(), graphEdges(), graphMappings(), graphProperties(), blobs());
-    }
+	public String blobs() {
+		return name("blob");
+	}
+
+	public List<String> all() {
+		return ImmutableList.of(metadata(), repositories(), config(), refs(), conflicts(), objects(), index(),
+				indexMappings(), indexObjects(), commits(), features(), featureTypes(), trees(), graphEdges(),
+				graphMappings(), graphProperties(), blobs());
+	}
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/TableNames.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/TableNames.java
@@ -16,146 +16,147 @@ import com.google.common.collect.ImmutableList;
 
 public class TableNames implements Cloneable {
 
-	public static final String DEFAULT_SCHEMA = "public";
+    public static final String DEFAULT_SCHEMA = "public";
 
-	public static final String DEFAULT_TABLE_PREFIX = "geogig_";
+    public static final String DEFAULT_TABLE_PREFIX = "geogig_";
 
-	private final String schema;
+    private final String schema;
 
-	private final String prefix;
+    private final String prefix;
 
-	public TableNames() {
-		this(DEFAULT_SCHEMA);
-	}
+    public TableNames() {
+        this(DEFAULT_SCHEMA);
+    }
 
-	public TableNames(String schema) {
-		this(schema, DEFAULT_TABLE_PREFIX);
-	}
+    public TableNames(String schema) {
+        this(schema, DEFAULT_TABLE_PREFIX);
+    }
 
-	public TableNames(String schema, String prefix) {
-		Preconditions.checkNotNull(schema);
-		Preconditions.checkNotNull(prefix);
-		this.schema = schema;
-		this.prefix = prefix;
-	}
+    public TableNames(String schema, String prefix) {
+        Preconditions.checkNotNull(schema);
+        Preconditions.checkNotNull(prefix);
+        this.schema = schema;
+        this.prefix = prefix;
+    }
 
-	public String getPrefix() {
-		return prefix;
-	}
+    public String getPrefix() {
+        return prefix;
+    }
 
-	public String metadata() {
-		return name("medatada");
-	}
+    public String metadata() {
+        return name("medatada");
+    }
 
-	public String repositories() {
-		return name("repository");
-	}
+    public String repositories() {
+        return name("repository");
+    }
 
-	public String repositoryNamesView() {
-		return repositories() + "_name";
-	}
+    public String repositoryNamesView() {
+        return repositories() + "_name";
+    }
 
-	private String name(String name) {
-		return new StringBuilder(schema).append('.').append(prefix).append(name).toString();
-	}
+    private String name(String name) {
+        return new StringBuilder(schema).append('.').append(prefix).append(name).toString();
+    }
 
-	public String refs() {
-		return name("ref");
-	}
+    public String refs() {
+        return name("ref");
+    }
 
-	public String objects() {
-		return name("object");
-	}
+    public String objects() {
+        return name("object");
+    }
 
-	public String index() {
-		return name("index");
-	}
+    public String index() {
+        return name("index");
+    }
 
-	public String indexMappings() {
-		return name("index_mappings");
-	}
+    public String indexMappings() {
+        return name("index_mappings");
+    }
 
-	public String indexObjects() {
-		return name("index_object");
-	}
+    public String indexObjects() {
+        return name("index_object");
+    }
 
-	private int featuresTablePartitionCount = 16;
+    private int featuresTablePartitionCount = 16;
 
-	void setFeaturesPartitions(int featuresTablePartitionCount) {
-		Preconditions.checkArgument(featuresTablePartitionCount >= 0 && featuresTablePartitionCount <= 256);
-		this.featuresTablePartitionCount = featuresTablePartitionCount;
-	}
+    void setFeaturesPartitions(int featuresTablePartitionCount) {
+        Preconditions.checkArgument(
+                featuresTablePartitionCount >= 0 && featuresTablePartitionCount <= 256);
+        this.featuresTablePartitionCount = featuresTablePartitionCount;
+    }
 
-	public String features(final int hash) {
-		if (0 == featuresTablePartitionCount) {
-			return features();
-		}
-		final int min = Integer.MIN_VALUE;
-		final long max = (long) Integer.MAX_VALUE + 1;
-		final int numTables = featuresTablePartitionCount;
-		final int step = (int) (((long) max - (long) min) / numTables);
+    public String features(final int hash) {
+        if (0 == featuresTablePartitionCount) {
+            return features();
+        }
+        final int min = Integer.MIN_VALUE;
+        final long max = (long) Integer.MAX_VALUE + 1;
+        final int numTables = featuresTablePartitionCount;
+        final int step = (int) (((long) max - (long) min) / numTables);
 
-		int index = 0;
-		long curr = min;
-		for (int i = 0; i < numTables; i++) {
-			long next = curr + step;
-			if (hash >= curr && hash < next) {
-				index = i;
-				break;
-			}
-			curr = next;
-		}
-		return String.format("%s_%d", features(), index);
-	}
+        int index = 0;
+        long curr = min;
+        for (int i = 0; i < numTables; i++) {
+            long next = curr + step;
+            if (hash >= curr && hash < next) {
+                index = i;
+                break;
+            }
+            curr = next;
+        }
+        return String.format("%s_%d", features(), index);
+    }
 
-	public String features() {
-		return name("object_feature");
-	}
+    public String features() {
+        return name("object_feature");
+    }
 
-	public String featureTypes() {
-		return name("object_featuretype");
-	}
+    public String featureTypes() {
+        return name("object_featuretype");
+    }
 
-	public String tags() {
-		return name("object_tag");
-	}
+    public String tags() {
+        return name("object_tag");
+    }
 
-	public String trees() {
-		return name("object_tree");
-	}
+    public String trees() {
+        return name("object_tree");
+    }
 
-	public String commits() {
-		return name("object_commit");
-	}
+    public String commits() {
+        return name("object_commit");
+    }
 
-	public String config() {
-		return name("config");
-	}
+    public String config() {
+        return name("config");
+    }
 
-	public String conflicts() {
-		return name("conflict");
-	}
+    public String conflicts() {
+        return name("conflict");
+    }
 
-	public String graphEdges() {
-		return name("graph_edge");
-	}
+    public String graphEdges() {
+        return name("graph_edge");
+    }
 
-	public String graphProperties() {
-		return name("graph_property");
-	}
+    public String graphProperties() {
+        return name("graph_property");
+    }
 
-	public String graphMappings() {
-		return name("graph_mapping");
-	}
+    public String graphMappings() {
+        return name("graph_mapping");
+    }
 
-	public String blobs() {
-		return name("blob");
-	}
+    public String blobs() {
+        return name("blob");
+    }
 
-	public List<String> all() {
-		return ImmutableList.of(metadata(), repositories(), config(), refs(), conflicts(), objects(), index(),
-				indexMappings(), indexObjects(), commits(), features(), featureTypes(), trees(), graphEdges(),
-				graphMappings(), graphProperties(), blobs());
-	}
+    public List<String> all() {
+        return ImmutableList.of(metadata(), repositories(), config(), refs(), conflicts(),
+                objects(), index(), indexMappings(), indexObjects(), commits(), features(),
+                featureTypes(), trees(), graphEdges(), graphMappings(), graphProperties(), blobs());
+    }
 
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Version.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Version.java
@@ -9,9 +9,12 @@
  */
 package org.locationtech.geogig.storage.postgresql.config;
 
+import java.util.List;
 import java.util.Objects;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
 
 /**
  * Server version, given by it's major, minor, and patch numbers
@@ -21,70 +24,97 @@ import com.google.common.base.Preconditions;
  */
 public class Version implements Comparable<Version> {
 
-    public static final Version V9_4_0 = new Version(9, 4, 0);
+	public static final Version V9_4_0 = new Version(9, 4, 0);
 
-    public static final Version V9_5_0 = new Version(9, 5, 0);
+	public static final Version V9_5_0 = new Version(9, 5, 0);
 
-    public static final Version V9_6_0 = new Version(9, 6, 0);
+	public static final Version V9_6_0 = new Version(9, 6, 0);
 
-    public static final Version V10_0_0 = new Version(10, 0, 0);
+	public static final Version V10_0_0 = new Version(10, 0, 0);
 
-    public final int major;
+	public final int major;
 
-    public final int minor;
+	public final int minor;
 
-    public final int patch;
+	public final int patch;
 
-    Version(int major, int minor, int patch) {
-        this.major = major;
-        this.minor = minor;
-        this.patch = patch;
-    }
+	Version(int major, int minor, int patch) {
+		this.major = major;
+		this.minor = minor;
+		this.patch = patch;
+	}
 
-    public @Override int compareTo(Version o) {
-        int compare = Integer.compare(major, o.major);
-        if (0 == compare) {
-            compare = Integer.compare(minor, o.minor);
-            if (0 == compare) {
-                compare = Integer.compare(patch, o.patch);
-            }
-        }
-        return compare;
-    }
+	public @Override int compareTo(Version o) {
+		int compare = Integer.compare(major, o.major);
+		if (0 == compare) {
+			compare = Integer.compare(minor, o.minor);
+			if (0 == compare) {
+				compare = Integer.compare(patch, o.patch);
+			}
+		}
+		return compare;
+	}
 
-    public @Override boolean equals(Object o) {
-        if (!(o instanceof Version)) {
-            return false;
-        }
-        Version v = (Version) o;
-        return major == v.major && minor == v.minor && patch == v.patch;
-    }
+	public @Override boolean equals(Object o) {
+		if (!(o instanceof Version)) {
+			return false;
+		}
+		Version v = (Version) o;
+		return major == v.major && minor == v.minor && patch == v.patch;
+	}
 
-    public @Override int hashCode() {
-        return Objects.hash(major, minor, patch);
-    }
+	public @Override int hashCode() {
+		return Objects.hash(major, minor, patch);
+	}
 
-    public @Override String toString() {
-        return String.format("%d.%d.%d", major, minor, patch);
-    }
+	public @Override String toString() {
+		return String.format("%d.%d.%d", major, minor, patch);
+	}
 
-    public boolean lowerThan(Version v) {
-        Preconditions.checkNotNull(v);
-        return compareTo(v) < 0;
-    }
+	public boolean lowerThan(Version v) {
+		Preconditions.checkNotNull(v);
+		return compareTo(v) < 0;
+	}
 
-    public boolean lowerOrEqualTo(Version v) {
-        Preconditions.checkNotNull(v);
-        return compareTo(v) <= 0;
-    }
+	public boolean lowerOrEqualTo(Version v) {
+		Preconditions.checkNotNull(v);
+		return compareTo(v) <= 0;
+	}
 
-    public boolean greatherThan(Version v) {
-        Preconditions.checkNotNull(v);
-        return compareTo(v) > 0;
-    }
+	public boolean greatherThan(Version v) {
+		Preconditions.checkNotNull(v);
+		return compareTo(v) > 0;
+	}
 
-    public boolean greatherOrEqualTo(Version v) {
-        Preconditions.checkNotNull(v);
-        return compareTo(v) >= 0;
-    }
+	public boolean greatherOrEqualTo(Version v) {
+		Preconditions.checkNotNull(v);
+		return compareTo(v) >= 0;
+	}
+
+	public static Version valueOf(final String versionQueryResult) {
+		// version string may not be a simple x.y.x value. Let's just take it from the
+		// front and
+		// stop at the first
+		// non-digit, non-decimal-point character
+		final String regex = "[^0-9.]";
+		// replace first non-digit, non-decimal point with XXX
+		String marked = versionQueryResult.replaceFirst(regex, "XXX");
+		if (marked.contains("XXX")) {
+			// no throw away everything starting with XXX
+			marked = marked.substring(0, marked.indexOf("XXX"));
+		}
+		final List<Integer> versions = Lists.transform(Splitter.on('.').splitToList(marked),
+				(s) -> Integer.parseInt(s));
+		// version string can be either
+		// {major}.{minor}.{patch}
+		// or (since PostgreSQL 10)
+		// {major}.{minor}
+		Preconditions.checkState(versions.size() == 3 || versions.size() == 2,
+				"Expected version format x.y.z or x.y, got " + versionQueryResult);
+		int major = versions.get(0).intValue();
+		int minor = versions.get(1).intValue();
+		// patch may not be present. If not, just use 0
+		int patch = (versions.size() == 3) ? versions.get(2).intValue() : 0;
+		return new Version(major, minor, patch);
+	}
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Version.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/config/Version.java
@@ -24,97 +24,97 @@ import com.google.common.collect.Lists;
  */
 public class Version implements Comparable<Version> {
 
-	public static final Version V9_4_0 = new Version(9, 4, 0);
+    public static final Version V9_4_0 = new Version(9, 4, 0);
 
-	public static final Version V9_5_0 = new Version(9, 5, 0);
+    public static final Version V9_5_0 = new Version(9, 5, 0);
 
-	public static final Version V9_6_0 = new Version(9, 6, 0);
+    public static final Version V9_6_0 = new Version(9, 6, 0);
 
-	public static final Version V10_0_0 = new Version(10, 0, 0);
+    public static final Version V10_0_0 = new Version(10, 0, 0);
 
-	public final int major;
+    public final int major;
 
-	public final int minor;
+    public final int minor;
 
-	public final int patch;
+    public final int patch;
 
-	Version(int major, int minor, int patch) {
-		this.major = major;
-		this.minor = minor;
-		this.patch = patch;
-	}
+    Version(int major, int minor, int patch) {
+        this.major = major;
+        this.minor = minor;
+        this.patch = patch;
+    }
 
-	public @Override int compareTo(Version o) {
-		int compare = Integer.compare(major, o.major);
-		if (0 == compare) {
-			compare = Integer.compare(minor, o.minor);
-			if (0 == compare) {
-				compare = Integer.compare(patch, o.patch);
-			}
-		}
-		return compare;
-	}
+    public @Override int compareTo(Version o) {
+        int compare = Integer.compare(major, o.major);
+        if (0 == compare) {
+            compare = Integer.compare(minor, o.minor);
+            if (0 == compare) {
+                compare = Integer.compare(patch, o.patch);
+            }
+        }
+        return compare;
+    }
 
-	public @Override boolean equals(Object o) {
-		if (!(o instanceof Version)) {
-			return false;
-		}
-		Version v = (Version) o;
-		return major == v.major && minor == v.minor && patch == v.patch;
-	}
+    public @Override boolean equals(Object o) {
+        if (!(o instanceof Version)) {
+            return false;
+        }
+        Version v = (Version) o;
+        return major == v.major && minor == v.minor && patch == v.patch;
+    }
 
-	public @Override int hashCode() {
-		return Objects.hash(major, minor, patch);
-	}
+    public @Override int hashCode() {
+        return Objects.hash(major, minor, patch);
+    }
 
-	public @Override String toString() {
-		return String.format("%d.%d.%d", major, minor, patch);
-	}
+    public @Override String toString() {
+        return String.format("%d.%d.%d", major, minor, patch);
+    }
 
-	public boolean lowerThan(Version v) {
-		Preconditions.checkNotNull(v);
-		return compareTo(v) < 0;
-	}
+    public boolean lowerThan(Version v) {
+        Preconditions.checkNotNull(v);
+        return compareTo(v) < 0;
+    }
 
-	public boolean lowerOrEqualTo(Version v) {
-		Preconditions.checkNotNull(v);
-		return compareTo(v) <= 0;
-	}
+    public boolean lowerOrEqualTo(Version v) {
+        Preconditions.checkNotNull(v);
+        return compareTo(v) <= 0;
+    }
 
-	public boolean greatherThan(Version v) {
-		Preconditions.checkNotNull(v);
-		return compareTo(v) > 0;
-	}
+    public boolean greatherThan(Version v) {
+        Preconditions.checkNotNull(v);
+        return compareTo(v) > 0;
+    }
 
-	public boolean greatherOrEqualTo(Version v) {
-		Preconditions.checkNotNull(v);
-		return compareTo(v) >= 0;
-	}
+    public boolean greatherOrEqualTo(Version v) {
+        Preconditions.checkNotNull(v);
+        return compareTo(v) >= 0;
+    }
 
-	public static Version valueOf(final String versionQueryResult) {
-		// version string may not be a simple x.y.x value. Let's just take it from the
-		// front and
-		// stop at the first
-		// non-digit, non-decimal-point character
-		final String regex = "[^0-9.]";
-		// replace first non-digit, non-decimal point with XXX
-		String marked = versionQueryResult.replaceFirst(regex, "XXX");
-		if (marked.contains("XXX")) {
-			// no throw away everything starting with XXX
-			marked = marked.substring(0, marked.indexOf("XXX"));
-		}
-		final List<Integer> versions = Lists.transform(Splitter.on('.').splitToList(marked),
-				(s) -> Integer.parseInt(s));
-		// version string can be either
-		// {major}.{minor}.{patch}
-		// or (since PostgreSQL 10)
-		// {major}.{minor}
-		Preconditions.checkState(versions.size() == 3 || versions.size() == 2,
-				"Expected version format x.y.z or x.y, got " + versionQueryResult);
-		int major = versions.get(0).intValue();
-		int minor = versions.get(1).intValue();
-		// patch may not be present. If not, just use 0
-		int patch = (versions.size() == 3) ? versions.get(2).intValue() : 0;
-		return new Version(major, minor, patch);
-	}
+    public static Version valueOf(final String versionQueryResult) {
+        // version string may not be a simple x.y.x value. Let's just take it from the
+        // front and
+        // stop at the first
+        // non-digit, non-decimal-point character
+        final String regex = "[^0-9.]";
+        // replace first non-digit, non-decimal point with XXX
+        String marked = versionQueryResult.replaceFirst(regex, "XXX");
+        if (marked.contains("XXX")) {
+            // no throw away everything starting with XXX
+            marked = marked.substring(0, marked.indexOf("XXX"));
+        }
+        final List<Integer> versions = Lists.transform(Splitter.on('.').splitToList(marked),
+                (s) -> Integer.parseInt(s));
+        // version string can be either
+        // {major}.{minor}.{patch}
+        // or (since PostgreSQL 10)
+        // {major}.{minor}
+        Preconditions.checkState(versions.size() == 3 || versions.size() == 2,
+                "Expected version format x.y.z or x.y, got " + versionQueryResult);
+        int major = versions.get(0).intValue();
+        int minor = versions.get(1).intValue();
+        // patch may not be present. If not, just use 0
+        int patch = (versions.size() == 3) ? versions.get(2).intValue() : 0;
+        return new Version(major, minor, patch);
+    }
 }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/GetAllOp.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/GetAllOp.java
@@ -70,18 +70,21 @@ class GetAllOp<T extends RevObject> implements Callable<List<T>> {
                     tableName);
 
             try (Connection cx = PGStorage.newConnection(db.dataSource)) {
-                try (PreparedStatement ps = cx.prepareStatement(log(sql, PGObjectStore.LOG, queryIds))) {
+                try (PreparedStatement ps = cx
+                        .prepareStatement(log(sql, PGObjectStore.LOG, queryIds))) {
                     final Array array = toJDBCArray(cx, queryIds);
                     ps.setFetchSize(queryCount);
                     ps.setArray(1, array);
 
-                    final Stopwatch sw = PGObjectStore.LOG.isTraceEnabled() ? Stopwatch.createStarted()
+                    final Stopwatch sw = PGObjectStore.LOG.isTraceEnabled()
+                            ? Stopwatch.createStarted()
                             : null;
 
                     try (ResultSet rs = ps.executeQuery()) {
                         if (PGObjectStore.LOG.isTraceEnabled()) {
-                            PGObjectStore.LOG.trace(String.format("Executed getAll for %,d ids in %,dms",
-                                    queryCount, sw.elapsed(TimeUnit.MILLISECONDS)));
+                            PGObjectStore.LOG
+                                    .trace(String.format("Executed getAll for %,d ids in %,dms",
+                                            queryCount, sw.elapsed(TimeUnit.MILLISECONDS)));
                         }
                         while (rs.next()) {
                             id = PGId.valueOf(rs, 1).toObjectId();

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/GetObjectOp.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/GetObjectOp.java
@@ -70,7 +70,8 @@ class GetObjectOp<T extends RevObject> implements Callable<List<ObjectInfo<T>>> 
 
             final Array array = toJDBCArray(cx, queryNodes);
 
-            try (PreparedStatement ps = cx.prepareStatement(log(sql, PGObjectStore.LOG, queryNodes))) {
+            try (PreparedStatement ps = cx
+                    .prepareStatement(log(sql, PGObjectStore.LOG, queryNodes))) {
                 ps.setFetchSize(queryCount);
                 ps.setArray(1, array);
 

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGConfigDatabase.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGConfigDatabase.java
@@ -495,6 +495,7 @@ public class PGConfigDatabase implements ConfigDatabase {
             if (!PGStorage.tableExists(this.dataSource, config.getTables().config())) {
                 PGStorage.createTables(config);
             }
+            PGStorage.verifyDatabaseCompatibility(dataSource, config);
         }
         return dataSource;
     }

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGObjectStoreGetAllIterator.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGObjectStoreGetAllIterator.java
@@ -43,8 +43,8 @@ class PGObjectStoreGetAllIterator<T extends RevObject> extends AbstractIterator<
 
     final ObjectCache cache;
 
-    public PGObjectStoreGetAllIterator(Iterator<ObjectId> ids, Class<T> type, BulkOpListener listener,
-            PGObjectStore store) {
+    public PGObjectStoreGetAllIterator(Iterator<ObjectId> ids, Class<T> type,
+            BulkOpListener listener, PGObjectStore store) {
         this.ids = Iterators.peekingIterator(ids);
         this.type = type;
         this.listener = listener;

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGObjectStoreObjectIterator.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGObjectStoreObjectIterator.java
@@ -51,8 +51,8 @@ class PGObjectStoreObjectIterator<T extends RevObject>
 
     private ObjectInfo<T> next;
 
-    public PGObjectStoreObjectIterator(Iterator<NodeRef> refs, Class<T> type, BulkOpListener listener,
-            PGObjectStore store) {
+    public PGObjectStoreObjectIterator(Iterator<NodeRef> refs, Class<T> type,
+            BulkOpListener listener, PGObjectStore store) {
         this.nodes = Iterators.peekingIterator(refs);
         this.type = type;
         this.listener = listener;
@@ -136,8 +136,7 @@ class PGObjectStoreObjectIterator<T extends RevObject>
             futures.add(dbBatch);
         }
 
-        final Function<Future<List<ObjectInfo<T>>>, List<ObjectInfo<T>>> futureGetter = (
-                objs) -> {
+        final Function<Future<List<ObjectInfo<T>>>, List<ObjectInfo<T>>> futureGetter = (objs) -> {
             try {
                 return objs.get();
             } catch (InterruptedException | ExecutionException e) {

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilderTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/config/EnvironmentBuilderTest.java
@@ -26,12 +26,14 @@ public class EnvironmentBuilderTest {
 
     private static final String UTF8 = StandardCharsets.UTF_8.name();
 
-    private URI buildUri(String host, @Nullable Integer port, String dbName, @Nullable String schema, String repoName,
-            String user, String password) throws URISyntaxException, UnsupportedEncodingException {
+    private URI buildUri(String host, @Nullable Integer port, String dbName,
+            @Nullable String schema, String repoName, String user, String password)
+            throws URISyntaxException, UnsupportedEncodingException {
         /**
-         * Using Spring's URI builder utils here because java.net.URI doesn't handle special characters in the query
-         * parameter encoding correctly. If we want to build a URI with host=localhost, port=5432, dbName=myDb,
-         * schema=mySchema, repoName=myRepo, user=myUser and password=myPass&word, the URI should look like this:
+         * Using Spring's URI builder utils here because java.net.URI doesn't handle special
+         * characters in the query parameter encoding correctly. If we want to build a URI with
+         * host=localhost, port=5432, dbName=myDb, schema=mySchema, repoName=myRepo, user=myUser and
+         * password=myPass&word, the URI should look like this:
          * <p>
          * postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%26word
          * <p>
@@ -39,22 +41,25 @@ public class EnvironmentBuilderTest {
          * <p>
          * "postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass&word"
          * <p>
-         * java.net.URI will try to Encode the String, but will interpret the `&` in the password value as a query
-         * parameter delimiter, in this case yielding 3 query parameters: user, password and myPass.
+         * java.net.URI will try to Encode the String, but will interpret the `&` in the password
+         * value as a query parameter delimiter, in this case yielding 3 query parameters: user,
+         * password and myPass.
          * <p>
          * If we URLEncode the password value before building the URI, using this string:
          * <p>
          * "postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%26word"
          * <p>
-         * java.net.URI will try to Encode the String anyway, thus double encoding the password value, resulting in:
+         * java.net.URI will try to Encode the String anyway, thus double encoding the password
+         * value, resulting in:
          * <p>
          * postgresql://localhost:5432/myDb/mySchema/myRepo?user=myUser&password=myPass%2526word
          * <p>
-         * java.net.URI doesn't have a way to construct a URI with a pre-encoded query parameter value, so there isn't
-         * a way to use it to correctly encode special characters in query parameter values. Using Spring-web's
-         * URIComponentsBuilder, we can URLEncode the parameter values first, then build a URIComponents such that
-         * the URI doesn't double encode the query parameter by using URIComponentsBuilder.build(true), which tells
-         * the builder that the URI is already encoded.
+         * java.net.URI doesn't have a way to construct a URI with a pre-encoded query parameter
+         * value, so there isn't a way to use it to correctly encode special characters in query
+         * parameter values. Using Spring-web's URIComponentsBuilder, we can URLEncode the parameter
+         * values first, then build a URIComponents such that the URI doesn't double encode the
+         * query parameter by using URIComponentsBuilder.build(true), which tells the builder that
+         * the URI is already encoded.
          */
         UriComponentsBuilder builder = UriComponentsBuilder.newInstance();
         // set the scheme
@@ -82,8 +87,9 @@ public class EnvironmentBuilderTest {
         return builder.build(true).toUri();
     }
 
-    private void test(String host, @Nullable Integer port, String dbName, @Nullable String schema, String repoName,
-            String user, String password) throws URISyntaxException, UnsupportedEncodingException {
+    private void test(String host, @Nullable Integer port, String dbName, @Nullable String schema,
+            String repoName, String user, String password)
+            throws URISyntaxException, UnsupportedEncodingException {
         // build the URI
         URI uri = buildUri(host, port, dbName, schema, repoName, user, password);
         // Build an Environment
@@ -113,19 +119,22 @@ public class EnvironmentBuilderTest {
     }
 
     @Test
-    public void testextractShortKeys_withPassword_hash() throws URISyntaxException, UnsupportedEncodingException {
+    public void testextractShortKeys_withPassword_hash()
+            throws URISyntaxException, UnsupportedEncodingException {
         // test some basic values
         test("testHost", null, "testDb", null, "testRepo", "testUser", "test#Password");
     }
 
     @Test
-    public void testextractShortKeys_withPassword_ampersand() throws URISyntaxException, UnsupportedEncodingException {
+    public void testextractShortKeys_withPassword_ampersand()
+            throws URISyntaxException, UnsupportedEncodingException {
         // test some basic values
         test("testHost", null, "testDb", null, "testRepo", "testUser", "test&Password");
     }
 
     @Test
-    public void testextractShortKeys_withPassword_multiSpecial() throws URISyntaxException, UnsupportedEncodingException {
+    public void testextractShortKeys_withPassword_multiSpecial()
+            throws URISyntaxException, UnsupportedEncodingException {
         // test some basic values
         test("testHost", null, "testDb", null, "testRepo", "testUser", "!@#$%^&*()");
     }

--- a/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/v9/PGConflictsDatabaseTest.java
+++ b/src/storage/postgres/src/test/java/org/locationtech/geogig/storage/postgresql/v9/PGConflictsDatabaseTest.java
@@ -45,8 +45,8 @@ import org.mockito.runners.MockitoJUnitRunner;
 @RunWith(MockitoJUnitRunner.class)
 public class PGConflictsDatabaseTest {
 
-    private static final Conflict c1 = new Conflict("Rivers/1", NULL, RevObjectTestSupport.hashString("ours"),
-            RevObjectTestSupport.hashString("theirs"));
+    private static final Conflict c1 = new Conflict("Rivers/1", NULL,
+            RevObjectTestSupport.hashString("ours"), RevObjectTestSupport.hashString("theirs"));
 
     @Rule
     public ExpectedException expected = ExpectedException.none();


### PR DESCRIPTION
Forward-port from #468:

Add CLI commands ls-repos, postgres-ddl, and postgres-upgrade

* `ls-repos` show repository names at a given base URI (i.e. directory
or database). The verbose option can be used to generate CSV or a nice
table with some extra information like number of branches, commits,
feature types, and features per repository.

* `postgres-ddl` is an utility to generate the DDL script to initialize
a PostgreSQL database to be used by Geogig. Most of the time Geogig
does it all by itself when first accessing the database, but it could be
the case where the database user used to connect with has no enough
proviledges and the script needs to be run by hand using psql for
example.

* `postgres-upgrade` is an utility to upgrade an existing geogig database
from any geogig version prior to 1.2.1. It will create a geogig_metadata
table and add a column to geogig_graph_edge in that is used to ensure the
correct order of commit parents in a commit graph traversal. Curiously,
in Postgres 9.4 it worked by accident, but Postgres 9.5+ returns the
parents in different order unless the query instructs it how to, which
is ok and exposed a bug in geogig itself.