### PR TITLE
Move ObjectSerializingFactory to api's RevObjectSerializer

### DIFF
--- a/src/api/src/main/java/org/locationtech/geogig/storage/RevObjectSerializer.java
+++ b/src/api/src/main/java/org/locationtech/geogig/storage/RevObjectSerializer.java
@@ -7,7 +7,7 @@
  * Contributors:
  * David Winslow (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.impl;
+package org.locationtech.geogig.storage;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -18,11 +18,10 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
 
 /**
- * The ObjectSerializingFactory is used to create instances of the various writers and readers used
- * to work with the serialized forms of various repository elements.
+ * Defines a serialization/de-serialization mechanism for {@link RevObject} instances
  * 
  */
-public interface ObjectSerializingFactory {
+public interface RevObjectSerializer {
 
     void write(RevObject o, OutputStream out) throws IOException;
 

--- a/src/cli/core/src/main/java/org/locationtech/geogig/cli/plumbing/Cat.java
+++ b/src/cli/core/src/main/java/org/locationtech/geogig/cli/plumbing/Cat.java
@@ -21,8 +21,8 @@ import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.plumbing.CatObject;
 import org.locationtech.geogig.plumbing.RevObjectParse;
 import org.locationtech.geogig.repository.impl.GeoGIG;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 import com.beust.jcommander.Parameter;
 import com.beust.jcommander.Parameters;
@@ -69,7 +69,7 @@ public class Cat extends AbstractCommand {
         }
         checkParameter(obj.isPresent(), "refspec did not resolve to any object.");
         if (binary) {
-            ObjectSerializingFactory factory = DataStreamSerializationFactoryV1.INSTANCE;
+            RevObjectSerializer factory = DataStreamSerializationFactoryV1.INSTANCE;
             factory.write(obj.get(), System.out);
         } else {
             CharSequence s = geogig.command(CatObject.class)

--- a/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
+++ b/src/core/src/main/java/org/locationtech/geogig/di/GeogigModule.java
@@ -24,9 +24,9 @@ import org.locationtech.geogig.storage.ConfigDatabase;
 import org.locationtech.geogig.storage.ConflictsDatabase;
 import org.locationtech.geogig.storage.IndexDatabase;
 import org.locationtech.geogig.storage.ObjectDatabase;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.RefDatabase;
 import org.locationtech.geogig.storage.fs.IniFileConfigDatabase;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 import com.google.inject.AbstractModule;
 import com.google.inject.Binder;
@@ -47,7 +47,7 @@ import com.google.inject.util.Providers;
  * @see ObjectDatabase
  * @see StagingDatabase
  * @see RefDatabase
- * @see ObjectSerializingFactory
+ * @see RevObjectSerializer
  */
 
 public class GeogigModule extends AbstractModule {

--- a/src/core/src/main/java/org/locationtech/geogig/storage/cache/CacheManager.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/cache/CacheManager.java
@@ -29,12 +29,15 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.ServiceFinder;
 import org.locationtech.geogig.storage.ObjectStore;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ConnectionManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
+
+import lombok.NonNull;
 
 /**
  * Manages a pool of {@link ObjectCache} operating against a single internal shared cache.
@@ -130,6 +133,10 @@ public class CacheManager implements CacheManagerBean {
         return _SHARED_CACHE;
     }
 
+    public void setEncoder(@NonNull RevObjectSerializer encoder) {
+        sharedCache().setEncoder(encoder);
+    }
+    
     /**
      * Resolves the default maximum cache size in bytes.
      * <p>

--- a/src/core/src/main/java/org/locationtech/geogig/storage/cache/SharedCache.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/cache/SharedCache.java
@@ -15,7 +15,7 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.storage.ObjectStore;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 
 /**
  * A {@link RevObject} cache to be used by multiple {@link ObjectStore} instances operating upon a
@@ -42,12 +42,12 @@ public interface SharedCache {
      */
     static final SharedCache NO_CACHE = new SharedCache() {
         @Override
-        public void setEncoder(ObjectSerializingFactory encoder) {
+        public void setEncoder(RevObjectSerializer encoder) {
             // nothing to do
         }
     };
 
-    public void setEncoder(ObjectSerializingFactory encoder);
+    public void setEncoder(RevObjectSerializer encoder);
 
     /**
      * Creates and returns a shared cache with the given maximum heap memory capacity in bytes.

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1.java
@@ -49,8 +49,8 @@ import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevObjects;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectReader;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.storage.impl.ObjectWriter;
 import org.opengis.feature.type.GeometryType;
 import org.opengis.feature.type.Name;
@@ -65,7 +65,7 @@ import com.google.common.base.Throwables;
 import com.google.common.collect.Maps;
 import org.locationtech.jts.geom.Envelope;
 
-public class DataStreamSerializationFactoryV1 implements ObjectSerializingFactory {
+public class DataStreamSerializationFactoryV1 implements RevObjectSerializer {
 
     /**
      * factory singleton

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2.java
@@ -27,8 +27,8 @@ import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectReader;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.storage.impl.ObjectWriter;
 
 import com.google.common.base.Preconditions;
@@ -37,7 +37,7 @@ import com.google.common.io.ByteStreams;
 /**
  * Serialization factory for serial version 2
  */
-public class DataStreamSerializationFactoryV2 implements ObjectSerializingFactory {
+public class DataStreamSerializationFactoryV2 implements RevObjectSerializer {
 
     public static final DataStreamSerializationFactoryV2 INSTANCE = new DataStreamSerializationFactoryV2();
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/FormatCommonV1.java
@@ -116,12 +116,14 @@ public class FormatCommonV1 {
     private static final FeatureTypeFactory DEFAULT_FEATURETYPE_FACTORY = new SimpleFeatureTypeBuilder()
             .getFeatureTypeFactory();
 
-    public static RevTag readTag(ObjectId id, DataInput in) throws IOException {
+    public static RevTag readTag(@Nullable ObjectId id, DataInput in) throws IOException {
         final ObjectId commitId = readObjectId(in);
         final String name = in.readUTF();
         final String message = in.readUTF();
         final RevPerson tagger = readRevPerson(in);
-
+        if (id == null) {
+            return RevTagBuilder.build(name, commitId, message, tagger);
+        }
         return RevObjectFactory.defaultInstance().createTag(id, name, commitId, message, tagger);
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZ4SerializationFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZ4SerializationFactory.java
@@ -18,7 +18,7 @@ import java.util.zip.Checksum;
 import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Preconditions;
@@ -38,7 +38,7 @@ import net.jpountz.xxhash.XXHashFactory;
  * <a href="https://github.com/lz4/lz4-java/issues/48">lz-java issue #48</a>.
  */
 @Beta
-public class LZ4SerializationFactory implements ObjectSerializingFactory {
+public class LZ4SerializationFactory implements RevObjectSerializer {
 
     // cache factory to avoid thread contention when looking up for the fastest instance on some LZ4
     // lib synchronized blocks
@@ -50,9 +50,9 @@ public class LZ4SerializationFactory implements ObjectSerializingFactory {
 
     private static final int DEFAULT_SEED = 0x9747b28c;
 
-    private final ObjectSerializingFactory factory;
+    private final RevObjectSerializer factory;
 
-    public LZ4SerializationFactory(final ObjectSerializingFactory factory) {
+    public LZ4SerializationFactory(final RevObjectSerializer factory) {
         Preconditions.checkNotNull(factory);
         this.factory = factory;
     }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactory.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactory.java
@@ -16,7 +16,7 @@ import java.io.OutputStream;
 import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 
 import com.google.common.base.Preconditions;
 import com.ning.compress.lzf.ChunkDecoder;
@@ -28,9 +28,9 @@ import com.ning.compress.lzf.util.ChunkDecoderFactory;
 /**
  * Wrapper Factory that deflates/inflates data written to/read from streams using LZF compression.
  */
-public class LZFSerializationFactory implements ObjectSerializingFactory {
+public class LZFSerializationFactory implements RevObjectSerializer {
 
-    private final ObjectSerializingFactory factory;
+    private final RevObjectSerializer factory;
 
     /**
      * ChunkDecoder is stateless and can be reused concurrently, so cache it to avoid the factory
@@ -38,7 +38,7 @@ public class LZFSerializationFactory implements ObjectSerializingFactory {
      */
     private static final ChunkDecoder CHUNK_DECODER = ChunkDecoderFactory.optimalInstance();
 
-    public LZFSerializationFactory(final ObjectSerializingFactory factory) {
+    public LZFSerializationFactory(final RevObjectSerializer factory) {
         Preconditions.checkNotNull(factory);
         this.factory = factory;
     }

--- a/src/core/src/main/java/org/locationtech/geogig/storage/impl/AbstractObjectStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/impl/AbstractObjectStore.java
@@ -30,6 +30,7 @@ import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTag;
 import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.storage.BulkOpListener;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 
@@ -42,23 +43,23 @@ import com.google.common.io.Closeables;
  */
 public abstract class AbstractObjectStore implements ObjectStore {
 
-    private ObjectSerializingFactory serializer;
+    private RevObjectSerializer serializer;
 
     public AbstractObjectStore() {
         this(new SerializationFactoryProxy());
     }
 
-    public AbstractObjectStore(final ObjectSerializingFactory serializer) {
+    public AbstractObjectStore(final RevObjectSerializer serializer) {
         checkNotNull(serializer);
         this.serializer = serializer;
     }
 
-    protected void setSerializationFactory(ObjectSerializingFactory serializer) {
+    protected void setSerializationFactory(RevObjectSerializer serializer) {
         checkNotNull(serializer);
         this.serializer = serializer;
     }
 
-    public ObjectSerializingFactory serializer() {
+    public RevObjectSerializer serializer() {
         return serializer;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/cache/CacheManagerTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/cache/CacheManagerTest.java
@@ -34,7 +34,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.locationtech.geogig.model.RevObject;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -70,7 +70,7 @@ public class CacheManagerTest {
         public static class TestCache implements SharedCache {
             private ConcurrentHashMap<CacheKey, RevObject> map = new ConcurrentHashMap<>();
 
-            public @Override void setEncoder(ObjectSerializingFactory encoder) {
+            public @Override void setEncoder(RevObjectSerializer encoder) {
                 // do nothing
             }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/cache/ObjectCacheStressTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/cache/ObjectCacheStressTest.java
@@ -30,9 +30,9 @@ import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.model.impl.RevObjectTestSupport;
 import org.locationtech.geogig.model.impl.RevTreeBuilder;
 import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.LZ4SerializationFactory;
 import org.locationtech.geogig.storage.datastream.v2_3.DataStreamSerializationFactoryV2_3;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.collect.ImmutableList;
@@ -56,7 +56,7 @@ public class ObjectCacheStressTest {
 
     private List<RevTree> bucketTrees;
 
-    private static final List<ObjectSerializingFactory> encoders = ImmutableList.of(//
+    private static final List<RevObjectSerializer> encoders = ImmutableList.of(//
             // raw encoders
             // DataStreamSerializationFactoryV1.INSTANCE //
             // , DataStreamSerializationFactoryV2.INSTANCE //
@@ -138,13 +138,13 @@ public class ObjectCacheStressTest {
         System.err.println(
                 "----------------------------------------------------------------------------------");
         System.err.printf("Format\t\t Count\t Hits\t Insert\t\t Query\t\t Size\t\t Stats\n");
-        for (ObjectSerializingFactory encoder : encoders) {
+        for (RevObjectSerializer encoder : encoders) {
             cache.invalidateAll();
             run(encoder, objects);
         }
     }
 
-    public void run(ObjectSerializingFactory encoder, List<? extends RevObject> objects) {
+    public void run(RevObjectSerializer encoder, List<? extends RevObject> objects) {
         // cache.setEncoder(encoder);
         final Stopwatch put = put(objects);
         try {

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV1Test.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class DataStreamSerializationFactoryV1Test extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return DataStreamSerializationFactoryV1.INSTANCE;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2Test.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class DataStreamSerializationFactoryV2Test extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return DataStreamSerializationFactoryV2.INSTANCE;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_1Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_1Test.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class DataStreamSerializationFactoryV2_1Test extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return DataStreamSerializationFactoryV2_1.INSTANCE;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_2Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/DataStreamSerializationFactoryV2_2Test.java
@@ -17,16 +17,15 @@ import org.locationtech.geogig.model.Bounded;
 import org.locationtech.geogig.model.CanonicalNodeOrder;
 import org.locationtech.geogig.model.RevObjects;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
-
 import org.locationtech.jts.geom.Envelope;
 
 
 public class DataStreamSerializationFactoryV2_2Test  extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return DataStreamSerializationFactoryV2_2.INSTANCE;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/LZ4SerializationFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/LZ4SerializationFactoryTest.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class LZ4SerializationFactoryTest extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return new LZ4SerializationFactory(DataStreamSerializationFactoryV2_1.INSTANCE);
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/LZFSerializationFactoryTest.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class LZFSerializationFactoryTest extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return new LZFSerializationFactory(DataStreamSerializationFactoryV2_1.INSTANCE);
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/datastream/v2_3/DataStreamSerializationFactoryV2_3Test.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/datastream/v2_3/DataStreamSerializationFactoryV2_3Test.java
@@ -9,13 +9,13 @@
  */
 package org.locationtech.geogig.storage.datastream.v2_3;
 
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2_2Test;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class DataStreamSerializationFactoryV2_3Test extends DataStreamSerializationFactoryV2_2Test {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return DataStreamSerializationFactoryV2_3.INSTANCE;
     }
 

--- a/src/core/src/test/java/org/locationtech/geogig/storage/text/TextSerializationFactoryTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/storage/text/TextSerializationFactoryTest.java
@@ -19,8 +19,8 @@ import java.io.OutputStreamWriter;
 import org.junit.Test;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.impl.RevObjectTestSupport;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.impl.ObjectSerializationFactoryTest;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 /**
  *
@@ -28,7 +28,7 @@ import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 public class TextSerializationFactoryTest extends ObjectSerializationFactoryTest {
 
     @Override
-    protected ObjectSerializingFactory getObjectSerializingFactory() {
+    protected RevObjectSerializer getObjectSerializingFactory() {
         return new TextSerializationFactory();
     }
 

--- a/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/ObjectFunnels.java
+++ b/src/remoting/src/main/java/org/locationtech/geogig/remotes/internal/ObjectFunnels.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 import org.locationtech.geogig.model.RevObject;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -24,12 +24,12 @@ public class ObjectFunnels {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ObjectFunnels.class);
 
-    public static ObjectFunnel newFunnel(OutputStream out, ObjectSerializingFactory serializer) {
+    public static ObjectFunnel newFunnel(OutputStream out, RevObjectSerializer serializer) {
         return new DirectFunnel(out, serializer);
     }
 
     public static ObjectFunnel newFunnel(final Supplier<OutputStream> outputFactory,
-            final ObjectSerializingFactory serializer, final int byteSoftLimit) {
+            final RevObjectSerializer serializer, final int byteSoftLimit) {
 
         return new SizeLimitingFunnel(outputFactory, serializer, byteSoftLimit);
     }
@@ -38,9 +38,9 @@ public class ObjectFunnels {
 
         private OutputStream out;
 
-        private ObjectSerializingFactory serializer;
+        private RevObjectSerializer serializer;
 
-        public DirectFunnel(OutputStream out, ObjectSerializingFactory serializer) {
+        public DirectFunnel(OutputStream out, RevObjectSerializer serializer) {
             this.out = out;
             this.serializer = serializer;
         }
@@ -65,14 +65,14 @@ public class ObjectFunnels {
 
         private Supplier<OutputStream> outputFactory;
 
-        private final ObjectSerializingFactory serializer;
+        private final RevObjectSerializer serializer;
 
         private final int byteSoftLimit;
 
         private CountingOutputStream currentTarget;
 
         public SizeLimitingFunnel(Supplier<OutputStream> outputFactory,
-                ObjectSerializingFactory serializer, final int byteSoftLimit) {
+                RevObjectSerializer serializer, final int byteSoftLimit) {
             this.outputFactory = outputFactory;
             this.serializer = serializer;
             this.byteSoftLimit = byteSoftLimit;

--- a/src/storage/cache/caffeine/src/main/java/org/locationtech/geogig/cache/caffeine/CaffeineSharedCache.java
+++ b/src/storage/cache/caffeine/src/main/java/org/locationtech/geogig/cache/caffeine/CaffeineSharedCache.java
@@ -19,12 +19,12 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.cache.CacheIdentifier;
 import org.locationtech.geogig.storage.cache.CacheKey;
 import org.locationtech.geogig.storage.cache.CacheStats;
 import org.locationtech.geogig.storage.cache.SharedCache;
 import org.locationtech.geogig.storage.datastream.v2_3.DataStreamSerializationFactoryV2_3;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
@@ -66,7 +66,7 @@ public class CaffeineSharedCache implements SharedCache {
                 new ArrayBlockingQueue<Runnable>(nThreads), tf, sameThreadHandler);
     }
 
-    private static final ObjectSerializingFactory ENCODER = //
+    private static final RevObjectSerializer ENCODER = //
             DataStreamSerializationFactoryV2_3.INSTANCE;
 
     /**
@@ -74,7 +74,7 @@ public class CaffeineSharedCache implements SharedCache {
      */
     private static final int L1_CACHE_SIZE = 10_000;
 
-    private ObjectSerializingFactory encoder = ENCODER;
+    private RevObjectSerializer encoder = ENCODER;
 
     /**
      * Used to track the size in bytes of the cache, since {@link Cache} can return only the
@@ -108,7 +108,7 @@ public class CaffeineSharedCache implements SharedCache {
     }
 
     @VisibleForTesting
-    public void setEncoder(ObjectSerializingFactory encoder) {
+    public void setEncoder(RevObjectSerializer encoder) {
         this.encoder = encoder;
     }
 

--- a/src/storage/cache/caffeine/src/test/java/org/locationtech/geogig/cache/performance/ObjectCacheStressTest.java
+++ b/src/storage/cache/caffeine/src/test/java/org/locationtech/geogig/cache/performance/ObjectCacheStressTest.java
@@ -41,13 +41,13 @@ import org.locationtech.geogig.model.RevTree;
 import org.locationtech.geogig.model.impl.RevObjectTestSupport;
 import org.locationtech.geogig.model.impl.RevTreeBuilder;
 import org.locationtech.geogig.repository.IndexInfo;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.cache.CacheIdentifier;
 import org.locationtech.geogig.storage.cache.ObjectCache;
 import org.locationtech.geogig.storage.cache.SharedCache;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2_2;
 import org.locationtech.geogig.storage.datastream.LZ4SerializationFactory;
 import org.locationtech.geogig.storage.datastream.v2_3.DataStreamSerializationFactoryV2_3;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.ParseException;
@@ -79,7 +79,7 @@ public class ObjectCacheStressTest {
 
     private SharedCache sharedCache;
 
-    private static final List<ObjectSerializingFactory> encoders = ImmutableList.of(//
+    private static final List<RevObjectSerializer> encoders = ImmutableList.of(//
             // raw encoders
             // DataStreamSerializationFactoryV1.INSTANCE //
             // , DataStreamSerializationFactoryV2.INSTANCE //
@@ -208,7 +208,7 @@ public class ObjectCacheStressTest {
 
     public List<TestResult> runTest(List<? extends RevObject> objects) {
         List<TestResult> results = new ArrayList<>();
-        for (ObjectSerializingFactory encoder : encoders) {
+        for (RevObjectSerializer encoder : encoders) {
             cache.invalidateAll();
             TestResult result = run(encoder, objects);
             results.add(result);
@@ -230,7 +230,7 @@ public class ObjectCacheStressTest {
         private final long sizeBytes;
     }
 
-    public TestResult run(ObjectSerializingFactory encoder, List<? extends RevObject> objects) {
+    public TestResult run(RevObjectSerializer encoder, List<? extends RevObject> objects) {
         sharedCache.setEncoder(encoder);
         final Stopwatch put = put(objects);
         Collections.shuffle(objects);

--- a/src/storage/cache/guava/src/main/java/org/locationtech/geogig/cache/guava/GuavaSharedCache.java
+++ b/src/storage/cache/guava/src/main/java/org/locationtech/geogig/cache/guava/GuavaSharedCache.java
@@ -28,14 +28,13 @@ import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.RevObject.TYPE;
 import org.locationtech.geogig.model.RevTree;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.cache.CacheIdentifier;
 import org.locationtech.geogig.storage.cache.CacheKey;
 import org.locationtech.geogig.storage.cache.CacheStats;
 import org.locationtech.geogig.storage.cache.SharedCache;
 import org.locationtech.geogig.storage.datastream.v2_3.DataStreamSerializationFactoryV2_3;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalCause;
@@ -71,10 +70,10 @@ public class GuavaSharedCache implements SharedCache {
                 new ArrayBlockingQueue<Runnable>(nThreads), tf, sameThreadHandler);
     }
 
-    private static final ObjectSerializingFactory ENCODER = //
+    private static final RevObjectSerializer ENCODER = //
             DataStreamSerializationFactoryV2_3.INSTANCE;
 
-    private ObjectSerializingFactory encoder = ENCODER;
+    private RevObjectSerializer encoder = ENCODER;
 
     /**
      * Used to track the size in bytes of the cache, since {@link Cache} can return only the
@@ -110,8 +109,7 @@ public class GuavaSharedCache implements SharedCache {
         }
     }
 
-    @VisibleForTesting
-    public void setEncoder(ObjectSerializingFactory encoder) {
+    public void setEncoder(RevObjectSerializer encoder) {
         this.encoder = encoder;
     }
 

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbObjectStore.java
@@ -45,12 +45,12 @@ import org.locationtech.geogig.rocksdb.DBHandle.RocksDBReference;
 import org.locationtech.geogig.storage.AutoCloseableIterator;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.ObjectInfo;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV2;
 import org.locationtech.geogig.storage.datastream.LZFSerializationFactory;
 import org.locationtech.geogig.storage.datastream.SerializationFactoryProxy;
 import org.locationtech.geogig.storage.impl.AbstractObjectStore;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.rocksdb.ReadOptions;
 import org.rocksdb.RocksDB;
 import org.rocksdb.RocksDBException;
@@ -123,8 +123,8 @@ public class RocksdbObjectStore extends AbstractObjectStore implements ObjectSto
         this.bulkReadOptions.setFillCache(false);
         this.bulkReadOptions.setVerifyChecksums(false);
 
-        ObjectSerializingFactory defaultSerializer = new SerializationFactoryProxy();
-        ObjectSerializingFactory serializer = defaultSerializer;
+        RevObjectSerializer defaultSerializer = new SerializationFactoryProxy();
+        RevObjectSerializer serializer = defaultSerializer;
         final Optional<String> serializerValue = dbhandle.getMetadata("serializer");
         if (serializerValue.isPresent()) {
             String sval = serializerValue.get();

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/BinaryPackedObjects.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/BinaryPackedObjects.java
@@ -28,10 +28,10 @@ import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.remotes.internal.Deduplicator;
 import org.locationtech.geogig.remotes.internal.ObjectFunnel;
 import org.locationtech.geogig.storage.BulkOpListener;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.BulkOpListener.CountingListener;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,7 +49,7 @@ public final class BinaryPackedObjects {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(BinaryPackedObjects.class);
 
-    private final ObjectSerializingFactory marshaller;
+    private final RevObjectSerializer marshaller;
 
     private final ObjectStore database;
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpMappedRemoteRepo.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpMappedRemoteRepo.java
@@ -44,8 +44,8 @@ import org.locationtech.geogig.repository.impl.RepositoryFilter;
 import org.locationtech.geogig.repository.impl.RepositoryFilter.FilterDescription;
 import org.locationtech.geogig.repository.impl.RepositoryImpl;
 import org.locationtech.geogig.storage.AutoCloseableIterator;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -368,7 +368,7 @@ public class HttpMappedRemoteRepo extends AbstractMappedRemoteRepo {
                     connection.setDoInput(true);
                     out = connection.getOutputStream();
                     // pack the commit object
-                    final ObjectSerializingFactory writer = DataStreamSerializationFactoryV1.INSTANCE;
+                    final RevObjectSerializer writer = DataStreamSerializationFactoryV1.INSTANCE;
                     writer.write(commit, out);
 
                     // write the new parents

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpRemoteRepo.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpRemoteRepo.java
@@ -51,9 +51,9 @@ import org.locationtech.geogig.repository.AbstractGeoGigOp;
 import org.locationtech.geogig.repository.ProgressListener;
 import org.locationtech.geogig.repository.Remote;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -273,7 +273,7 @@ public class HttpRemoteRepo extends AbstractRemoteRepo {
                 final boolean traverseCommits = false;
 
                 Stopwatch sw = Stopwatch.createStarted();
-                ObjectSerializingFactory serializer = DataStreamSerializationFactoryV1.INSTANCE;
+                RevObjectSerializer serializer = DataStreamSerializationFactoryV1.INSTANCE;
                 SendObjectsConnectionFactory outFactory;
                 ObjectFunnel objectFunnel;
 

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpUtils.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/HttpUtils.java
@@ -33,8 +33,8 @@ import org.locationtech.geogig.model.Ref;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.model.SymRef;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -163,7 +163,7 @@ class HttpUtils {
             // Get Response
             InputStream is = HttpUtils.getResponseStream(connection);
             try {
-                ObjectSerializingFactory reader = DataStreamSerializationFactoryV1.INSTANCE;
+                RevObjectSerializer reader = DataStreamSerializationFactoryV1.INSTANCE;
                 RevObject revObject = reader.read(objectId, is);
                 if (localRepository != null) {
                     localRepository.objectDatabase().put(revObject);

--- a/src/web/api/src/main/java/org/locationtech/geogig/remote/http/pack/StreamingPackIO.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/remote/http/pack/StreamingPackIO.java
@@ -10,8 +10,8 @@ import java.util.Arrays;
 import org.eclipse.jdt.annotation.Nullable;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.v2_3.DataStreamSerializationFactoryV2_3;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 
 public class StreamingPackIO {
 
@@ -25,7 +25,7 @@ public class StreamingPackIO {
         OBJECT_STREAM_END //
     }
 
-    private ObjectSerializingFactory objmarshaller = DataStreamSerializationFactoryV2_3.INSTANCE;
+    private RevObjectSerializer objmarshaller = DataStreamSerializationFactoryV2_3.INSTANCE;
 
     public @Nullable RevObject readObject(DataInputStream in) throws IOException {
         Event evt = readNextEvent(in);

--- a/src/web/api/src/main/java/org/locationtech/geogig/spring/dto/Objects.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/spring/dto/Objects.java
@@ -18,8 +18,8 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 import org.locationtech.geogig.model.RevObject;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.springframework.http.MediaType;
 
 /**
@@ -29,7 +29,7 @@ import org.springframework.http.MediaType;
 @XmlAccessorType(XmlAccessType.FIELD)
 public class Objects extends LegacyRepoResponse {
 
-    private static final ObjectSerializingFactory SERIALIZER =
+    private static final RevObjectSerializer SERIALIZER =
             DataStreamSerializationFactoryV1.INSTANCE;
 
     @XmlElement

--- a/src/web/api/src/main/java/org/locationtech/geogig/spring/service/LegacyApplyChangesService.java
+++ b/src/web/api/src/main/java/org/locationtech/geogig/spring/service/LegacyApplyChangesService.java
@@ -27,8 +27,8 @@ import org.locationtech.geogig.remote.http.HttpFilteredDiffIterator;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.rest.repository.RepositoryProvider;
 import org.locationtech.geogig.storage.AutoCloseableIterator;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.web.api.CommandSpecException;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -48,7 +48,7 @@ public class LegacyApplyChangesService extends AbstractRepositoryService {
         if (repository != null) {
             try {
                 // read in commit object
-                final ObjectSerializingFactory serializer = DataStreamSerializationFactoryV1.INSTANCE;
+                final RevObjectSerializer serializer = DataStreamSerializationFactoryV1.INSTANCE;
                 RevCommit commit = (RevCommit) serializer.read(ObjectId.NULL, input); // I don't
                                                                                       // need to
                                                                                       // know the

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ApplyChangesControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ApplyChangesControllerTest.java
@@ -27,8 +27,8 @@ import org.locationtech.geogig.porcelain.RevertOp;
 import org.locationtech.geogig.remote.http.BinaryPackedChanges;
 import org.locationtech.geogig.repository.Repository;
 import org.locationtech.geogig.storage.AutoCloseableIterator;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.test.TestData;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -68,7 +68,7 @@ public class ApplyChangesControllerTest extends AbstractControllerTest {
         assertTrue(masterCommits.hasNext());
         RevCommit masterCommit = masterCommits.next();
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         serialFac.write(masterCommit, baos);
         // number of parent IDs?

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/BatchObjectsControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/BatchObjectsControllerTest.java
@@ -23,8 +23,8 @@ import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.porcelain.CheckoutOp;
 import org.locationtech.geogig.porcelain.LogOp;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.test.TestData;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -110,7 +110,7 @@ public class BatchObjectsControllerTest extends AbstractControllerTest {
         // get an InputStream from the content
         ByteArrayInputStream bais = new ByteArrayInputStream(content);
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         // expected number of RevObjects to be read
         final int expectedNumRevObjects = 14;
         // actual number of RevObject read

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/FilteredChangesControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/FilteredChangesControllerTest.java
@@ -27,9 +27,9 @@ import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.RevObject;
 import org.locationtech.geogig.plumbing.RevObjectParse;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
 import org.locationtech.geogig.storage.datastream.FormatCommonV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.test.TestData;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -133,9 +133,9 @@ public class FilteredChangesControllerTest extends AbstractControllerTest {
         private final ByteArrayInputStream in;
         private final DataInput data;
         private boolean filtered;
-        private final ObjectSerializingFactory serializer;
+        private final RevObjectSerializer serializer;
 
-        private FilteredChangesReader(byte[] bytes, ObjectSerializingFactory serializer) {
+        private FilteredChangesReader(byte[] bytes, RevObjectSerializer serializer) {
             this.in = new ByteArrayInputStream(bytes);
             this.data = new DataInputStream(in);
             this.serializer = serializer;

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ObjectsControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/ObjectsControllerTest.java
@@ -22,8 +22,8 @@ import org.junit.Test;
 import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.porcelain.LogOp;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.test.TestData;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -65,7 +65,7 @@ public class ObjectsControllerTest extends AbstractControllerTest {
         Iterator<RevCommit> call = repo.command(LogOp.class).call();
         assertTrue(call.hasNext());
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         while (call.hasNext()) {
             RevCommit next = call.next();
             // serialize the RevCommit

--- a/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/SendObjectControllerTest.java
+++ b/src/web/api/src/test/java/org/locationtech/geogig/spring/controller/SendObjectControllerTest.java
@@ -28,8 +28,8 @@ import org.locationtech.geogig.model.RevCommit;
 import org.locationtech.geogig.model.impl.CommitBuilder;
 import org.locationtech.geogig.porcelain.LogOp;
 import org.locationtech.geogig.repository.Repository;
+import org.locationtech.geogig.storage.RevObjectSerializer;
 import org.locationtech.geogig.storage.datastream.DataStreamSerializationFactoryV1;
-import org.locationtech.geogig.storage.impl.ObjectSerializingFactory;
 import org.locationtech.geogig.test.TestData;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
@@ -81,7 +81,7 @@ public class SendObjectControllerTest extends AbstractControllerTest {
         Iterator<RevCommit> call = repo.command(LogOp.class).call();
         assertTrue(call.hasNext());
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         while (call.hasNext()) {
             RevCommit next = call.next();
             // serialize the RevCommit
@@ -112,7 +112,7 @@ public class SendObjectControllerTest extends AbstractControllerTest {
         Iterator<RevCommit> call = repo.command(LogOp.class).call();
         assertTrue(call.hasNext());
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         while (call.hasNext()) {
             RevCommit next = call.next();
@@ -155,7 +155,7 @@ public class SendObjectControllerTest extends AbstractControllerTest {
                 RevCommit.class);
         assertNull("Modified commit should not be in the repository yet.", preCheck);
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         // write the commit OID
         byte[] commitOid = sendObjectCommit.getId().getRawValue();
@@ -196,7 +196,7 @@ public class SendObjectControllerTest extends AbstractControllerTest {
                 RevCommit.class);
         assertNull("Modified commit should not be in the repository yet.", preCheck);
         // get the Object serializer
-        final ObjectSerializingFactory serialFac = DataStreamSerializationFactoryV1.INSTANCE;
+        final RevObjectSerializer serialFac = DataStreamSerializationFactoryV1.INSTANCE;
         ByteArrayOutputStream baos = new ByteArrayOutputStream();
         // wrap it with GZIP
         GZIPOutputStream gzos = new GZIPOutputStream(baos, true);


### PR DESCRIPTION
Refactor core module interface ObjectSerializingFactory to
the api module under the RevObjectSerializer name, as it's not
a factory anymore since a long time ago.

