### PR TITLE
move lz4 and lzf revobject serialization decorators to their own micro-modules

### DIFF
--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -70,17 +70,6 @@
       <artifactId>guice</artifactId>
       <classifier>no_aop</classifier>
     </dependency>
-
-    <dependency>
-      <groupId>com.ning</groupId>
-      <artifactId>compress-lzf</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>net.jpountz.lz4</groupId>
-      <artifactId>lz4</artifactId>
-    </dependency>
-
     <!-- Test scope dependencies -->
     <dependency>
       <groupId>junit</groupId>

--- a/src/core/src/main/java/org/locationtech/geogig/storage/datastream/RevObjectSerializerProxy.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/datastream/RevObjectSerializerProxy.java
@@ -44,17 +44,6 @@ public class RevObjectSerializerProxy implements RevObjectSerializer {
      * The serialized object is added a header that's one unsigned byte with the index of the
      * corresponding factory in this array
      */
-    private static final RevObjectSerializer[] DEFAULT_SUPPORTED_FORMATS = { //
-            new RevObjectSerializerLZF(DataStreamRevObjectSerializerV1.INSTANCE), //
-            new RevObjectSerializerLZF(DataStreamRevObjectSerializerV2.INSTANCE), //
-            new RevObjectSerializerLZF(DataStreamRevObjectSerializerV2_1.INSTANCE), //
-            new RevObjectSerializerLZF(DataStreamRevObjectSerializerV2_2.INSTANCE)//
-    };
-
-    /**
-     * The serialized object is added a header that's one unsigned byte with the index of the
-     * corresponding factory in this array
-     */
     private final RevObjectSerializer[] supportedFormats;
 
     private final int maxFormatCode;
@@ -63,10 +52,6 @@ public class RevObjectSerializerProxy implements RevObjectSerializer {
      * The serialization factory used for writing is the highest supported version one
      */
     private final RevObjectSerializer writer;
-
-    public RevObjectSerializerProxy() {
-        this(DEFAULT_SUPPORTED_FORMATS);
-    }
 
     public RevObjectSerializerProxy(@NonNull RevObjectSerializer... supportedFormats) {
         this.supportedFormats = supportedFormats;

--- a/src/core/src/main/java/org/locationtech/geogig/storage/impl/AbstractObjectStore.java
+++ b/src/core/src/main/java/org/locationtech/geogig/storage/impl/AbstractObjectStore.java
@@ -31,7 +31,6 @@ import org.locationtech.geogig.storage.AbstractStore;
 import org.locationtech.geogig.storage.BulkOpListener;
 import org.locationtech.geogig.storage.ObjectStore;
 import org.locationtech.geogig.storage.RevObjectSerializer;
-import org.locationtech.geogig.storage.datastream.RevObjectSerializerProxy;
 
 import com.google.common.io.Closeables;
 
@@ -45,14 +44,6 @@ import lombok.NonNull;
 public abstract class AbstractObjectStore extends AbstractStore implements ObjectStore {
 
     private RevObjectSerializer serializer;
-
-    public AbstractObjectStore() {
-        this(false);
-    }
-
-    public AbstractObjectStore(boolean readOnly) {
-        this(new RevObjectSerializerProxy(), readOnly);
-    }
 
     public AbstractObjectStore(final @NonNull RevObjectSerializer serializer, boolean readOnly) {
         super(readOnly);

--- a/src/storage/formats/lz4/pom.xml
+++ b/src/storage/formats/lz4/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.locationtech.geogig</groupId>
+    <artifactId>geogig-storage-formats</artifactId>
+    <version>2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>geogig-serialization-lz4</artifactId>
+  <packaging>jar</packaging>
+  <name>LZ4 compression serialization decorator</name>
+
+  <properties>
+    <project.relativePath>storage/formats/lz4</project.relativePath>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>geogig.lz4</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>net.jpountz.lz4</groupId>
+      <artifactId>lz4</artifactId>
+    </dependency>
+
+
+    <!-- Test scope dependencies -->
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/storage/formats/lz4/src/main/java/org/locationtech/geogig/storage/format/lz4/RevObjectSerializerLZ4.java
+++ b/src/storage/formats/lz4/src/main/java/org/locationtech/geogig/storage/format/lz4/RevObjectSerializerLZ4.java
@@ -7,7 +7,7 @@
  * Contributors:
  * Gabriel Roldan (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.datastream;
+package org.locationtech.geogig.storage.format.lz4;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;

--- a/src/storage/formats/lz4/src/test/java/org/locationtech/geogig/storage/format/lz4/RevObjectSerializerLZ4Test.java
+++ b/src/storage/formats/lz4/src/test/java/org/locationtech/geogig/storage/format/lz4/RevObjectSerializerLZ4Test.java
@@ -7,15 +7,16 @@
  * Contributors:
  * Gabriel Roldan (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.datastream;
+package org.locationtech.geogig.storage.format.lz4;
 
 import org.locationtech.geogig.storage.RevObjectSerializer;
+import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_1;
 import org.locationtech.geogig.storage.impl.RevObjectSerializerConformanceTest;
 
-public class RevObjectSerializerLZFTest extends RevObjectSerializerConformanceTest {
+public class RevObjectSerializerLZ4Test extends RevObjectSerializerConformanceTest {
 
     protected @Override RevObjectSerializer newObjectSerializer() {
-        return new RevObjectSerializerLZF(DataStreamRevObjectSerializerV2_1.INSTANCE);
+        return new RevObjectSerializerLZ4(DataStreamRevObjectSerializerV2_1.INSTANCE);
     }
 
 }

--- a/src/storage/formats/lzf/pom.xml
+++ b/src/storage/formats/lzf/pom.xml
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="ISO-8859-1"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.locationtech.geogig</groupId>
+    <artifactId>geogig-storage-formats</artifactId>
+    <version>2.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>geogig-serialization-lzf</artifactId>
+  <packaging>jar</packaging>
+  <name>LZF compression serialization decorator</name>
+
+  <properties>
+    <project.relativePath>storage/formats/lzf</project.relativePath>
+  </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <archive>
+            <manifestEntries>
+              <Automatic-Module-Name>geogig.lzf</Automatic-Module-Name>
+            </manifestEntries>
+          </archive>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.ning</groupId>
+      <artifactId>compress-lzf</artifactId>
+    </dependency>
+
+    <!-- Test scope dependencies -->
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-core</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-core</artifactId>
+      <version>${project.version}</version>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/src/storage/formats/lzf/src/main/java/org/locationtech/geogig/storage/format/lzf/RevObjectSerializerLZF.java
+++ b/src/storage/formats/lzf/src/main/java/org/locationtech/geogig/storage/format/lzf/RevObjectSerializerLZF.java
@@ -7,7 +7,7 @@
  * Contributors:
  * Erik Merkle (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.datastream;
+package org.locationtech.geogig.storage.format.lzf;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/storage/formats/lzf/src/test/java/org/locationtech/geogig/storage/format/lzf/RevObjectSerializerLZFTest.java
+++ b/src/storage/formats/lzf/src/test/java/org/locationtech/geogig/storage/format/lzf/RevObjectSerializerLZFTest.java
@@ -7,15 +7,16 @@
  * Contributors:
  * Gabriel Roldan (Boundless) - initial implementation
  */
-package org.locationtech.geogig.storage.datastream;
+package org.locationtech.geogig.storage.format.lzf;
 
 import org.locationtech.geogig.storage.RevObjectSerializer;
+import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_1;
 import org.locationtech.geogig.storage.impl.RevObjectSerializerConformanceTest;
 
-public class RevObjectSerializerLZ4Test extends RevObjectSerializerConformanceTest {
+public class RevObjectSerializerLZFTest extends RevObjectSerializerConformanceTest {
 
     protected @Override RevObjectSerializer newObjectSerializer() {
-        return new RevObjectSerializerLZ4(DataStreamRevObjectSerializerV2_1.INSTANCE);
+        return new RevObjectSerializerLZF(DataStreamRevObjectSerializerV2_1.INSTANCE);
     }
 
 }

--- a/src/storage/formats/pom.xml
+++ b/src/storage/formats/pom.xml
@@ -19,5 +19,7 @@
 
   <modules>
     <module>flatbuffers</module>
+    <module>lz4</module>
+    <module>lzf</module>
   </modules>
 </project>

--- a/src/storage/postgres/pom.xml
+++ b/src/storage/postgres/pom.xml
@@ -49,6 +49,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <!-- for legacy purposes, may be removed in the future -->
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-serialization-lzf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
     </dependency>

--- a/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGSerializationProxy.java
+++ b/src/storage/postgres/src/main/java/org/locationtech/geogig/storage/postgresql/v9/PGSerializationProxy.java
@@ -15,8 +15,8 @@ import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2;
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_1;
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_2;
-import org.locationtech.geogig.storage.datastream.RevObjectSerializerLZF;
 import org.locationtech.geogig.storage.datastream.RevObjectSerializerProxy;
+import org.locationtech.geogig.storage.format.lzf.RevObjectSerializerLZF;
 
 /**
  * 

--- a/src/storage/rocksdb/pom.xml
+++ b/src/storage/rocksdb/pom.xml
@@ -50,6 +50,12 @@
       <version>${project.version}</version>
     </dependency>
     <dependency>
+      <!-- for legacy purposes, may be removed in the future -->
+      <groupId>org.locationtech.geogig</groupId>
+      <artifactId>geogig-serialization-lzf</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
       <!-- Google Common Libraries. Featuring com.google.collect collection classes -->
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>

--- a/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbSerializationProxy.java
+++ b/src/storage/rocksdb/src/main/java/org/locationtech/geogig/rocksdb/RocksdbSerializationProxy.java
@@ -15,8 +15,8 @@ import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2;
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_1;
 import org.locationtech.geogig.storage.datastream.DataStreamRevObjectSerializerV2_2;
-import org.locationtech.geogig.storage.datastream.RevObjectSerializerLZF;
 import org.locationtech.geogig.storage.datastream.RevObjectSerializerProxy;
+import org.locationtech.geogig.storage.format.lzf.RevObjectSerializerLZF;
 
 /**
  * @since 2.0
@@ -33,6 +33,8 @@ class RocksdbSerializationProxy extends RevObjectSerializerProxy {
             // The above formats oughta stay like that for backwards compatibility
             , new FlatBuffersRevObjectSerializer()//
     };
+
+    static final RocksdbSerializationProxy INSTANCE = new RocksdbSerializationProxy();
 
     public RocksdbSerializationProxy() {
         super(SUPPORTED_FORMATS);


### PR DESCRIPTION
Fixes #483

Most probably a first step towards deprecating and removing
them, moving them off as direct dependencies of core specially
because they carry over native libraries that might better
be avoided depending on the library components needed on each
application that uses geogig as a library.
