### PR TITLE
Intermitent LogOp/MergeOp test failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -33,6 +33,6 @@ jobs:
 
       - name: Verify
         run: |
-                mvn -f src/metadata -Dfmt.skip clean install
-                mvn -T1C -Dfmt.skip verify -Pexperimental -rf :geogig-api
+                mvn -ntp -f src/metadata -Dfmt.skip clean install
+                mvn -ntp -T1C -Dfmt.skip verify -Pexperimental -rf :geogig-api
 

--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
     <junit.version>4.13</junit.version>
     <logback.version>1.1.2</logback.version>
     <mockito.version>3.3.3</mockito.version>
+    <hamcrest.version>2.2</hamcrest.version>
     <slf4j.version>1.7.5</slf4j.version>
     <hikaricp.version>3.4.5</hikaricp.version>
     <rocksdb.version>6.8.1</rocksdb.version>
@@ -295,6 +296,12 @@
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
         <version>${mockito.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest</artifactId>
+        <version>${hamcrest.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/src/api/src/main/java/org/locationtech/geogig/model/RevCommitBuilder.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/RevCommitBuilder.java
@@ -47,7 +47,6 @@ public final @Accessors(fluent = true) class RevCommitBuilder {
     private @Setter Platform platform;
 
     RevCommitBuilder() {
-
     }
 
     /**

--- a/src/api/src/main/java/org/locationtech/geogig/model/internal/HeapDAGStorageProvider.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/internal/HeapDAGStorageProvider.java
@@ -74,7 +74,7 @@ class HeapDAGStorageProvider implements DAGStorageProvider {
 
     public @Override Node getNode(NodeId nodeId) {
         Object n = nodes.get(nodeId.name());
-        Preconditions.checkState(n != null,  "node not fount: " + nodeId.name());
+        Preconditions.checkState(n != null, "node not fount: " + nodeId.name());
         Node dagNode = n instanceof DAGNode ? ((DAGNode) n).resolve(source) : (Node) n;
         return dagNode;
     }

--- a/src/api/src/main/java/org/locationtech/geogig/model/internal/HeapDAGStorageProvider.java
+++ b/src/api/src/main/java/org/locationtech/geogig/model/internal/HeapDAGStorageProvider.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
 import org.locationtech.geogig.model.Node;
@@ -33,8 +34,8 @@ class HeapDAGStorageProvider implements DAGStorageProvider {
 
     public HeapDAGStorageProvider(ObjectStore source) {
         this.source = source;
-        this.nodes = new HashMap<>();
-        this.trees = new HashMap<>();
+        this.nodes = new ConcurrentHashMap<>();
+        this.trees = new ConcurrentHashMap<>();
     }
 
     public void close() {
@@ -73,7 +74,7 @@ class HeapDAGStorageProvider implements DAGStorageProvider {
 
     public @Override Node getNode(NodeId nodeId) {
         Object n = nodes.get(nodeId.name());
-        Preconditions.checkState(n != null);
+        Preconditions.checkState(n != null,  "node not fount: " + nodeId.name());
         Node dagNode = n instanceof DAGNode ? ((DAGNode) n).resolve(source) : (Node) n;
         return dagNode;
     }

--- a/src/api/src/main/java/org/locationtech/geogig/repository/Platform.java
+++ b/src/api/src/main/java/org/locationtech/geogig/repository/Platform.java
@@ -36,6 +36,9 @@ public interface Platform extends Serializable {
 
     /**
      * @return the current time in milliseconds
+     * @apiNote a proper implementation must ensure that not two calls can ever return the same
+     *          value on the same JVM, even among different instances in order to prevent possible
+     *          time-based topology errors in the commit graph.
      */
     public long currentTimeMillis();
 

--- a/src/api/src/test/java/org/locationtech/geogig/repository/DefaultPlatformTest.java
+++ b/src/api/src/test/java/org/locationtech/geogig/repository/DefaultPlatformTest.java
@@ -7,31 +7,30 @@
  * Contributors:
  * David Blasby (Boundless) - initial implementation
  */
-package org.locationtech.geogig.test;
+package org.locationtech.geogig.repository;
 
 import static org.junit.Assert.assertNotEquals;
 
 import java.io.IOException;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
 
-public class TestPlatformTest {
+public class DefaultPlatformTest {
 
-    @Rule
-    public TemporaryFolder tempFolder = new TemporaryFolder();
-
-    // simple test -- ensure that the platform clock is always increase (no repeated values).
+    // simple test -- ensure that the platform clock is always increase (no repeated
+    // values).
     @Test
     public void testClock() throws IOException {
-        TestPlatform testPlatform = new TestPlatform(tempFolder.getRoot());
+        DefaultPlatform p1 = new DefaultPlatform();
+        DefaultPlatform p2 = new DefaultPlatform();
 
         long lastTime = 0;
-        for (int t = 0; t < 100; t++) {
-            long time = testPlatform.currentTimeMillis();
-            assertNotEquals(time, lastTime);
-            lastTime = time;
+        for (int t = 0; t < 1000; t++) {
+            long time1 = p1.currentTimeMillis();
+            long time2 = p2.currentTimeMillis();
+            assertNotEquals(time1, lastTime);
+            assertNotEquals(time1, time2);
+            lastTime = time2;
         }
     }
 }

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -62,15 +62,6 @@
     </dependency>
     <!-- Test scope dependencies -->
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <scope>test</scope>

--- a/src/core/src/main/java/org/locationtech/geogig/dsl/Refs.java
+++ b/src/core/src/main/java/org/locationtech/geogig/dsl/Refs.java
@@ -24,10 +24,10 @@ public @RequiredArgsConstructor class Refs {
     private final @NonNull Context context;
 
     public Optional<Ref> head() {
-        return get(Ref.HEAD);
+        return find(Ref.HEAD);
     }
 
-    public Optional<Ref> get(@NonNull String name) {
+    public Optional<Ref> find(@NonNull String name) {
         return context.command(RefParse.class).setName(name).call();
     }
 

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CheckoutOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CheckoutOp.java
@@ -46,6 +46,7 @@ import org.locationtech.geogig.plumbing.RevParse;
 import org.locationtech.geogig.plumbing.UpdateRefs;
 import org.locationtech.geogig.plumbing.UpdateTree;
 import org.locationtech.geogig.porcelain.CheckoutException.StatusCode;
+import org.locationtech.geogig.porcelain.CheckoutResult.Results;
 import org.locationtech.geogig.repository.Conflict;
 import org.locationtech.geogig.repository.WorkingTree;
 import org.locationtech.geogig.repository.impl.AbstractGeoGigOp;
@@ -365,7 +366,9 @@ public class CheckoutOp extends AbstractGeoGigOp<CheckoutResult> {
                 updateRefs.add(new SymRef(Ref.HEAD, target));
                 checkoutResult.setNewRef(targetRef.get());
                 checkoutResult.setOid(targetCommitId.get());
-                checkoutResult.setResult(CheckoutResult.Results.CHECKOUT_LOCAL_BRANCH);
+                if (checkoutResult.getResult() != Results.CHECKOUT_REMOTE_BRANCH) {
+                    checkoutResult.setResult(CheckoutResult.Results.CHECKOUT_LOCAL_BRANCH);
+                }
             } else {
                 // set HEAD to a dettached state
                 ObjectId commitId = targetCommitId.get();

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CheckoutResult.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CheckoutResult.java
@@ -12,66 +12,27 @@ package org.locationtech.geogig.porcelain;
 import org.locationtech.geogig.model.ObjectId;
 import org.locationtech.geogig.model.Ref;
 
+import lombok.AccessLevel;
+import lombok.Data;
+import lombok.NonNull;
+import lombok.Setter;
+import lombok.experimental.Accessors;
+
+@Data
+@Accessors(chain = true)
 public class CheckoutResult {
 
     public enum Results {
         NO_RESULT, DETACHED_HEAD, CHECKOUT_REMOTE_BRANCH, CHECKOUT_LOCAL_BRANCH, UPDATE_OBJECTS
     }
 
-    private ObjectId oid = null;
+    private @Setter(value = AccessLevel.PACKAGE) ObjectId oid;
 
-    private Ref newRef = null;
+    private @Setter(value = AccessLevel.PACKAGE) Ref newRef;
 
-    private String remoteName = null;
+    private @Setter(value = AccessLevel.PACKAGE) String remoteName;
 
-    private ObjectId newTree = null;
+    private @Setter(value = AccessLevel.PACKAGE) ObjectId newTree;
 
-    private Results resultEnumVal = Results.NO_RESULT;
-
-    public ObjectId getOid() {
-        return oid;
-    }
-
-    public CheckoutResult setOid(ObjectId oid) {
-        this.oid = oid;
-        return this;
-    }
-
-    public Ref getNewRef() {
-        return newRef;
-    }
-
-    public CheckoutResult setNewRef(Ref newRef) {
-        this.newRef = newRef;
-        return this;
-    }
-
-    public ObjectId getNewTree() {
-        return newTree;
-    }
-
-    public CheckoutResult setNewTree(ObjectId newTree) {
-        this.newTree = newTree;
-        return this;
-    }
-
-    public Results getResult() {
-        return resultEnumVal;
-    }
-
-    public CheckoutResult setResult(Results result) {
-        if (this.resultEnumVal == Results.NO_RESULT) {
-            this.resultEnumVal = result;
-        }
-        return this;
-    }
-
-    public String getRemoteName() {
-        return remoteName;
-    }
-
-    public void setRemoteName(String remoteName) {
-        this.remoteName = remoteName;
-    }
-
+    private @NonNull @Setter(value = AccessLevel.PACKAGE) Results result = Results.NO_RESULT;
 }

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/CommitOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/CommitOp.java
@@ -333,7 +333,7 @@ public class CommitOp extends AbstractGeoGigOp<RevCommit> {
             }
         }
 
-        RevCommitBuilder builder = RevCommit.builder();
+        RevCommitBuilder builder = RevCommit.builder().platform(this.platform());
         if (this.commit == null) {
             builder.author(resolveAuthor())//
                     .authorEmail(resolveAuthorEmail())//

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/LogOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/LogOp.java
@@ -9,6 +9,8 @@
  */
 package org.locationtech.geogig.porcelain;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -29,7 +31,6 @@ import org.locationtech.geogig.plumbing.FindTreeChild;
 import org.locationtech.geogig.repository.impl.AbstractGeoGigOp;
 import org.locationtech.geogig.storage.GraphDatabase;
 
-import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
 import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterators;
@@ -90,7 +91,6 @@ public class LogOp extends AbstractGeoGigOp<Iterator<RevCommit>> {
      * @return {@code this}
      */
     public LogOp setSkip(int skip) {
-        Preconditions.checkArgument(skip > 0, "skip shall be > 0: " + skip);
         this.skip = Integer.valueOf(skip);
         return this;
     }
@@ -100,7 +100,6 @@ public class LogOp extends AbstractGeoGigOp<Iterator<RevCommit>> {
      * @return {@code this}
      */
     public LogOp setLimit(int limit) {
-        Preconditions.checkArgument(limit > 0, "limit shall be > 0: " + limit);
         this.limit = Integer.valueOf(limit);
         return this;
     }
@@ -224,6 +223,8 @@ public class LogOp extends AbstractGeoGigOp<Iterator<RevCommit>> {
      * @see org.locationtech.geogig.repository.impl.AbstractGeoGigOp#call()
      */
     protected @Override Iterator<RevCommit> _call() {
+        checkArgument(limit == null || limit > 0, "limit shall be > 0: " + limit);
+        checkArgument(skip == null || skip > 0, "skip shall be > 0: " + skip);
 
         Geogig geogig = geogig();
         ObjectId newestCommitId;

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/RevertOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/RevertOp.java
@@ -460,7 +460,7 @@ public class RevertOp extends AbstractGeoGigOp<Boolean> {
         String committerName = resolveCommitter();
         String committerEmail = resolveCommitterEmail();
         // Create new commit
-        RevCommitBuilder builder = RevCommit.builder();
+        RevCommitBuilder builder = RevCommit.builder().platform(this.platform());
         builder.parentIds(Arrays.asList(revertHead));
         builder.treeId(newTreeId);
         builder.committerTimestamp(timestamp);

--- a/src/core/src/main/java/org/locationtech/geogig/porcelain/SquashOp.java
+++ b/src/core/src/main/java/org/locationtech/geogig/porcelain/SquashOp.java
@@ -196,7 +196,7 @@ public class SquashOp extends AbstractGeoGigOp<ObjectId> {
         parents.addAll(firstParents);
         parents.addAll(secondaryParents);
         ObjectId endTree = until.getTreeId();
-        RevCommitBuilder builder = RevCommit.builder().init(until);
+        RevCommitBuilder builder = RevCommit.builder().platform(this.platform()).init(until);
         Collection<ObjectId> filteredParents = Collections2.filter(parents,
                 new Predicate<ObjectId>() {
                     public @Override boolean apply(@Nullable ObjectId id) {
@@ -255,7 +255,7 @@ public class SquashOp extends AbstractGeoGigOp<ObjectId> {
         replacedCommits.put(until.getId(), squashedId);
         ObjectId head = squashedId;
         for (RevCommit commit : commits) {
-            RevCommitBuilder builder = RevCommit.builder().init(commit);
+            RevCommitBuilder builder = RevCommit.builder().platform(this.platform()).init(commit);
             Function<ObjectId, ObjectId> fn = new Function<ObjectId, ObjectId>() {
                 public @Override ObjectId apply(ObjectId id) {
                     if (replacedCommits.containsKey(id)) {

--- a/src/core/src/main/java/org/locationtech/geogig/transaction/TransactionEnd.java
+++ b/src/core/src/main/java/org/locationtech/geogig/transaction/TransactionEnd.java
@@ -164,7 +164,7 @@ public class TransactionEnd extends AbstractGeoGigOp<Void> {
                     transaction.getTransactionId());
             return Optional.empty();
         }
-        Optional<Ref> currValue = geogig().refs().get(deleted.name());
+        Optional<Ref> currValue = geogig().refs().find(deleted.name());
         if (currValue.isPresent() && !currValue.equals(deleted.oldValue())) {
             log.warn(
                     "Not deleting {} when committing transaction {}. Ref changed outside the transaction.",
@@ -193,7 +193,7 @@ public class TransactionEnd extends AbstractGeoGigOp<Void> {
 
         Geogig tx = new Geogig(transaction);
 
-        final @Nullable Ref valueOutsideTx = geogig().refs().get(refName).orElse(null);
+        final @Nullable Ref valueOutsideTx = geogig().refs().find(refName).orElse(null);
         final Ref valueInsideTx = change.newValue().get();
         final Ref finalValue;
 
@@ -216,7 +216,7 @@ public class TransactionEnd extends AbstractGeoGigOp<Void> {
                         refName, valueInsideTx.getObjectId(), valueOutsideTx.getObjectId(), ce);
                 throw ce;
             }
-            finalValue = tx.refs().get(refName).get();
+            finalValue = tx.refs().find(refName).get();
         } else {
             try { // sync transactions have to use merge to prevent divergent history
                 tx.commands().merge(valueOutsideTx.getObjectId())
@@ -226,7 +226,7 @@ public class TransactionEnd extends AbstractGeoGigOp<Void> {
                 LOGGER.debug("Transaction merge for {} unnecessary. {}", valueOutsideTx.getName(),
                         e.getMessage());
             }
-            finalValue = tx.refs().get(refName).get();
+            finalValue = tx.refs().find(refName).get();
         }
         List<Ref> updates;
         if (currentBranchOutsideTx.isPresent()

--- a/src/core/src/test/java/org/locationtech/geogig/test/TestPlatform.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/TestPlatform.java
@@ -10,7 +10,6 @@
 package org.locationtech.geogig.test;
 
 import java.io.File;
-import java.util.concurrent.atomic.AtomicLong;
 
 import org.locationtech.geogig.repository.DefaultPlatform;
 import org.locationtech.geogig.repository.Platform;
@@ -51,19 +50,5 @@ public class TestPlatform extends DefaultPlatform implements Platform, Cloneable
     public @Override String toString() {
         return getClass().getSimpleName() + "[home=" + this.userHomeDirectory + ", pwd="
                 + super.workingDir + "]";
-    }
-
-    // Make sure that all the times are unique (make sure clock ticks between calls)
-    private AtomicLong lastTick = new AtomicLong();
-
-    public @Override long currentTimeMillis() {
-        final long current = super.currentTimeMillis();
-        long unique = lastTick.updateAndGet(curr -> {
-            if (curr == current) {
-                return current + 1;
-            }
-            return current;
-        });
-        return unique;
     }
 }

--- a/src/core/src/test/java/org/locationtech/geogig/test/integration/RebaseOpTest.java
+++ b/src/core/src/test/java/org/locationtech/geogig/test/integration/RebaseOpTest.java
@@ -129,6 +129,7 @@ public class RebaseOpTest extends RepositoryTestCase {
 
         // Commit 3
         RevCommit logC3 = log.next();
+        assertFalse(c3.getTreeId().equals(logC3.getTreeId()));
         assertEquals(c3.getAuthor(), logC3.getAuthor());
         assertEquals(c3.getCommitter().getName(), logC3.getCommitter().getName());
         assertEquals(c3.getCommitter().getEmail(), logC3.getCommitter().getEmail());
@@ -138,7 +139,6 @@ public class RebaseOpTest extends RepositoryTestCase {
         assertEquals(c3.getCommitter().getTimeZoneOffset(),
                 logC3.getCommitter().getTimeZoneOffset());
         assertFalse(c3.getCommitter().getTimestamp() == logC3.getCommitter().getTimestamp());
-        assertFalse(c3.getTreeId().equals(logC3.getTreeId()));
 
         // Commit 2
         RevCommit logC2 = log.next();

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -557,6 +557,18 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+    </dependency>
   </dependencies>
 
 </project>


### PR DESCRIPTION
Intermitent `LogOp.testAll()`/`testMerged()` failure on canonical repo

Fix time-based commit graph topology errors
    
Ensuring Platform.currentTimeMillis() never returns the same value
(increments by one millisecond if it's about to return the same time
twice) ensures fast calls to commit can't result time-based topology
errors messing up log-op.
