### PR TITLE
Use Maven CI Friendly Versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.locationtech.geogig</groupId>
   <artifactId>geogig-bom</artifactId>
-  <version>2.0-SNAPSHOT</version>
+  <version>${revision}</version>
   <packaging>pom</packaging>
   <name>GeoGig Root BOM</name>
   <description>Root pom providing dependency and plugin management for all geogig modules</description>
@@ -15,6 +15,7 @@
   </modules>
 
   <properties>
+    <revision>2.0-SNAPSHOT</revision>
     <lombok.version>1.18.12</lombok.version>
     <flatbuffers-java.version>1.12.0</flatbuffers-java.version>
     <flatbuffers-compiler.version>1.12.0.1</flatbuffers-compiler.version>

--- a/src/api/pom.xml
+++ b/src/api/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-api</artifactId>

--- a/src/benchmarks/core/pom.xml
+++ b/src/benchmarks/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-benchmarks</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>geogig-benchmarks-core</artifactId>
   <packaging>jar</packaging>

--- a/src/benchmarks/pom.xml
+++ b/src/benchmarks/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-benchmarks</artifactId>

--- a/src/cli/app/pom.xml
+++ b/src/cli/app/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-cli-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cli-app</artifactId>

--- a/src/cli/core/pom.xml
+++ b/src/cli/core/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-cli-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cli-core</artifactId>

--- a/src/cli/geotools/pom.xml
+++ b/src/cli/geotools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-cli-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cli-geotools</artifactId>

--- a/src/cli/pom.xml
+++ b/src/cli/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cli-parent</artifactId>

--- a/src/cli/remoting/pom.xml
+++ b/src/cli/remoting/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-cli-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>geogig-cli-remoting</artifactId>
   <name>geogig-cli-remoting</name>

--- a/src/cli/storage-postgres/pom.xml
+++ b/src/cli/storage-postgres/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-cli-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cli-pg-storage</artifactId>

--- a/src/core/pom.xml
+++ b/src/core/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-core</artifactId>

--- a/src/experimental/pom.xml
+++ b/src/experimental/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-experimental</artifactId>

--- a/src/experimental/ql/pom.xml
+++ b/src/experimental/ql/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-experimental</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-ql</artifactId>

--- a/src/geotools/adapter/pom.xml
+++ b/src/geotools/adapter/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-gt-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-gt-adapter</artifactId>

--- a/src/geotools/commands/pom.xml
+++ b/src/geotools/commands/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-gt-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-gt-commands</artifactId>

--- a/src/geotools/datastore/pom.xml
+++ b/src/geotools/datastore/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-gt-parent</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-gt-datastore</artifactId>

--- a/src/geotools/pom.xml
+++ b/src/geotools/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-gt-parent</artifactId>

--- a/src/metadata/pom.xml
+++ b/src/metadata/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-metadata</artifactId>

--- a/src/pom.xml
+++ b/src/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-bom</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
   <artifactId>geogig</artifactId>
   <packaging>pom</packaging>

--- a/src/pullrequests/pom.xml
+++ b/src/pullrequests/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-pullrequests</artifactId>

--- a/src/remoting/pom.xml
+++ b/src/remoting/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-remoting</artifactId>

--- a/src/storage/cache/caffeine/pom.xml
+++ b/src/storage/cache/caffeine/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage-cache</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-cache-caffeine</artifactId>

--- a/src/storage/cache/pom.xml
+++ b/src/storage/cache/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-storage-cache</artifactId>

--- a/src/storage/formats/flatbuffers/pom.xml
+++ b/src/storage/formats/flatbuffers/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage-formats</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-serialization-flatbuffers</artifactId>

--- a/src/storage/formats/lz4/pom.xml
+++ b/src/storage/formats/lz4/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage-formats</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-serialization-lz4</artifactId>

--- a/src/storage/formats/lzf/pom.xml
+++ b/src/storage/formats/lzf/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage-formats</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-serialization-lzf</artifactId>

--- a/src/storage/formats/pom.xml
+++ b/src/storage/formats/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-storage-formats</artifactId>

--- a/src/storage/pom.xml
+++ b/src/storage/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-storage</artifactId>

--- a/src/storage/postgres/pom.xml
+++ b/src/storage/postgres/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-postgres</artifactId>

--- a/src/storage/rocksdb/pom.xml
+++ b/src/storage/rocksdb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-rocksdb</artifactId>

--- a/src/storage/temporary-rocksdb/pom.xml
+++ b/src/storage/temporary-rocksdb/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.locationtech.geogig</groupId>
     <artifactId>geogig-storage</artifactId>
-    <version>2.0-SNAPSHOT</version>
+    <version>${revision}</version>
   </parent>
 
   <artifactId>geogig-temporary-storage-rocksdb</artifactId>


### PR DESCRIPTION
Use a maven property `revision` in the root pom as the single definition
of the project version for all modules.

This way, child maven modules don't need to specify parent project version.

This has two main advantages:

- Changing the project version is achieved by modifying only the root
  pom (the `revision` property).
- Modules in feature branches created in a version prior to the latest
  in the upstream branch don't get outdated when rebased/merged.

And one drawback:
- `mvn versions:set` will still modify all the poms,
   despite it asking "Enter the new version to set ${revision}:".
   So just change the revision property manually, not a big deal.

See https://maven.apache.org/maven-ci-friendly.html for more information.